### PR TITLE
ホームの構成刷新とマップ導線の整理Feature/home page

### DIFF
--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -275,6 +275,29 @@ export default function MapView({
     saveBag([{ id, name: value, fromShopId, category, createdAt: Date.now() }, ...items]);
   }, []);
 
+  const selectedShopIndex = useMemo(() => {
+    if (!selectedShop) return -1;
+    return shops.findIndex((shop) => shop.id === selectedShop.id);
+  }, [selectedShop]);
+
+  const canNavigate = selectedShopIndex >= 0 && shops.length > 1;
+
+  const handleSelectByOffset = useCallback((offset: number) => {
+    if (!canNavigate) return;
+    const nextIndex = (selectedShopIndex + offset + shops.length) % shops.length;
+    const nextShop = shops[nextIndex];
+    if (!nextShop) return;
+    setSelectedShop(nextShop);
+    const minZoom = getMinZoomForShopDetails();
+    const currentZoom = mapRef.current?.getZoom() ?? INITIAL_ZOOM;
+    const targetZoom = Math.max(currentZoom, minZoom, 18);
+    if (mapRef.current) {
+      mapRef.current.flyTo([nextShop.lat, nextShop.lng], targetZoom, {
+        duration: 0.6,
+      });
+    }
+  }, [canNavigate, selectedShopIndex]);
+
   return (
     <div className="relative h-full w-full">
       <MapContainer
@@ -402,11 +425,31 @@ export default function MapView({
       )}
 
       {selectedShop && (
-        <ShopDetailBanner
-          shop={selectedShop}
-          onClose={() => setSelectedShop(null)}
-          onAddToBag={handleAddToBag}
-        />
+        <>
+          <ShopDetailBanner
+            shop={selectedShop}
+            onClose={() => setSelectedShop(null)}
+            onAddToBag={handleAddToBag}
+          />
+          {canNavigate && (
+            <div className="fixed bottom-28 left-1/2 z-[2100] flex -translate-x-1/2 gap-3">
+              <button
+                type="button"
+                onClick={() => handleSelectByOffset(-1)}
+                className="rounded-full border border-amber-200 bg-white/90 px-4 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
+              >
+                ←前へ
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSelectByOffset(1)}
+                className="rounded-full border border-amber-200 bg-white/90 px-4 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
+              >
+                次へ→
+              </button>
+            </div>
+          )}
+        </>
       )}
 
       <MapAgentAssistant

--- a/app/(public)/search/components/SearchResults.tsx
+++ b/app/(public)/search/components/SearchResults.tsx
@@ -11,6 +11,7 @@ interface SearchResultsProps {
   favoriteShopIds: number[];
   onCategoryClick?: (category: string) => void;
   onToggleFavorite?: (shopId: number) => void;
+  onSelectShop?: (shop: Shop) => void;
 }
 
 /**
@@ -24,6 +25,7 @@ export default function SearchResults({
   favoriteShopIds,
   onCategoryClick,
   onToggleFavorite,
+  onSelectShop,
 }: SearchResultsProps) {
   // 結果がない場合は空状態を表示
   if (shops.length === 0) {
@@ -53,6 +55,7 @@ export default function SearchResults({
             shop={shop}
             isFavorite={favoriteShopIds.includes(shop.id)}
             onToggleFavorite={onToggleFavorite}
+            onSelectShop={onSelectShop}
           />
         ))}
       </div>

--- a/app/(public)/search/components/ShopResultCard.tsx
+++ b/app/(public)/search/components/ShopResultCard.tsx
@@ -8,15 +8,27 @@ interface ShopResultCardProps {
   shop: Shop;
   isFavorite: boolean;
   onToggleFavorite?: (shopId: number) => void;
+  onSelectShop?: (shop: Shop) => void;
 }
 
 /**
  * 店舗検索結果カードコンポーネント
  * 店舗情報と「地図で見る」リンクを表示
  */
