### PR TITLE
fix: Jekyll Liquid構文エラーを修正（GitHub Pagesビルド対応）

### DIFF
--- a/ARCHITECTURE_SHOP_MARKERS.md
+++ b/ARCHITECTURE_SHOP_MARKERS.md
@@ -82,6 +82,7 @@ Leaflet Marker（当たり判定）
 
 **重要な実装**:
 ```typescript
+{% raw %}
 // Leaflet DivIconで店舗イラストをHTML化
 const iconMarkup = renderToStaticMarkup(
   <div className="shop-marker-container">
@@ -103,6 +104,7 @@ return (
     eventHandlers={{ click: () => onClick(shop) }}
   />
 );
+{% endraw %}
 ```
 
 **なぜこれで解決するのか**:
@@ -139,6 +141,7 @@ export interface Shop {
 
 #### 変更前（旧アーキテクチャ）
 ```typescript
+{% raw %}
 <ImageOverlay url={HANDDRAWN_MAP_IMAGE} bounds={MAP_BOUNDS} />
 
 {shops.map((shop) => (
@@ -148,6 +151,7 @@ export interface Shop {
     eventHandlers={{ click: () => setSelectedShop(shop) }}
   />
 ))}
+{% endraw %}
 ```
 
 #### 変更後（新アーキテクチャ）
@@ -357,6 +361,7 @@ return liveShops.map((shop) => (
 
 ### 4. アニメーション強化
 ```typescript
+{% raw %}
 // ShopMarker.tsxに追加
 <motion.div
   initial={{ scale: 0 }}
@@ -365,6 +370,7 @@ return liveShops.map((shop) => (
 >
   <ShopIllustration />
 </motion.div>
+{% endraw %}
 ```
 
 ## まとめ

--- a/ILLUSTRATION_OPTIMIZATION_GUIDE.md
+++ b/ILLUSTRATION_OPTIMIZATION_GUIDE.md
@@ -125,6 +125,7 @@ const iconMarkup = renderToStaticMarkup(
 #### 実装例
 
 ```typescript
+{% raw %}
 // スプライトシート定義
 const SPRITE_POSITIONS = {
   'shop-001': { x: 0, y: 0, width: 60, height: 60 },
@@ -142,6 +143,7 @@ const SPRITE_POSITIONS = {
     height: `${pos.height}px`,
   }}
 />
+{% endraw %}
 ```
 
 ### 5. キャッシュ戦略

--- a/MOBILE_VIEWPORT_OPTIMIZATION.md
+++ b/MOBILE_VIEWPORT_OPTIMIZATION.md
@@ -96,6 +96,7 @@ export default function ViewportHeightUpdater() {
 
 #### MapPageClient.tsx
 ```typescript
+{% raw %}
 // ❌ Before
 <div className="h-screen pb-16">
   <main className="flex-1">
@@ -111,6 +112,7 @@ export default function ViewportHeightUpdater() {
   <GrandmaChatter /> {/* fixed position */}
   <NavigationBar />  {/* fixed position */}
 </div>
+{% endraw %}
 ```
 
 **効果**: 地図が全画面表示、UIはオーバーレイ（圧迫しない）
@@ -136,6 +138,7 @@ export function MenuProvider({ children }: { children: ReactNode }) {
 
 #### AppHeader.tsx
 ```typescript
+{% raw %}
 export default function AppHeader() {
   const { isMenuOpen } = useMenu();
 
@@ -151,6 +154,7 @@ export default function AppHeader() {
     </header>
   );
 }
+{% endraw %}
 ```
 
 #### HamburgerMenu.tsx
@@ -182,6 +186,7 @@ export default function HamburgerMenu() {
 
 #### NavigationBar.tsx
 ```typescript
+{% raw %}
 export default function NavigationBar() {
   return (
     <nav
@@ -196,6 +201,7 @@ export default function NavigationBar() {
     </nav>
   );
 }
+{% endraw %}
 ```
 
 **効果**:

--- a/docs/FIREBASE_AUTH_MIGRATION.md
+++ b/docs/FIREBASE_AUTH_MIGRATION.md
@@ -157,6 +157,7 @@ service cloud.firestore {
 **`lib/auth/AuthContext.tsx` の変更**
 
 ```typescript
+{% raw %}
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
@@ -271,6 +272,7 @@ export function useAuth() {
   }
   return context;
 }
+{% endraw %}
 ```
 
 ### ステップ 2: HamburgerMenu をログインフォームに対応


### PR DESCRIPTION
- ILLUSTRATION_OPTIMIZATION_GUIDE.md
- MOBILE_VIEWPORT_OPTIMIZATION.md
- ARCHITECTURE_SHOP_MARKERS.md
- docs/FIREBASE_AUTH_MIGRATION.md

問題: コード例の `{{` がJekyll Liquidテンプレート構文として誤認識される
解決: {% raw %} ... {% endraw %} でコードブロックを囲む

🤖 Generated with [Claude Code](https://claude.com/claude-code)