### PR TITLE
バッジページ拡張：時間帯ゲージ改善＆買い物・ことづてバッジ追加Feature/badge page

### DIFF
--- a/app/(public)/badges/kotodute/page.tsx
+++ b/app/(public)/badges/kotodute/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import NavigationBar from '../../../components/NavigationBar';
+import { getKotoduteProgress, NOTE_BADGES, LIKE_BADGES } from '../services/kotoduteBadgeService';
+
+type ProgressState = {
+  notes: number;
+  likes: number;
+};
+
+function buildStatus(threshold: number, current: number) {
+  return current >= threshold;
+}
+
+export default function KotoduteBadgesPage() {
+  const [progress, setProgress] = useState<ProgressState>({ notes: 0, likes: 0 });
+
+  useEffect(() => {
+    const p = getKotoduteProgress();
+    setProgress({ notes: p.noteCount, likes: p.likeCount });
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+      <header className="border-b border-sky-100 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-700">badges</p>
+            <h1 className="text-2xl font-bold text-gray-900">ことづてバッジ一覧</h1>
+            <p className="text-sm text-gray-700">投稿数といいね数で解放されます。</p>
+          </div>
+          <Link
+            href="/badges"
+            className="rounded-full border border-sky-200 bg-white px-3 py-2 text-xs font-semibold text-sky-800 shadow-sm hover:bg-sky-50"
+          >
+            バッジトップへ戻る
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-8">
+        <section className="rounded-2xl border border-sky-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">投稿バッジ</h2>
+              <p className="text-sm text-gray-700">現在 {progress.notes} 通</p>
+            </div>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {NOTE_BADGES.map((badge) => {
+              const unlocked = buildStatus(badge.threshold, progress.notes);
+              return (
+                <div
+                  key={badge.id}
+                  className={`flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm ${
+                    unlocked ? 'border-amber-200 bg-amber-50/80' : 'border-gray-200 bg-gray-50/80'
+                  }`}
+                >
+                  <span
+                    className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-full border text-lg"
+                    style={{
+                      backgroundColor: unlocked ? '#fef3c7' : 'white',
+                      borderColor: unlocked ? '#f59e0b' : '#d1d5db',
+                    }}
+                    aria-hidden
+                  >
+                    ✉️
+                  </span>
+                  <div className="flex-1 space-y-1">
+                    <p className="text-base font-semibold text-gray-900">{badge.label}</p>
+                    <p className="text-xs text-gray-600">必要: {badge.threshold} 通</p>
+                  </div>
+                  <span className="text-sm font-semibold text-amber-700">
+                    {unlocked ? '✓' : ''}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-sky-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">いいねバッジ</h2>
+              <p className="text-sm text-gray-700">現在 {progress.likes} 個</p>
+            </div>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {LIKE_BADGES.map((badge) => {
+              const unlocked = buildStatus(badge.threshold, progress.likes);
+              return (
+                <div
+                  key={badge.id}
+                  className={`flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm ${
+                    unlocked ? 'border-sky-200 bg-sky-50/80' : 'border-gray-200 bg-gray-50/80'
+                  }`}
+                >
+                  <span
+                    className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-full border text-lg"
+                    style={{
+                      backgroundColor: unlocked ? '#e0f2fe' : 'white',
+                      borderColor: unlocked ? '#38bdf8' : '#d1d5db',
+                    }}
+                    aria-hidden
+                  >
+                    💌
+                  </span>
+                  <div className="flex-1 space-y-1">
+                    <p className="text-base font-semibold text-gray-900">{badge.label}</p>
+                    <p className="text-xs text-gray-600">必要: {badge.threshold} いいね</p>
+                  </div>
+                  <span className="text-sm font-semibold text-sky-700">
+                    {unlocked ? '✓' : ''}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/(public)/badges/page.tsx
+++ b/app/(public)/badges/page.tsx
@@ -3,12 +3,16 @@
 import { useEffect, useState } from 'react';
 import NavigationBar from '../../components/NavigationBar';
 import { listTimeBadgeProgress, type TimeBadgeProgress } from '../map/services/timeBadgeService';
+import { getShoppingProgress, SHOPPING_SEGMENTS } from './services/shoppingBadgeService';
 
 export default function BadgesPage() {
   const [badges, setBadges] = useState<TimeBadgeProgress[]>([]);
+  const [shoppingUnlocked, setShoppingUnlocked] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setBadges(listTimeBadgeProgress());
+    const shopping = getShoppingProgress();
+    setShoppingUnlocked(shopping.unlocked);
   }, []);
 
   const collected = badges.filter((b) => b.count > 0).length;
@@ -84,6 +88,78 @@ export default function BadgesPage() {
               <span role="img" aria-label="flower">🌼</span>
             </div>
             <p className="mt-2 text-xs text-amber-800">後日イラストに差し替え予定です。</p>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-emerald-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">お買い物バッジ</h2>
+              <p className="text-sm text-gray-700">
+                bag に入れたカテゴリに応じて塗り絵が色付きます。色がついたパートは獲得済みです。
+              </p>
+            </div>
+            <a
+              href="/badges/shopping"
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-800 shadow-sm transition hover:bg-emerald-100"
+            >
+              お買い物バッジを見る
+            </a>
+          </div>
+
+          <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-gray-50 p-4">
+            <p className="text-xs font-semibold text-gray-600">塗り絵（仮の線画）</p>
+            <div className="relative mx-auto flex h-40 w-full max-w-md items-center justify-center">
+              <svg viewBox="0 0 260 140" className="h-full w-full">
+                {SHOPPING_SEGMENTS.map((seg, idx) => {
+                  const x = 20 + idx * 40;
+                  const y = 30 + (idx % 2) * 40;
+                  const unlocked = shoppingUnlocked.has(seg.id);
+                  return (
+                    <g key={seg.id}>
+                      <rect
+                        x={x}
+                        y={y}
+                        width={30}
+                        height={60}
+                        rx={6}
+                        className="stroke-gray-700"
+                        strokeWidth={2}
+                        fill={unlocked ? seg.color : 'white'}
+                        fillOpacity={unlocked ? 1 : 0}
+                      />
+                      <rect
+                        x={x}
+                        y={y}
+                        width={30}
+                        height={60}
+                        rx={6}
+                        fill="none"
+                        className="stroke-gray-700"
+                        strokeDasharray="4 3"
+                        strokeWidth={2}
+                      />
+                    </g>
+                  );
+                })}
+              </svg>
+              <div className="pointer-events-none absolute inset-0 rounded-2xl border border-dashed border-gray-400" aria-hidden />
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-xs text-gray-700">
+              {SHOPPING_SEGMENTS.map((seg) => (
+                <div key={seg.id} className="flex items-center gap-2">
+                  <span
+                    className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-gray-300"
+                    style={{ backgroundColor: shoppingUnlocked.has(seg.id) ? seg.color : 'white' }}
+                    aria-hidden
+                  />
+                  <span>{seg.label}</span>
+                  <span className="text-[10px] text-gray-500">
+                    {shoppingUnlocked.has(seg.id) ? '獲得' : '未獲得'}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       </div>

--- a/app/(public)/badges/page.tsx
+++ b/app/(public)/badges/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import NavigationBar from '../../components/NavigationBar';
+import { listTimeBadgeProgress, type TimeBadgeProgress } from '../map/services/timeBadgeService';
+
+export default function BadgesPage() {
+  const [badges, setBadges] = useState<TimeBadgeProgress[]>([]);
+
+  useEffect(() => {
+    setBadges(listTimeBadgeProgress());
+  }, []);
+
+  const collected = badges.filter((b) => b.count > 0).length;
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+      <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">badges</p>
+            <h1 className="text-2xl font-bold">集めたバッジ</h1>
+            <p className="text-sm text-gray-700">日曜市で集めたバッジを見返せます。</p>
+          </div>
+          <div className="rounded-full bg-amber-100 px-3 py-2 text-xs font-semibold text-amber-800 border border-amber-200">
+            {collected} / {badges.length || '–'} 獲得
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-8">
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">時間帯ゲージ</h2>
+              <p className="text-sm text-gray-700">
+                毎週日曜の30分ごとの来訪状況をゲージで表示します。緑が訪問済み、灰色が未訪問。
+              </p>
+            </div>
+            <a
+              href="/badges/time"
+              className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800 shadow-sm transition hover:bg-amber-100"
+            >
+              時間帯バッジを見る
+            </a>
+          </div>
+
+          <div className="overflow-x-auto">
+            <div className="flex min-w-max flex-col gap-2">
+              <div className="flex flex-nowrap items-end gap-1 pb-1">
+                {badges.map((entry) => {
+                  const acquired = entry.count > 0;
+                  return (
+                    <div key={entry.slot} className="relative h-10 w-[21px] shrink-0 overflow-hidden rounded-full">
+                      <span className="sr-only">
+                        {entry.slot} {acquired ? `訪問済み (${entry.count}回)` : '未訪問'}
+                      </span>
+                      <div
+                        className={`absolute inset-0 ${acquired ? 'bg-emerald-500' : 'bg-gray-300'}`}
+                        aria-hidden
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="flex flex-nowrap items-center gap-6 text-[11px] text-gray-600">
+                {['05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00', '17:00'].map(
+                  (label) => (
+                    <span key={label} className="shrink-0">{label}</span>
+                  )
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-2 rounded-2xl border border-amber-100 bg-gradient-to-r from-amber-50 via-orange-50 to-yellow-50 p-5 shadow-inner">
+            <p className="text-sm font-semibold text-amber-900 mb-2">日曜市の小路イメージ（仮）</p>
+            <div className="flex items-center gap-3 text-4xl">
+              <span role="img" aria-label="market-stall">🏘️</span>
+              <span role="img" aria-label="fruit">🍊</span>
+              <span role="img" aria-label="vegetable">🥕</span>
+              <span role="img" aria-label="fish">🐟</span>
+              <span role="img" aria-label="flower">🌼</span>
+            </div>
+            <p className="mt-2 text-xs text-amber-800">後日イラストに差し替え予定です。</p>
+          </div>
+        </section>
+      </div>
+
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/(public)/badges/page.tsx
+++ b/app/(public)/badges/page.tsx
@@ -4,15 +4,22 @@ import { useEffect, useState } from 'react';
 import NavigationBar from '../../components/NavigationBar';
 import { listTimeBadgeProgress, type TimeBadgeProgress } from '../map/services/timeBadgeService';
 import { getShoppingProgress, SHOPPING_SEGMENTS } from './services/shoppingBadgeService';
+import { getKotoduteProgress, NOTE_BADGES, LIKE_BADGES } from './services/kotoduteBadgeService';
 
 export default function BadgesPage() {
   const [badges, setBadges] = useState<TimeBadgeProgress[]>([]);
   const [shoppingUnlocked, setShoppingUnlocked] = useState<Set<string>>(new Set());
+  const [kotoduteCounts, setKotoduteCounts] = useState<{ notes: number; likes: number }>({
+    notes: 0,
+    likes: 0,
+  });
 
   useEffect(() => {
     setBadges(listTimeBadgeProgress());
     const shopping = getShoppingProgress();
     setShoppingUnlocked(shopping.unlocked);
+    const kotodute = getKotoduteProgress();
+    setKotoduteCounts({ notes: kotodute.noteCount, likes: kotodute.likeCount });
   }, []);
 
   const collected = badges.filter((b) => b.count > 0).length;
@@ -159,6 +166,83 @@ export default function BadgesPage() {
                   </span>
                 </div>
               ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-sky-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">ことづてバッジ</h2>
+              <p className="text-sm text-gray-700">
+                投稿数に応じてラブレターが積み重なります。いいね数のバッジも用意しています。
+              </p>
+            </div>
+            <a
+              href="/badges/kotodute"
+              className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-2 text-xs font-semibold text-sky-800 shadow-sm transition hover:bg-sky-100"
+            >
+              ことづてバッジを見る
+            </a>
+          </div>
+
+          <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-gray-50 p-4">
+            <p className="text-xs font-semibold text-gray-600">積み上がるラブレター（投稿数に応じて色付き）</p>
+            <div className="relative mx-auto flex h-48 w-full max-w-md items-end justify-center">
+              {Array.from({ length: 8 }).map((_, idx) => {
+                const filled = idx < Math.min(kotoduteCounts.notes, 8);
+                const y = 10 * idx;
+                const rotate = (idx % 3) * 2 - 2;
+                return (
+                  <svg
+                    key={idx}
+                    viewBox="0 0 120 60"
+                    className="absolute"
+                    style={{
+                      bottom: `${y}px`,
+                      transform: `translateY(${y}px) rotate(${rotate}deg)`,
+                    }}
+                  >
+                    <rect
+                      x="10"
+                      y="10"
+                      width="100"
+                      height="40"
+                      rx="6"
+                      fill={filled ? '#fef3c7' : '#ffffff'}
+                      stroke="#0f172a"
+                      strokeWidth="2"
+                    />
+                    <path
+                      d="M10 10 L60 40 L110 10"
+                      fill="none"
+                      stroke="#0f172a"
+                      strokeWidth="2"
+                    />
+                    {filled && (
+                      <path
+                        d="M55 33 L60 38 L65 33"
+                        fill="none"
+                        stroke="#f97316"
+                        strokeWidth="2"
+                      />
+                    )}
+                  </svg>
+                );
+              })}
+              <div className="pointer-events-none absolute inset-0 rounded-2xl border border-dashed border-gray-400" aria-hidden />
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-xs text-gray-700">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-amber-300 border border-amber-400" aria-hidden />
+                <span>投稿数</span>
+                <span className="text-[10px] text-gray-500">{kotoduteCounts.notes} 通</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-sky-300 border border-sky-400" aria-hidden />
+                <span>いいね数</span>
+                <span className="text-[10px] text-gray-500">{kotoduteCounts.likes} 個</span>
+              </div>
             </div>
           </div>
         </section>

--- a/app/(public)/badges/services/kotoduteBadgeService.ts
+++ b/app/(public)/badges/services/kotoduteBadgeService.ts
@@ -1,0 +1,51 @@
+import { loadKotodute } from '../../../../lib/kotoduteStorage';
+
+const LIKE_STORAGE_KEY = 'nicchyo-kotodute-likes';
+
+export type BadgeDef = {
+  id: string;
+  label: string;
+  threshold: number;
+};
+
+function loadLikes(): Record<string, number> {
+  if (typeof window === 'undefined') return {};
+  const raw = localStorage.getItem(LIKE_STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, number>;
+    return parsed ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function getKotoduteProgress() {
+  const notes = loadKotodute();
+  const likesMap = loadLikes();
+
+  const noteCount = notes.length;
+  const likeCount = Object.values(likesMap).reduce((acc, n) => acc + (Number(n) || 0), 0);
+
+  return {
+    noteCount,
+    likeCount,
+  };
+}
+
+export const NOTE_BADGES: BadgeDef[] = [
+  { id: 'note-01', label: 'ことづて 1通', threshold: 1 },
+  { id: 'note-05', label: 'ことづて 5通', threshold: 5 },
+  { id: 'note-10', label: 'ことづて 10通', threshold: 10 },
+  { id: 'note-20', label: 'ことづて 20通', threshold: 20 },
+  { id: 'note-50', label: 'ことづて 50通', threshold: 50 },
+  { id: 'note-100', label: 'ことづて 100通', threshold: 100 },
+];
+
+export const LIKE_BADGES: BadgeDef[] = [
+  { id: 'like-01', label: 'いいね 1個', threshold: 1 },
+  { id: 'like-10', label: 'いいね 10個', threshold: 10 },
+  { id: 'like-30', label: 'いいね 30個', threshold: 30 },
+  { id: 'like-60', label: 'いいね 60個', threshold: 60 },
+  { id: 'like-100', label: 'いいね 100個', threshold: 100 },
+];

--- a/app/(public)/badges/services/shoppingBadgeService.ts
+++ b/app/(public)/badges/services/shoppingBadgeService.ts
@@ -1,0 +1,87 @@
+import { shops } from '../../map/data/shops';
+
+const STORAGE_KEY = 'nicchyo-fridge-items';
+
+type BagItem = {
+  id: string;
+  name: string;
+  fromShopId?: number;
+  createdAt: number;
+};
+
+export type ShoppingSegment = {
+  id: string;
+  label: string;
+  color: string;
+  keywords: string[];
+};
+
+export const SHOPPING_SEGMENTS: ShoppingSegment[] = [
+  { id: 'veggies', label: '野菜', color: '#22c55e', keywords: ['野菜', '菜', '大根', '人参', 'にんじん', 'ねぎ', 'ネギ', '芋', '葉'] },
+  { id: 'fish', label: '魚', color: '#3b82f6', keywords: ['魚', '鮮魚', '鰹', 'かつお', 'カツオ', '鯖', 'サバ', '鰯', 'いわし', '干物'] },
+  { id: 'fruit', label: '果物', color: '#f97316', keywords: ['果物', 'みかん', '柑橘', 'りんご', 'リンゴ', '梨', 'ぶどう', '葡萄', '柿'] },
+  { id: 'flowers', label: '花', color: '#ec4899', keywords: ['花', '切り花', '苗', '盆栽', 'ブーケ'] },
+  { id: 'snacks', label: 'おやつ', color: '#f59e0b', keywords: ['おやつ', 'パン', 'スイーツ', '餅', 'まんじゅう', 'ケーキ'] },
+  { id: 'drinks', label: '飲み物', color: '#6366f1', keywords: ['お茶', 'コーヒー', '飲み', 'ジュース', '酒', 'ビール', 'ワイン'] },
+];
+
+const shopCategoryMap: Record<string, string> = {
+  vegetables: 'veggies',
+  fish: 'fish',
+  fruits: 'fruit',
+  flowers: 'flowers',
+  snacks: 'snacks',
+  drinks: 'drinks',
+};
+
+function loadBagItems(): BagItem[] {
+  if (typeof window === 'undefined') return [];
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as BagItem[];
+  } catch {
+    return [];
+  }
+}
+
+function normalize(text: string) {
+  return text.toLowerCase();
+}
+
+function matchKeyword(name: string, segment: ShoppingSegment) {
+  const n = normalize(name);
+  return segment.keywords.some((kw) => n.includes(normalize(kw)));
+}
+
+function mapShopCategory(shopId?: number): string | undefined {
+  if (!shopId) return undefined;
+  const shop = shops.find((s) => s.id === shopId);
+  if (!shop?.category) return undefined;
+  return shopCategoryMap[shop.category] ?? undefined;
+}
+
+export function getShoppingProgress() {
+  const items = loadBagItems();
+  const unlocked = new Set<string>();
+
+  for (const item of items) {
+    const fromShopCategory = mapShopCategory(item.fromShopId);
+    if (fromShopCategory) {
+      unlocked.add(fromShopCategory);
+      continue;
+    }
+
+    for (const seg of SHOPPING_SEGMENTS) {
+      if (matchKeyword(item.name, seg)) {
+        unlocked.add(seg.id);
+        break;
+      }
+    }
+  }
+
+  return {
+    unlocked,
+    itemsCount: items.length,
+  };
+}

--- a/app/(public)/badges/shopping/page.tsx
+++ b/app/(public)/badges/shopping/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import NavigationBar from '../../../components/NavigationBar';
+import { getShoppingProgress, SHOPPING_SEGMENTS } from '../services/shoppingBadgeService';
+
+export default function ShoppingBadgesPage() {
+  const [unlocked, setUnlocked] = useState<Set<string>>(new Set());
+  const [itemsCount, setItemsCount] = useState(0);
+
+  useEffect(() => {
+    const progress = getShoppingProgress();
+    setUnlocked(progress.unlocked);
+    setItemsCount(progress.itemsCount);
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+      <header className="border-b border-emerald-100 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-700">
+              badges
+            </p>
+            <h1 className="text-2xl font-bold text-gray-900">お買い物バッジ一覧</h1>
+            <p className="text-sm text-gray-700">bag に追加したカテゴリごとに色がつきます。</p>
+          </div>
+          <Link
+            href="/badges"
+            className="rounded-full border border-emerald-200 bg-white px-3 py-2 text-xs font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50"
+          >
+            バッジトップへ戻る
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-8">
+        <section className="rounded-2xl border border-emerald-100 bg-white/95 p-5 shadow-sm space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">塗り絵の進捗</h2>
+              <p className="text-sm text-gray-700">
+                追加アイテム数: {itemsCount} 件 / 獲得: {unlocked.size} / {SHOPPING_SEGMENTS.length}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            {SHOPPING_SEGMENTS.map((seg) => {
+              const filled = unlocked.has(seg.id);
+              return (
+                <div
+                  key={seg.id}
+                  className={`flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm ${
+                    filled ? 'border-emerald-200 bg-emerald-50/80' : 'border-gray-200 bg-gray-50/80'
+                  }`}
+                >
+                  <span
+                    className="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full border"
+                    style={{
+                      backgroundColor: filled ? seg.color : 'white',
+                      borderColor: filled ? seg.color : '#d1d5db',
+                    }}
+                    aria-hidden
+                  />
+                  <div className="flex-1 space-y-1">
+                    <p className="text-base font-semibold text-gray-900">{seg.label}</p>
+                    <p className="text-xs text-gray-600">
+                      {filled ? '獲得済み' : '未獲得（bagに追加すると色がつきます）'}
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-emerald-700">
+                    {filled ? '✓' : ''}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/(public)/badges/time/page.tsx
+++ b/app/(public)/badges/time/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import NavigationBar from '../../../components/NavigationBar';
+import { listTimeBadgeProgress, type TimeBadgeProgress } from '../../map/services/timeBadgeService';
+
+function formatDate(date?: string) {
+  if (!date) return '';
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' });
+}
+
+export default function TimeBadgesPage() {
+  const [badges, setBadges] = useState<TimeBadgeProgress[]>([]);
+
+  useEffect(() => {
+    setBadges(listTimeBadgeProgress());
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+      <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">badges</p>
+            <h1 className="text-2xl font-bold">時間帯バッジ一覧</h1>
+            <p className="text-sm text-gray-700">毎週日曜 5:00〜17:00 / 30分刻み</p>
+          </div>
+          <Link
+            href="/badges"
+            className="rounded-full border border-amber-200 bg-white px-3 py-2 text-xs font-semibold text-amber-800 shadow-sm hover:bg-amber-50"
+          >
+            バッジトップへ戻る
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-8">
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm">
+          <div className="grid gap-3 md:grid-cols-2">
+            {badges.map((entry) => {
+              const acquired = entry.count > 0;
+              return (
+                <div
+                  key={entry.slot}
+                  className={`rounded-xl border px-4 py-3 shadow-sm ${
+                    acquired ? 'border-amber-200 bg-amber-50/70' : 'border-gray-100 bg-gray-50/60'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-amber-700">
+                        {entry.slot}
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xl" aria-hidden>
+                          {acquired ? entry.tierIcon ?? entry.badge.icon : '⏳'}
+                        </span>
+                        <div>
+                          <p className="text-base font-bold text-gray-900">{entry.badge.title}</p>
+                          <p className="text-xs text-gray-600">
+                            {acquired ? `${entry.tierTitle ?? ''} / ${entry.count}回` : '未獲得'}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                    {acquired && (
+                      <div className="text-right">
+                        <p className="text-[11px] text-gray-500">最終: {formatDate(entry.lastDate)}</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/(public)/map/services/timeBadgeService.ts
+++ b/app/(public)/map/services/timeBadgeService.ts
@@ -22,6 +22,15 @@ export type TimeBadgeResult = {
   count: number;
 };
 
+export type TimeBadgeProgress = {
+  slot: string;
+  badge: TimeBadge;
+  count: number;
+  lastDate?: string;
+  tierTitle?: string;
+  tierIcon?: string;
+};
+
 const STORAGE_KEY = 'nicchyo-time-badges';
 const BOUNDS = getRoadBounds();
 
@@ -95,6 +104,27 @@ function computeTier(badge: TimeBadge, count: number) {
     if (count >= t.count) tier = t;
   }
   return tier;
+}
+
+export function listTimeBadgeProgress(): TimeBadgeProgress[] {
+  const progress = loadProgress();
+  return timeBadgeMaster.map((badge) => {
+    const slotProgress = progress.slots[badge.slot];
+    const count = slotProgress?.count ?? 0;
+    const tier =
+      count > 0
+        ? computeTier(badge, count)
+        : undefined;
+
+    return {
+      slot: badge.slot,
+      badge,
+      count,
+      lastDate: slotProgress?.lastDate,
+      tierTitle: tier?.title,
+      tierIcon: tier?.icon,
+    };
+  });
 }
 
 /**

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -1,15 +1,8 @@
 /**
- * ハンバーガーメニューコンポーネント
+ * ハンバーガーメニュー
  *
- * 【機能】
- * - ログイン/ログアウト
- * - 将来の機能へのリンク（マイ店舗管理など）
- * - 高齢の出店者でも分かりやすいUI
- *
- * 【将来の拡張】
- * - マイ店舗管理ページへのリンク
- * - プロフィール編集
- * - 通知設定
+ * - ロール別のリンクを出し分け
+ * - デモ用に AuthContext の login を呼び出す簡易ログインボタンを用意
  */
 
 'use client';
@@ -23,28 +16,14 @@ export default function HamburgerMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const { isLoggedIn, user, login, logout, permissions } = useAuth();
 
-  const toggleMenu = () => setIsOpen(!isOpen);
+  const toggleMenu = () => setIsOpen((v) => !v);
   const closeMenu = () => setIsOpen(false);
 
-  /**
-   * ダミーログイン処理
-   *
-   * 【現在】
-   * - roleを選択してログイン
-   *
-   * 【将来】
-   * - ログインフォームを表示
-   * - Firebase Auth でメール/パスワード認証
-   * - Custom Claims から role を取得
-   */
   const handleLogin = (role: UserRole) => {
     login(role);
     closeMenu();
   };
 
-  /**
-   * ログアウト処理
-   */
   const handleLogout = () => {
     logout();
     closeMenu();
@@ -58,12 +37,7 @@ export default function HamburgerMenu() {
         className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/90 text-gray-700 shadow-md transition hover:bg-white hover:shadow-lg"
         aria-label="メニュー"
       >
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
+        <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -73,15 +47,12 @@ export default function HamburgerMenu() {
         </svg>
       </button>
 
-      {/* オーバーレイ */}
+      {/* 背景オーバーレイ */}
       {isOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm"
-          onClick={closeMenu}
-        />
+        <div className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm" onClick={closeMenu} />
       )}
 
-      {/* メニューパネル */}
+      {/* スライドメニュー */}
       <div
         className={`fixed right-0 top-0 z-50 h-full w-80 max-w-[90vw] transform bg-white shadow-2xl transition-transform duration-300 ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
@@ -102,62 +73,54 @@ export default function HamburgerMenu() {
             </button>
           </div>
 
-          {/* ログイン状態表示 */}
+          {/* プロフィール表示 */}
           <div className="border-b border-gray-200 bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4">
             {isLoggedIn && user ? (
-              <div className="space-y-2">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white text-xl font-bold">
-                    {user.name.charAt(0)}
-                  </div>
-                  <div className="flex-1">
-                    <p className="text-sm font-semibold text-gray-800">
-                      {user.name}
-                    </p>
-                    <div className="flex items-center gap-2">
-                      <p className="text-xs text-gray-600">ログイン中</p>
-                      {permissions.isSuperAdmin && (
-                        <span className="rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-semibold text-white">
-                          管理者
-                        </span>
-                      )}
-                      {permissions.isVendor && (
-                        <span className="rounded-full bg-blue-500 px-2 py-0.5 text-[10px] font-semibold text-white">
-                          出店者
-                        </span>
-                      )}
-                    </div>
+              <div className="flex items-center gap-3">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white text-xl font-bold">
+                  {user.name.charAt(0)}
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-semibold text-gray-800">{user.name}</p>
+                  <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-2 py-0.5 border border-amber-100">
+                      <span aria-hidden>👤</span>一般ユーザー
+                    </span>
+                    {permissions.isSuperAdmin && (
+                      <span className="rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-semibold text-white">
+                        管理者
+                      </span>
+                    )}
+                    {permissions.isVendor && (
+                      <span className="rounded-full bg-blue-500 px-2 py-0.5 text-[10px] font-semibold text-white">
+                        出店者
+                      </span>
+                    )}
                   </div>
                 </div>
               </div>
             ) : (
-              <div className="text-center">
-                <p className="text-sm text-gray-600">
-                  ログインすると、店舗管理などができます
-                </p>
+              <div className="text-sm text-gray-700">
+                ログインすると保存やbag・バッジが利用できます。
               </div>
             )}
           </div>
 
-          {/* メニュー項目 */}
+          {/* メニュー本体 */}
           <nav className="flex-1 overflow-y-auto px-4 py-4">
             <ul className="space-y-2">
               {isLoggedIn ? (
                 <>
-                  {/* ログイン時のメニュー */}
-
-                  {/* スーパー管理者専用メニュー */}
                   {permissions.isSuperAdmin && (
                     <>
                       <li>
                         <div className="rounded-lg bg-red-50 px-3 py-2 mb-2">
                           <p className="text-xs font-semibold text-red-700 flex items-center gap-1">
-                            <span>🔐</span>
-                            管理者メニュー
+                            <span aria-hidden>⚙️</span>
+                            管理メニュー
                           </p>
                         </div>
                       </li>
-
                       <li>
                         <Link
                           href="/admin/shops"
@@ -167,14 +130,13 @@ export default function HamburgerMenu() {
                           <span className="text-xl">🏪</span>
                           <div className="flex-1">
                             <p className="text-sm font-medium">店舗管理</p>
-                            <p className="text-xs text-gray-500">全店舗の閲覧・編集</p>
+                            <p className="text-xs text-gray-500">出店情報の管理</p>
                           </div>
                           <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-700">
-                            準備中
+                            管理
                           </span>
                         </Link>
                       </li>
-
                       <li>
                         <Link
                           href="/admin/users"
@@ -184,14 +146,13 @@ export default function HamburgerMenu() {
                           <span className="text-xl">👥</span>
                           <div className="flex-1">
                             <p className="text-sm font-medium">ユーザー管理</p>
-                            <p className="text-xs text-gray-500">出店者アカウント管理</p>
+                            <p className="text-xs text-gray-500">権限設定など</p>
                           </div>
                           <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-700">
-                            準備中
+                            管理
                           </span>
                         </Link>
                       </li>
-
                       <li>
                         <Link
                           href="/admin/moderation"
@@ -200,22 +161,20 @@ export default function HamburgerMenu() {
                         >
                           <span className="text-xl">🛡️</span>
                           <div className="flex-1">
-                            <p className="text-sm font-medium">投稿モデレーション</p>
-                            <p className="text-xs text-gray-500">不適切な投稿の管理</p>
+                            <p className="text-sm font-medium">モデレーション</p>
+                            <p className="text-xs text-gray-500">投稿の確認</p>
                           </div>
                           <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-700">
-                            準備中
+                            管理
                           </span>
                         </Link>
                       </li>
-
                       <li>
                         <div className="my-3 border-t border-gray-200" />
                       </li>
                     </>
                   )}
 
-                  {/* 出店者メニュー */}
                   {permissions.isVendor && (
                     <li>
                       <Link
@@ -225,8 +184,8 @@ export default function HamburgerMenu() {
                       >
                         <span className="text-xl">🏪</span>
                         <div className="flex-1">
-                          <p className="text-sm font-medium">マイ店舗管理</p>
-                          <p className="text-xs text-gray-500">準備中</p>
+                          <p className="text-sm font-medium">マイ店舗</p>
+                          <p className="text-xs text-gray-500">Coming Soon</p>
                         </div>
                         <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
                           Coming Soon
@@ -235,50 +194,47 @@ export default function HamburgerMenu() {
                     </li>
                   )}
 
-                  {/* 一般ユーザー用メニュー */}
                   {permissions.isGeneralUser && (
-                    <li>
-                      <Link
-                        href="/bag"
-                        onClick={closeMenu}
-                        className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
-                      >
-                        <span className="text-xl">👜</span>
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">bag（買い物リスト）</p>
-                          <p className="text-xs text-gray-500">登録した買い物リストを見る</p>
-                        </div>
-                      </Link>
-                    </li>
+                    <>
+                      <li>
+                        <Link
+                          href="/bag"
+                          onClick={closeMenu}
+                          className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
+                        >
+                          <span className="text-xl">👜</span>
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">bag</p>
+                            <p className="text-xs text-gray-500">気になるものを保存</p>
+                          </div>
+                        </Link>
+                      </li>
+                      <li>
+                        <Link
+                          href="/badges"
+                          onClick={closeMenu}
+                          className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
+                        >
+                          <span className="text-xl">🏅</span>
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">バッジ</p>
+                            <p className="text-xs text-gray-500">獲得した来訪バッジを見る</p>
+                          </div>
+                        </Link>
+                      </li>
+                    </>
                   )}
 
-                  {permissions.isGeneralUser && (
-                    <li>
-                      <Link
-                        href="/badges"
-                        onClick={closeMenu}
-                        className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
-                      >
-                        <span className="text-xl">🏅</span>
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">バッジ</p>
-                          <p className="text-xs text-gray-500">獲得した記念バッジを見る</p>
-                        </div>
-                      </Link>
-                    </li>
-                  )}
-
-                  {/* 共通メニュー */}
                   <li>
                     <Link
                       href="/my-profile"
                       onClick={closeMenu}
                       className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
                     >
-                      <span className="text-xl">👤</span>
+                      <span className="text-xl">🙍‍♂️</span>
                       <div className="flex-1">
                         <p className="text-sm font-medium">プロフィール</p>
-                        <p className="text-xs text-gray-500">準備中</p>
+                        <p className="text-xs text-gray-500">Coming Soon</p>
                       </div>
                       <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
                         Coming Soon
@@ -302,34 +258,23 @@ export default function HamburgerMenu() {
                 </>
               ) : (
                 <>
-                  {/* 未ログイン時のメニュー */}
                   <li>
-                    <div className="rounded-lg bg-gray-50 p-4 mb-3">
-                      <p className="text-xs font-semibold text-gray-700 mb-2">
-                        ログイン（テスト版）
-                      </p>
-                      <p className="text-xs text-gray-600 leading-relaxed mb-3">
-                        開発テスト用のログイン機能です。
-                        役割を選択してログインできます。
-                      </p>
+                    <div className="rounded-lg bg-gray-50 p-4 mb-3 text-sm text-gray-700 leading-relaxed">
+                      デモ用ログインです。ロールを選んで機能を試せます。
                     </div>
                   </li>
-
                   <li>
                     <button
                       onClick={() => handleLogin('super_admin')}
                       className="flex w-full items-center gap-3 rounded-lg border-2 border-red-200 bg-red-50 px-4 py-3 text-gray-700 transition hover:bg-red-100"
                     >
-                      <span className="text-xl">🔐</span>
+                      <span className="text-xl">⚙️</span>
                       <div className="flex-1 text-left">
-                        <p className="text-sm font-semibold">管理者でログイン</p>
-                        <p className="text-xs text-gray-600">
-                          高知市・高専（全権限）
-                        </p>
+                        <p className="text-sm font-semibold">管理者としてログイン</p>
+                        <p className="text-xs text-gray-600">店舗・ユーザー管理</p>
                       </div>
                     </button>
                   </li>
-
                   <li>
                     <button
                       onClick={() => handleLogin('vendor')}
@@ -337,14 +282,11 @@ export default function HamburgerMenu() {
                     >
                       <span className="text-xl">🏪</span>
                       <div className="flex-1 text-left">
-                        <p className="text-sm font-semibold">出店者でログイン</p>
-                        <p className="text-xs text-gray-600">
-                          山田商店（店舗ID: 1）
-                        </p>
+                        <p className="text-sm font-semibold">出店者としてログイン</p>
+                        <p className="text-xs text-gray-600">デモIDで表示</p>
                       </div>
                     </button>
                   </li>
-
                   <li>
                     <button
                       onClick={() => handleLogin('general_user')}
@@ -353,27 +295,18 @@ export default function HamburgerMenu() {
                       <span className="text-xl">👤</span>
                       <div className="flex-1 text-left">
                         <p className="text-sm font-semibold">一般ユーザーでログイン</p>
-                        <p className="text-xs text-gray-600">
-                          観光客（閲覧のみ）
-                        </p>
+                        <p className="text-xs text-gray-600">bag・バッジを体験</p>
                       </div>
                     </button>
                   </li>
-
                   <li>
-                    <div className="mt-4 rounded-lg bg-amber-50 border border-amber-200 p-3">
-                      <p className="text-xs text-amber-800 leading-relaxed">
-                        <span className="font-semibold">💡 将来の実装：</span>
-                        <br />
-                        Firebase Authentication でメール/パスワード認証を行い、
-                        役割（role）はカスタムクレームで管理します。
-                      </p>
+                    <div className="mt-4 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800 leading-relaxed">
+                      本番環境では Firebase Auth 等に置き換えてください。
                     </div>
                   </li>
                 </>
               )}
 
-              {/* 共通メニュー */}
               <li>
                 <div className="my-3 border-t border-gray-200" />
               </li>
@@ -385,10 +318,9 @@ export default function HamburgerMenu() {
                   className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-gray-50"
                 >
                   <span className="text-xl">ℹ️</span>
-                  <p className="text-sm font-medium">プロジェクトについて</p>
+                  <p className="text-sm font-medium">このサービスについて</p>
                 </Link>
               </li>
-
               <li>
                 <Link
                   href="/faq"
@@ -399,7 +331,6 @@ export default function HamburgerMenu() {
                   <p className="text-sm font-medium">よくある質問</p>
                 </Link>
               </li>
-
               <li>
                 <Link
                   href="/contact"
@@ -415,9 +346,7 @@ export default function HamburgerMenu() {
 
           {/* フッター */}
           <div className="border-t border-gray-200 px-6 py-4">
-            <p className="text-xs text-gray-500 text-center">
-              © 2025 nicchyo - 日曜市デジタルマップ
-            </p>
+            <p className="text-xs text-gray-500 text-center">© 2025 nicchyo</p>
           </div>
         </div>
       </div>

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -13,8 +13,8 @@ const navItems: NavItem[] = [
   { name: 'ホーム', href: '/', icon: '🏠' },
   { name: 'マップ', href: '/map', icon: '🗺️' },
   { name: '検索', href: '/search', icon: '🔍' },
-  { name: '料理', href: '/recipes', icon: '🍳' },
-  { name: '投稿', href: '/kotodute', icon: '✏️' },
+  { name: 'レシピ', href: '/recipes', icon: '🍳' },
+  { name: 'ことづて', href: '/kotodute', icon: '✉️' },
 ];
 
 export default function NavigationBar() {
@@ -30,9 +30,7 @@ export default function NavigationBar() {
               key={item.name}
               href={item.href}
               className={`flex flex-col items-center justify-center flex-1 h-full transition-colors ${
-                isActive
-                  ? 'text-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
+                isActive ? 'text-amber-700' : 'text-gray-600 hover:text-gray-900'
               }`}
             >
               <span className="text-2xl mb-1">{item.icon}</span>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
 - 追加: バッジトップに「お買い物バッジ」「ことづてバッジ」導線を追加し、それぞれ専用ページを新設
  - 機能: 買い物バッジは bag のカテゴリ進捗に応じて塗り絵をカラー化、ことづてバッジは投稿数/いいね数でアンロック
  - UI: 時間帯バッジをゲージ＋詳細ページに分離、ゲージ幅やラベルを調整しスマホでも横スクロールで確認可能
  - テスト: npm test (Vitest) 通過

  補足: いいね数はローカルストレージ nicchyo-kotodute-likes を参照する設計です。

片岡勇登