-function ShopResultCard({ shop, isFavorite, onToggleFavorite }: ShopResultCardProps) {
+function ShopResultCard({ shop, isFavorite, onToggleFavorite, onSelectShop }: ShopResultCardProps) {
   return (
-    <div className="rounded-xl border border-amber-100 bg-amber-50/40 px-4 py-3 shadow-sm">
+    <div
+      className="rounded-xl border-2 border-orange-300 bg-amber-50/40 px-4 py-3 shadow-sm cursor-pointer transition active:scale-[1.02] active:bg-orange-50 hover:bg-orange-50"
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelectShop?.(shop)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelectShop?.(shop);
+        }
+      }}
+    >
       {/* ヘッダー: アイコン、店舗名、ブロック番号 */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
@@ -32,6 +44,8 @@ function ShopResultCard({ shop, isFavorite, onToggleFavorite }: ShopResultCardPr
           <button
             type="button"
             onClick={() => onToggleFavorite?.(shop.id)}
+            onMouseDown={(event) => event.stopPropagation()}
+            onClickCapture={(event) => event.stopPropagation()}
             aria-pressed={isFavorite}
             aria-label={isFavorite ? 'Remove favorite' : 'Add favorite'}
             className={`inline-flex h-8 w-8 items-center justify-center rounded-full border text-sm font-semibold shadow-sm transition ${isFavorite ? 'border-pink-300 bg-pink-500 text-white' : 'border-pink-200 bg-white text-pink-500 hover:bg-pink-50'}`}
@@ -56,6 +70,7 @@ function ShopResultCard({ shop, isFavorite, onToggleFavorite }: ShopResultCardPr
       {/* 地図で見るリンク */}
       <Link
         href={`/map?shop=${shop.id}`}
+        onClick={(event) => event.stopPropagation()}
         className="mt-3 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-white px-3 py-1 text-xs font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
       >
         地図で見る →

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,76 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 
 export const metadata = {
   title: "about | nicchyo",
-  description: "nicchyo は高知高専のプロジェクトとして日曜市のデジタル体験を探求しています。",
+  description:
+    "nicchyo は高知高専のプロジェクトとして日曜市のデジタル体験を探求しています。",
 };
+
+const pillars = [
+  {
+    title: "マップ",
+    icon: "🗺️",
+    desc: "屋台の位置やおすすめを地図で直感的に確認できます。",
+    href: "/map",
+  },
+  {
+    title: "おすすめ",
+    icon: "🔍",
+    desc: "お目当ての商品やお店を素早く検索して見つけられます。",
+    href: "/search",
+  },
+  {
+    title: "ことづて",
+    icon: "💬",
+    desc: "出店者と来場者の声をつなぐ短いメッセージボードです。",
+    href: "/kotodute",
+  },
+  {
+    title: "土佐の料理レシピ",
+    icon: "🍳",
+    desc: "季節の食材を使った土佐料理のレシピを紹介します。",
+    href: "/recipes",
+  },
+  {
+    title: "午後のイベント",
+    icon: "🎪",
+    desc: "市場が終わった後も楽しめる地域イベントやワークショップを掲載。",
+    href: "/events",
+  },
+];
+
+const audiences = [
+  {
+    title: "はじめての来訪",
+    subtitle: "どこを回ればいいか知りたい",
+    icon: "🧭",
+    points: [
+      "目安ルート提案で迷わず回れる",
+      "定番スポットと旬の見どころを表示",
+      "徒歩時間と距離の目安を把握",
+    ],
+  },
+  {
+    title: "リピーター",
+    subtitle: "新しい発見を探したい",
+    icon: "✨",
+    points: [
+      "その日だけの限定品をピックアップ",
+      "お気に入り店をブックマーク",
+      "ことづてで交流や質問ができる",
+    ],
+  },
+  {
+    title: "出店者",
+    subtitle: "お客さんに見つけてもらいたい",
+    icon: "📣",
+    points: [
+      "出店位置と商品をシンプルに掲示",
+      "おすすめ欄で季節の推しを告知",
+      "簡単なアンケートで声を集める",
+    ],
+  },
+];
 
 const coreValues = [
   "日曜市の空気感を壊さずにデジタルで補助する",
@@ -13,21 +80,21 @@ const coreValues = [
 
 const teamNotes = [
   "高知工業高等専門学校の学生・教員による研究プロジェクトです。",
-  "高知市の協力を得て、現地での聞き取りや実地テストを実施しています。",
-  "フィールドワークの結果は、OSS として公開できる部分から順次共有していきます。",
+  "高知市の協力を得て、現地での聞き取りとフィールドテストを実施しています。",
+  "成果は段階的に公開し、OSSとして共有できる部分は積極的に開いていきます。",
 ];
 
 export default function AboutPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
       <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 md:flex-row md:items-center md:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
               about nicchyo
             </p>
-            <h1 className="text-2xl font-bold">高知高専発・日曜市の実験プロジェクト</h1>
-            <p className="text-sm text-gray-700">
+            <h1 className="text-2xl font-bold md:text-3xl">高知高専発・日曜市の実験プロジェクト</h1>
+            <p className="mt-2 text-sm text-gray-700">
               日曜市をもっと歩きやすく、もっと知りやすくするための小さなデジタル実験です。
             </p>
           </div>
@@ -40,16 +107,62 @@ export default function AboutPage() {
         </div>
       </header>
 
-      <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm">
-          <h2 className="text-lg font-bold text-gray-900">プロジェクトの概要</h2>
-          <p className="mt-2 text-sm text-gray-700 leading-relaxed">
-            nicchyo は、高知工業高等専門学校（高知高専）の学生と教員が中心となって進める研究・開発プロジェクトです。
-            日曜市の持つ文化や人の温かさを損なわずに、マップ、レシピ、ことづてなどのデジタル機能で体験を補助することを目指しています。
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10">
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+          <h2 className="text-2xl font-bold">日曜市を、もっと歩きやすく</h2>
+          <p className="mt-3 text-sm text-gray-700 md:text-base">
+            nicchyo は、高知・日曜市の「見つける」「歩く」「交流する」をまとめたガイドです。
+            マップで位置を確認しながら、おすすめやイベント、ことづてをチェックできます。
           </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link
+              href="/map"
+              className="rounded-xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-300/40 transition hover:bg-amber-500"
+            >
+              マップを見る
+            </Link>
+            <Link
+              href="/search"
+              className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-xs text-gray-800 transition hover:border-gray-300"
+            >
+              お店を探す
+            </Link>
+          </div>
         </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm">
+        <section>
+          <div className="mb-6 text-center">
+            <h2 className="text-2xl font-bold md:text-3xl">nicchyo を支える 5つの柱</h2>
+            <p className="mt-3 text-sm text-gray-700 md:text-base">
+              マップを中心に、おすすめ、ことづて、イベントまで。日曜市をまるごと楽しめる導線を揃えました。
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {pillars.map((item) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
+              >
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-lg">
+                    <span>{item.icon}</span>
+                  </div>
+                  <h3 className="text-base font-semibold md:text-lg">{item.title}</h3>
+                </div>
+                <p className="flex-1 text-sm text-gray-700">{item.desc}</p>
+                <Link
+                  href={item.href}
+                  className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-amber-700"
+                >
+                  詳しくみる
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900">大切にしていること</h3>
           <ul className="mt-3 space-y-2 text-sm text-gray-800">
             {coreValues.map((v) => (
@@ -61,7 +174,35 @@ export default function AboutPage() {
           </ul>
         </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm">
+        <section>
+          <div className="mb-6 text-center md:text-left">
+            <h2 className="text-2xl font-bold md:text-3xl">それぞれの楽しみ方に寄り添う</h2>
+            <p className="mt-3 max-w-3xl text-sm text-gray-700 md:text-base">
+              観光客、リピーター、出店者それぞれの立場で「知りたいこと」を手早く見つけられるよう設計しました。
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {audiences.map((a) => (
+              <div
+                key={a.title}
+                className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
+              >
+                <div className="mb-2 flex items-center gap-2 text-base font-semibold">
+                  <span className="text-lg">{a.icon}</span>
+                  <span>{a.title}</span>
+                </div>
+                <p className="mb-3 text-xs text-gray-600">{a.subtitle}</p>
+                <ul className="mt-auto space-y-1.5 text-xs text-gray-700">
+                  {a.points.map((p) => (
+                    <li key={p}>・{p}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900">チームと活動</h3>
           <ul className="mt-3 space-y-2 text-sm text-gray-800">
             {teamNotes.map((n) => (
@@ -73,10 +214,10 @@ export default function AboutPage() {
           </ul>
         </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-5 shadow-sm">
+        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900">連携・お問い合わせ</h3>
           <p className="mt-2 text-sm text-gray-700">
-            実証実験への協力、フィードバック、メディア取材などは下記フォームからご連絡ください。
+            実証実験への協力、フィードバック、メディア取材などは下記からご連絡ください。
           </p>
           <div className="mt-3 flex flex-wrap gap-3 text-sm">
             <Link

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -1,7 +1,7 @@
-'use client';
+﻿"use client";
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 interface NavItem {
   name: string;
@@ -10,30 +10,29 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { name: 'ホーム', href: '/', icon: '🏠' },
-  { name: 'マップ', href: '/map', icon: '🗺️' },
-  { name: '検索', href: '/search', icon: '🔍' },
-  { name: 'レシピ', href: '/recipes', icon: '🍳' },
-  { name: 'ことづて', href: '/kotodute', icon: '✉️' },
+  { name: "マップ", href: "/map", icon: "🗺️" },
+  { name: "検索", href: "/search", icon: "🔍" },
+  { name: "レシピ", href: "/recipes", icon: "🍳" },
+  { name: "ことづて", href: "/kotodute", icon: "✉️" },
 ];
 
 export default function NavigationBar() {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg z-50">
-      <div className="flex justify-around items-center h-16 max-w-lg mx-auto">
+    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 bg-white shadow-lg">
+      <div className="mx-auto flex h-16 max-w-lg items-center justify-around">
         {navItems.map((item) => {
           const isActive = pathname === item.href;
           return (
             <Link
               key={item.name}
               href={item.href}
-              className={`flex flex-col items-center justify-center flex-1 h-full transition-colors ${
-                isActive ? 'text-amber-700' : 'text-gray-600 hover:text-gray-900'
+              className={`flex h-full flex-1 flex-col items-center justify-center transition-colors ${
+                isActive ? "text-amber-700" : "text-gray-600 hover:text-gray-900"
               }`}
             >
-              <span className="text-2xl mb-1">{item.icon}</span>
+              <span className="mb-1 text-2xl">{item.icon}</span>
               <span className="text-xs font-medium">{item.name}</span>
             </Link>
           );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,285 +1,30 @@
 ﻿"use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useEffect, useRef } from "react";
-import { motion, useAnimation, useInView } from "framer-motion";
-import NavigationBar from "./components/NavigationBar";
 
-const pillars = [
-  {
-    title: "マップ",
-    icon: "\uD83D\uDDFA\uFE0F",
-    desc: "屋台の位置やおすすめを地図で直感的に確認できます。",
-    href: "/map",
-  },
-  {
-    title: "おすすめ",
-    icon: "\uD83D\uDD0D",
-    desc: "お目当ての商品やお店を素早く検索して見つけられます。",
-    href: "/search",
-  },
-  {
-    title: "ことづて",
-    icon: "\uD83D\uDCAC",
-    desc: "出店者と来場者の声をつなぐ短いメッセージボードです。",
-    href: "/kotodute",
-  },
-  {
-    title: "土佐の料理レシピ",
-    icon: "\uD83C\uDF73",
-    desc: "季節の食材を使った土佐料理のレシピを紹介します。",
-    href: "/recipes",
-  },
-  {
-    title: "午後のイベント",
-    icon: "\uD83C\uDFAA",
-    desc: "市場が終わった後も楽しめる地域イベントやワークショップを掲載。",
-    href: "/events",
-  },
-];
-
-// ターゲットユーザーのデータ
-const audiences = [
-  {
-    title: "はじめての来訪",
-    subtitle: "どこを回ればいいか知りたい",
-    icon: "🧳",
-    points: [
-      "目安ルート提案で迷わず回れる",
-      "定番スポットと旬の見どころを表示",
-      "徒歩時間と距離の目安を把握",
-    ],
-  },
-  {
-    title: "リピーター",
-    subtitle: "新しい発見を探したい",
-    icon: "🔍",
-    points: [
-      "その日だけの限定品をピックアップ",
-      "お気に入り店をブックマーク",
-      "ことづてで交流や質問ができる",
-    ],
-  },
-  {
-    title: "出店者",
-    subtitle: "お客さんに見つけてもらいたい",
-    icon: "🧺",
-    points: [
-      "出店位置と商品をシンプルに掲示",
-      "おすすめ欄で季節の推しを告知",
-      "簡単なアンケートで声を集める",
-    ],
-  },
-];
-
-type Pillar = (typeof pillars)[number];
-
-function PillarCard({ item }: { item: Pillar }) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const inView = useInView(ref, { amount: 0.6 });
-  const controls = useAnimation();
-
-  useEffect(() => {
-    controls.start(
-      inView
-        ? {
-            y: 0,
-            opacity: 1,
-            scale: 1,
-            borderColor: "#f97316",
-            boxShadow: "0 10px 30px rgba(251, 146, 60, 0.16)",
-          }
-        : {
-            y: 30,
-            opacity: 0.75,
-            scale: 0.99,
-            borderColor: "#ffedd5",
-            boxShadow: "0 6px 16px rgba(0,0,0,0.06)",
-          }
-    );
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      whileHover={{ y: -4, scale: 1.01 }}
-      initial={{ opacity: 0.75, y: 30, scale: 0.99 }}
-      animate={controls}
-      transition={{ type: "spring", stiffness: 180, damping: 22 }}
-      className="group flex h-full flex-col rounded-2xl border bg-white p-5 transition"
-    >
-      <div className="mb-3 flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-lg">
-          <span>{item.icon}</span>
-        </div>
-        <h3 className="text-base font-semibold md:text-lg">{item.title}</h3>
-      </div>
-      <p className="flex-1 text-sm text-gray-700">{item.desc}</p>
-      <Link
-        href={item.href}
-        className={`mt-4 inline-flex items-center gap-1 text-xs font-semibold transition ${
-          inView ? "opacity-100 text-amber-700" : "opacity-0 text-amber-700 group-hover:opacity-100"
-        }`}
-      >
-        詳しくみる
-        <span aria-hidden>↗</span>
-      </Link>
-    </motion.div>
-  );
-}
+const MapView = dynamic(() => import("./(public)/map/components/MapView"), {
+  ssr: false,
+});
 
 export default function HomePage() {
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900">
-      <main className="flex-1">
-        {/* Hero */}
-        <section className="relative overflow-hidden border-b border-orange-100">
-          <div className="pointer-events-none absolute inset-0 opacity-40">
-            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-amber-300/50 blur-3xl" />
-            <div className="absolute -right-16 top-32 h-72 w-72 rounded-full bg-orange-200/60 blur-3xl" />
-            <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-amber-200 to-transparent" />
-          </div>
-
-          <div className="relative z-10 mx-auto flex max-w-5xl flex-col gap-10 px-4 py-14 md:flex-row md:items-center md:py-20">
-            <div className="flex-1 space-y-6">
-              <motion.h1
-                className="text-4xl font-bold leading-tight md:text-5xl"
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6 }}
-              >
-                日曜市を、
-                <span className="bg-gradient-to-r from-amber-600 via-orange-500 to-amber-600 bg-clip-text text-transparent">
-                  もっと歩きやすく、
-                </span>
-              </motion.h1>
-
-              <motion.p
-                className="max-w-2xl text-sm text-gray-700 md:text-base"
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1, duration: 0.6 }}
-              >
-                nicchyo は、高知・日曜市の「見つける」「歩く」「交流する」をまとめたガイドです。
-                マップで位置を確認しながら、おすすめやイベント、ことづてをチェックできます。
-              </motion.p>
-
-              <motion.div
-                className="flex flex-wrap items-center gap-3"
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.2, duration: 0.5 }}
-              >
-                <Link
-                  href="/map"
-                  className="rounded-xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-300/40 transition hover:bg-amber-500"
-                >
-                  <span className="flex items-center gap-2">
-                    マップを見る
-                    <span aria-hidden>↗</span>
-                  </span>
-                </Link>
-                <Link
-                  href="/about"
-                  className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-xs text-gray-800 transition hover:border-gray-300"
-                >
-                  プロジェクトについて
-                </Link>
-              </motion.div>
-            </div>
-
-            <motion.div
-              className="w-full max-w-sm self-stretch rounded-2xl border border-orange-100 bg-white/80 p-4 shadow-xl backdrop-blur md:max-w-xs"
-              initial={{ opacity: 0, x: 16 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.25, duration: 0.6 }}
-            >
-              <div className="mb-3 flex items-center justify-between text-xs text-gray-600">
-                <span>市場の今をチェック</span>
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                  LIVE
-                </span>
-              </div>
-              <div className="relative h-40 rounded-xl bg-gradient-to-br from-amber-50 to-orange-100">
-                <div className="absolute left-6 top-6 h-7 w-7 rounded-full border border-amber-500/60 bg-amber-500/50 shadow-lg shadow-amber-300/40" />
-                <div className="absolute left-20 top-12 h-5 w-5 rounded-full border border-orange-500/60 bg-orange-500/50 shadow-lg shadow-orange-300/40" />
-                <div className="absolute right-10 bottom-8 h-4 w-4 rounded-full border border-amber-300/60 bg-amber-200/80 shadow-lg shadow-amber-200/60" />
-                <div className="absolute inset-x-4 bottom-4 h-1 rounded-full bg-orange-200/70" />
-              </div>
-              <p className="mt-3 text-[11px] leading-relaxed text-gray-600">
-                出店位置・おすすめをリアルタイムにまとめています。お気に入りをブックマークしながら、市場を歩いてみてください。
-              </p>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Pillars */}
-        <section className="mx-auto max-w-5xl px-4 py-14 md:py-18">
-          <div className="mb-10 text-center">
-            <h2 className="text-2xl font-bold md:text-3xl">nicchyo を支える 5つの柱</h2>
-            <p className="mt-3 text-sm text-gray-700 md:text-base">
-              マップを中心に、おすすめ、ことづて、イベントまで。日曜市をまるごと楽しめる導線を揃えました。
-            </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {pillars.map((item) => (
-              <PillarCard key={item.title} item={item} />
-            ))}
-          </div>
-        </section>
-
-        {/* Audience */}
-        <section className="border-t border-orange-100 bg-amber-50/40">
-          <div className="mx-auto max-w-5xl px-4 py-14 md:py-18">
-            <div className="mb-8 text-center md:text-left">
-              <h2 className="text-2xl font-bold md:text-3xl">それぞれの楽しみ方に寄り添う</h2>
-              <p className="mt-3 max-w-3xl text-sm text-gray-700 md:text-base">
-                観光客、リピーター、出店者それぞれの立場で「知りたいこと」を手早く見つけられるよう設計しました。
-              </p>
-            </div>
-            <div className="grid gap-6 md:grid-cols-3">
-              {audiences.map((a) => (
-                <div
-                  key={a.title}
-                  className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
-                >
-                  <div className="mb-2 flex items-center gap-2 text-base font-semibold">
-                    <span className="text-lg">{a.icon}</span>
-                    <span>{a.title}</span>
-                  </div>
-                  <p className="mb-3 text-xs text-gray-600">{a.subtitle}</p>
-                  <ul className="mt-auto space-y-1.5 text-xs text-gray-700">
-                    {a.points.map((p) => (
-                      <li key={p}>・{p}</li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-      </main>
-
-      <footer className="border-t border-orange-100 bg-white px-4 py-6">
-        <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-3 text-[11px] text-gray-600 md:flex-row">
-          <span>© {new Date().getFullYear()} nicchyo – Kochi Sunday Market DX</span>
-          <div className="flex gap-4">
-            <Link href="/about" className="transition hover:text-amber-600">
-              プロジェクトについて
-            </Link>
-            <span className="text-gray-400">/</span>
-            <span className="text-gray-600">
-              Made in Kochi with ❤️
-            </span>
-          </div>
-        </div>
-      </footer>
-
-      <NavigationBar />
+    <div className="relative h-screen w-screen overflow-hidden bg-amber-50">
+      <div className="absolute inset-0 scale-[1.04] blur-md opacity-70">
+        <MapView />
+      </div>
+      <Link
+        href="/map"
+        className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-white/30 text-center backdrop-blur-sm"
+        aria-label="マップページへ移動"
+      >
+        <span className="text-5xl font-bold tracking-[0.08em] text-amber-900 md:text-7xl">
+          nicchyo
+        </span>
+        <span className="mt-4 text-sm font-semibold text-amber-800 md:text-base">
+          タップで始める
+        </span>
+      </Link>
     </div>
   );
 }
-
-
-
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,130 @@
 ﻿"use client";
 
 import dynamic from "next/dynamic";
-import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 const MapView = dynamic(() => import("./(public)/map/components/MapView"), {
   ssr: false,
 });
 
 export default function HomePage() {
+  const router = useRouter();
+  const [loaded, setLoaded] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
+
   return (
-    <div className="relative h-screen w-screen overflow-hidden bg-amber-50">
-      <div className="absolute inset-0 scale-[1.04] blur-md opacity-70">
-        <MapView />
-      </div>
-      <Link
-        href="/map"
-        className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-white/30 text-center backdrop-blur-sm"
-        aria-label="マップページへ移動"
-      >
-        <span className="text-5xl font-bold tracking-[0.08em] text-amber-900 md:text-7xl">
-          nicchyo
-        </span>
-        <span className="mt-4 text-sm font-semibold text-amber-800 md:text-base">
-          タップで始める
-        </span>
-      </Link>
+    <div className="min-h-screen bg-amber-50 text-gray-900">
+      <section className="relative h-screen w-screen overflow-hidden">
+        <div
+          className={`absolute inset-0 scale-[1.04] transition-all duration-700 ease-out ${
+            revealed
+              ? "blur-0 opacity-100"
+              : loaded
+                ? "blur-md opacity-70"
+                : "blur-xl opacity-0"
+          }`}
+        >
+          <MapView />
+        </div>
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-white/30 text-center backdrop-blur-sm transition-colors duration-500 -translate-y-4 md:-translate-y-6">
+          <img
+            src="/images/obaasan.webp"
+            alt=""
+            aria-hidden="true"
+            className="-mt-6 mb-6 h-40 w-40 rounded-2xl object-cover shadow-lg md:h-56 md:w-56"
+          />
+          <span className="text-5xl font-bold tracking-[0.08em] text-amber-900 md:text-7xl">
+            nicchyo
+          </span>
+          <div className="mt-6 flex w-full max-w-xs flex-col gap-3 text-sm font-semibold text-amber-900 md:max-w-sm">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                router.push("/signup");
+              }}
+              className="rounded-xl border border-amber-200 bg-white/90 px-4 py-3 shadow-sm transition hover:bg-amber-50"
+            >
+              サインアップ
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                router.push("/login");
+              }}
+              className="rounded-xl border border-amber-200 bg-white/90 px-4 py-3 shadow-sm transition hover:bg-amber-50"
+            >
+              ログイン
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                setRevealed(true);
+                window.setTimeout(() => {
+                  router.push("/map");
+                }, 350);
+              }}
+              className="rounded-xl border border-amber-200 bg-white/90 px-4 py-3 shadow-sm transition hover:bg-amber-50"
+            >
+              ログイン無しで利用する
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative border-t border-orange-100 bg-gradient-to-b from-amber-50 via-orange-50 to-white px-4 py-14 md:py-18">
+        <div className="mx-auto flex max-w-4xl flex-col gap-8">
+          <header className="text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
+              about nicchyo
+            </p>
+            <h2 className="mt-2 text-2xl font-bold md:text-3xl">
+              日曜市を、もっと歩きやすく
+            </h2>
+            <p className="mt-3 text-sm text-gray-700 md:text-base">
+              nicchyo は高知の日曜市を「迷わず、出会える」ようにするガイドです。
+              位置、食材、口コミ、イベントをひとつにまとめて、今日の市場を見渡せます。
+            </p>
+          </header>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="rounded-2xl border border-orange-100 bg-white/90 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-amber-900">今いる場所から逆算</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                マップで屋台の位置とおすすめを確認。歩く順番の目安が見えるので、
+                初めてでも迷わず楽しめます。
+              </p>
+            </div>
+            <div className="rounded-2xl border border-orange-100 bg-white/90 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-amber-900">旬の食材を軸に探す</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                欲しい食材から出店を探せるので、買い逃しが減ります。
+                気になるお店はその場でメモできます。
+              </p>
+            </div>
+            <div className="rounded-2xl border border-orange-100 bg-white/90 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-amber-900">声で広がるおすすめ</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                ことづてでリアルな声が集まるので、地元の推しに出会えます。
+                「次はここ行ってみよう」が生まれます。
+              </p>
+            </div>
+            <div className="rounded-2xl border border-orange-100 bg-white/90 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-amber-900">地図からすぐ始める</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                ボタンからすぐにマップへ。今の市場を眺めながら、
+                今日の一歩目を決められます。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
  # 概要

  ホームをスクロール可能な構成に刷新し、上部はぼかしたマップ背景＋認証導線、下部はプロジェクト説明のストーリーにまとめました。
  タップ遷移は廃止し、「ログイン無しで利用する」ボタンでブラー解除→遷移する導線に統一しています。

  # 変更内容

  - ホームをスクロール構成にし、説明セクションを追加
  - ぼかしたマップ背景を上下セクションに適用
  - サインアップ/ログイン/ログイン無しの導線をカード化
  - 全画面タップ遷移を廃止し、ログイン無しボタンのみブラー解除→遷移
  - ヒーローのレイアウト調整（おばあちゃん画像・文字位置）

  # UI影響

  - ホームのUIが大きく変更
  - スクロールで説明へ進める導線に変更
  - 認証ボタンの表示・遷移が明確化

片岡勇登