### PR TITLE
ログイン機能と出店者導線の追加（ダミー認証・マイ店舗連携）Feature/login

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 pb-24">
+      <div className="mx-auto w-full max-w-md px-4 pt-10">
+        <div className="mb-6 rounded-3xl border border-orange-200 bg-white/90 p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-700">
+            login
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-slate-900">ログイン</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            メールアドレスとパスワードでログインしてください。
+          </p>
+        </div>
+
+        <form className="space-y-4 rounded-3xl border border-orange-300 bg-white p-5 shadow-sm">
+          <label className="block text-sm text-slate-700">
+            メールアドレス
+            <input
+              type="email"
+              required
+              placeholder="example@domain.com"
+              className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
+            />
+          </label>
+          <label className="block text-sm text-slate-700">
+            パスワード
+            <input
+              type="password"
+              required
+              placeholder="••••••••"
+              className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="w-full rounded-full bg-amber-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
+          >
+            ログインする
+          </button>
+        </form>
+
+        <div className="mt-4 flex items-center justify-center">
+          <Link
+            href="/"
+            className="rounded-full border border-orange-200 bg-white px-4 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
+          >
+            ホームに戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -173,7 +173,7 @@ export default function MapPageClient() {
             )}
 
             {showVendorPrompt && vendorShopName && (
-              <div className="absolute left-4 right-4 top-4 z-[1300]">
+              <div className="absolute left-4 right-4 top-1/2 z-[1300] -translate-y-1/2">
                 <div className="rounded-2xl border border-amber-200 bg-white/95 p-4 shadow-xl">
                   <div className="flex items-start justify-between gap-3">
                     <div>
@@ -193,6 +193,15 @@ export default function MapPageClient() {
                       ×
                     </button>
                   </div>
+                  {(vendorShop?.images?.main || "/images/shops/tosahamono.webp") && (
+                    <div className="mt-3 overflow-hidden rounded-2xl border border-amber-100 bg-white">
+                      <img
+                        src={vendorShop?.images?.main ?? "/images/shops/tosahamono.webp"}
+                        alt={`${vendorShopName}の写真`}
+                        className="h-40 w-full object-cover object-center"
+                      />
+                    </div>
+                  )}
                   <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                     <button
                       type="button"

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -132,7 +132,6 @@ export default function GrandmaChatter({
   const handleAvatarPointerUp = (event: React.PointerEvent<HTMLButtonElement>) => {
     if (dragStateRef.current.pointerId !== event.pointerId) return;
     dragStateRef.current.pointerId = null;
-    dragStateRef.current.moved = false;
     if (rafRef.current !== null) {
       window.cancelAnimationFrame(rafRef.current);
       rafRef.current = null;

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -33,7 +33,7 @@ import {
   getRecommendedZoomBounds,
 } from '../config/roadConfig';
 import { getZoomConfig } from '../utils/zoomCalculator';
-import { FAVORITE_SHOPS_KEY, loadFavoriteShopIds } from "../../../../lib/favoriteShops";
+import { FAVORITE_SHOPS_KEY, FAVORITE_SHOPS_UPDATED_EVENT, loadFavoriteShopIds } from "../../../../lib/favoriteShops";
 import {
   getViewModeForZoom,
   ViewMode,
@@ -226,8 +226,17 @@ export default function MapView({
         setFavoriteShopIds(loadFavoriteShopIds());
       }
     };
+    const handleFavoriteUpdate = (event: Event) => {
+      if (event.type === FAVORITE_SHOPS_UPDATED_EVENT) {
+        setFavoriteShopIds(loadFavoriteShopIds());
+      }
+    };
     window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
+    window.addEventListener(FAVORITE_SHOPS_UPDATED_EVENT, handleFavoriteUpdate);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(FAVORITE_SHOPS_UPDATED_EVENT, handleFavoriteUpdate);
+    };
   }, []);
 
   const recipeIngredients = useMemo(() => {
@@ -408,6 +417,7 @@ export default function MapView({
           shops={shops}
           onShopClick={handleShopClick}
           selectedShopId={selectedShop?.id}
+          favoriteShopIds={favoriteShopIds}
         />
 
         {/* レシピオーバーレイ */}

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -120,7 +120,7 @@ export default function OptimizedShopLayerWithClustering({
       // 店舗イラスト + 吹き出しを含むHTML文字列を生成
       const iconMarkup = renderToStaticMarkup(
         <div
-          className="shop-marker-container"
+          className={`shop-marker-container shop-side-${shop.side}`}
           style={{
             position: 'relative',
             cursor: 'pointer',

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -30,16 +30,30 @@ interface OptimizedShopLayerWithClusteringProps {
   shops: Shop[];
   onShopClick: (shop: Shop) => void;
   selectedShopId?: number;
+  favoriteShopIds?: number[];
 }
 
 export default function OptimizedShopLayerWithClustering({
   shops,
   onShopClick,
   selectedShopId,
+  favoriteShopIds,
 }: OptimizedShopLayerWithClusteringProps) {
   const map = useMap();
   const clusterGroupRef = useRef<L.MarkerClusterGroup | null>(null);
   const markersRef = useRef<Map<number, L.Marker>>(new Map());
+  const favoriteSetRef = useRef<Set<number>>(new Set());
+  const prevFavoriteSetRef = useRef<Set<number>>(new Set());
+
+  const setMarkerFavorite = (marker: L.Marker, isFavorite: boolean) => {
+    const icon = marker.getElement();
+    if (!icon) return;
+    if (isFavorite) {
+      icon.classList.add('is-favorite');
+    } else {
+      icon.classList.remove('is-favorite');
+    }
+  };
 
   useEffect(() => {
     // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -113,6 +127,9 @@ export default function OptimizedShopLayerWithClustering({
             transition: 'transform 0.2s ease',
           }}
         >
+          <div className="shop-favorite-badge" aria-hidden="true">
+            &#10084;
+          </div>
           {/* 商品吹き出し */}
           <ShopBubble
             icon={shop.icon}
@@ -151,6 +168,9 @@ export default function OptimizedShopLayerWithClustering({
       marker.on('click', () => {
         onShopClick(shop);
       });
+      marker.on('add', () => {
+        setMarkerFavorite(marker, favoriteSetRef.current.has(shop.id));
+      });
 
       // クラスタグループに追加
       markers.addLayer(marker);
@@ -172,6 +192,29 @@ export default function OptimizedShopLayerWithClustering({
   // 【ポイント8】選択中店舗のスタイル更新
   // - 選択状態をCSSクラスで表現
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  useEffect(() => {
+    favoriteSetRef.current = new Set(favoriteShopIds ?? []);
+    const nextFavorites = favoriteSetRef.current;
+    const prevFavorites = prevFavoriteSetRef.current;
+    const changed = new Set<number>();
+
+    prevFavorites.forEach((id) => {
+      if (!nextFavorites.has(id)) changed.add(id);
+    });
+    nextFavorites.forEach((id) => {
+      if (!prevFavorites.has(id)) changed.add(id);
+    });
+
+    changed.forEach((id) => {
+      const marker = markersRef.current.get(id);
+      if (marker) {
+        setMarkerFavorite(marker, nextFavorites.has(id));
+      }
+    });
+
+    prevFavoriteSetRef.current = nextFavorites;
+  }, [favoriteShopIds]);
+
   useEffect(() => {
     markersRef.current.forEach((marker, shopId) => {
       const icon = marker.getElement();

--- a/app/(public)/map/components/ShopDetailBanner.tsx
+++ b/app/(public)/map/components/ShopDetailBanner.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Shop } from "../data/shops";
+import { useAuth } from "../../../../lib/auth/AuthContext";
 import {
   FAVORITE_SHOPS_KEY,
   FAVORITE_SHOPS_UPDATED_EVENT,
@@ -49,6 +50,7 @@ export default function ShopDetailBanner({
   onAddToBag,
 }: ShopDetailBannerProps) {
   const router = useRouter();
+  const { permissions } = useAuth();
   const [draggedProduct, setDraggedProduct] = useState<string | null>(null);
   const [isBagHover, setIsBagHover] = useState(false);
   const [pendingProduct, setPendingProduct] = useState<string | null>(null);
@@ -164,6 +166,12 @@ export default function ShopDetailBanner({
     setFavoriteShopIds(next);
   }, [shop.id]);
 
+  const canEditShop = permissions.canEditShop(shop.id);
+
+  const handleEditShop = useCallback(() => {
+    router.push("/my-shop");
+  }, [router]);
+
   const handleConfirmAdd = useCallback(() => {
     if (!pendingProduct) return;
     onAddToBag?.(pendingProduct, shop.id);
@@ -197,6 +205,15 @@ export default function ShopDetailBanner({
               >
                 <span className="text-lg font-bold">{isFavorite ? "❤" : "♡"}</span>
               </button>
+              {canEditShop && (
+                <button
+                  type="button"
+                  onClick={handleEditShop}
+                  className="rounded-full border border-amber-200 bg-white px-3 py-1.5 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
+                >
+                  編集する
+                </button>
+              )}
             </div>
             <p className="text-sm text-slate-600">
               {shop.category} | {shop.ownerName}

--- a/app/(public)/map/components/ShopDetailBanner.tsx
+++ b/app/(public)/map/components/ShopDetailBanner.tsx
@@ -185,22 +185,24 @@ export default function ShopDetailBanner({
         {/* ヘッダー */}
         <div className="mb-2 flex items-start justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-slate-900">
-              {shop.name}
-            </h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-2xl font-semibold text-slate-900">
+                {shop.name}
+              </h2>
+              <button
+                className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm shadow-sm transition-transform hover:scale-105 ${isFavorite ? "bg-pink-100 text-pink-600" : "bg-white/70 text-pink-500"}`}
+                type="button"
+                onClick={handleToggleFavorite}
+                aria-label={isFavorite ? "お気に入りを解除" : "お気に入りに追加"}
+              >
+                <span className="text-lg font-bold">{isFavorite ? "❤" : "♡"}</span>
+              </button>
+            </div>
             <p className="text-sm text-slate-600">
               {shop.category} | {shop.ownerName}
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <button
-              className={`mr-4 flex items-center gap-2 rounded-full px-4 py-2 text-sm shadow-sm transition-transform hover:scale-105 ${isFavorite ? "bg-pink-100 text-pink-600" : "bg-white/70 text-pink-500"}`}
-              type="button"
-              onClick={handleToggleFavorite}
-              aria-label={isFavorite ? "お気に入りを解除" : "お気に入りに追加"}
-            >
-              <span className="text-lg font-bold">{isFavorite ? "❤" : "♡"}</span>
-            </button>
             <button
               onClick={onClose}
               className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-slate-900 text-2xl font-bold shadow transition-transform hover:scale-110"

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,0 +1,446 @@
+﻿"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type FormState = {
+  name: string;
+  ownerName: string;
+  category: string;
+  icon: string;
+  stallStyle: string;
+  schedule: string;
+  productsText: string;
+  description: string;
+  specialtyDish: string;
+  aboutVendor: string;
+  message: string;
+  imageMain: string;
+  imageThumb: string;
+  imageAdditional: string;
+  instagram: string;
+  facebook: string;
+  twitter: string;
+  website: string;
+};
+
+const CATEGORIES = [
+  "食材",
+  "食べ物",
+  "道具・工具",
+  "生活雑貨",
+  "植物・苗",
+  "アクセサリー",
+  "手作り・工芸",
+];
+
+const CATEGORY_ICONS: Record<string, string[]> = {
+  "食材": ["🥬", "🥕", "🍅"],
+  "食べ物": ["🍙", "🍡", "🍠"],
+  "道具・工具": ["🔪", "🧰", "🪚"],
+  "生活雑貨": ["🧺", "🧼", "🧻"],
+  "植物・苗": ["🪴", "🌱", "🌼"],
+  "アクセサリー": ["💍", "🧵", "🎀"],
+  "手作り・工芸": ["🧶", "🎨", "🧵"],
+};
+
+const REQUIRED_FIELDS: (keyof FormState)[] = [
+  "name",
+  "ownerName",
+  "category",
+  "icon",
+  "productsText",
+  "description",
+  "schedule",
+];
+
+const EMPTY_FORM: FormState = {
+  name: "",
+  ownerName: "",
+  category: "",
+  icon: "",
+  stallStyle: "",
+  schedule: "",
+  productsText: "",
+  description: "",
+  specialtyDish: "",
+  aboutVendor: "",
+  message: "",
+  imageMain: "",
+  imageThumb: "",
+  imageAdditional: "",
+  instagram: "",
+  facebook: "",
+  twitter: "",
+  website: "",
+};
+
+export default function MyShopPage() {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
+
+  const iconOptions = useMemo(() => {
+    if (!form.category) return [];
+    return CATEGORY_ICONS[form.category] ?? [];
+  }, [form.category]);
+
+  useEffect(() => {
+    if (!form.category) {
+      setForm((prev) => ({ ...prev, icon: "" }));
+      return;
+    }
+    if (form.icon && !iconOptions.includes(form.icon)) {
+      setForm((prev) => ({ ...prev, icon: "" }));
+    }
+  }, [form.category, form.icon, iconOptions]);
+
+  const handleChange =
+    (key: keyof FormState) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const value = event.target.value;
+      setForm((prev) => ({ ...prev, [key]: value }));
+      if (errors[key]) {
+        setErrors((prev) => ({ ...prev, [key]: undefined }));
+      }
+    };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors: Partial<Record<keyof FormState, string>> = {};
+    REQUIRED_FIELDS.forEach((key) => {
+      if (!form[key].trim()) {
+        nextErrors[key] = "必須項目です。";
+      }
+    });
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+    // TODO: save form
+  };
+
+  const requiredMark = (
+    <span className="ml-1 text-[11px] font-semibold text-rose-600">*</span>
+  );
+
+  const fieldClass = (key: keyof FormState) =>
+    `mt-1 w-full rounded-xl border px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none ${
+      errors[key]
+        ? "border-rose-400 focus:border-rose-500"
+        : "border-orange-200 focus:border-amber-400"
+    }`;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 pb-24">
+      <div className="mx-auto w-full max-w-4xl px-4 pt-6">
+        <div className="mb-4 rounded-3xl border border-orange-200 bg-white/90 p-4 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-700">
+            マイ店舗
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-slate-900">
+            出店情報の入力
+          </h1>
+          <p className="mt-2 text-sm text-slate-600">
+            入力内容は運営の確認後に反映されます。必須項目には * が付きます。
+          </p>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+          <section className="rounded-3xl border border-orange-300 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-bold text-amber-700">基本情報</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="block text-sm text-slate-700">
+                店舗名{requiredMark}
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={handleChange("name")}
+                  placeholder="例: 旬の野菜やさん"
+                  className={fieldClass("name")}
+                  aria-invalid={!!errors.name}
+                  required
+                />
+                {errors.name && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.name}
+                  </span>
+                )}
+              </label>
+              <label className="block text-sm text-slate-700">
+                店主名{requiredMark}
+                <input
+                  type="text"
+                  value={form.ownerName}
+                  onChange={handleChange("ownerName")}
+                  placeholder="例: 山田 花子"
+                  className={fieldClass("ownerName")}
+                  aria-invalid={!!errors.ownerName}
+                  required
+                />
+                {errors.ownerName && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.ownerName}
+                  </span>
+                )}
+              </label>
+              <label className="block text-sm text-slate-700">
+                カテゴリー{requiredMark}
+                <select
+                  value={form.category}
+                  onChange={handleChange("category")}
+                  className={fieldClass("category")}
+                  aria-invalid={!!errors.category}
+                  required
+                >
+                  <option value="">選択してください</option>
+                  {CATEGORIES.map((category) => (
+                    <option key={category} value={category}>
+                      {category}
+                    </option>
+                  ))}
+                </select>
+                {errors.category && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.category}
+                  </span>
+                )}
+              </label>
+              <label className="block text-sm text-slate-700">
+                アイコン{requiredMark}
+                <select
+                  value={form.icon}
+                  onChange={handleChange("icon")}
+                  className={fieldClass("icon")}
+                  aria-invalid={!!errors.icon}
+                  required
+                  disabled={!form.category}
+                >
+                  <option value="">
+                    {form.category ? "選択してください" : "カテゴリーを選択してください"}
+                  </option>
+                  {iconOptions.map((icon) => (
+                    <option key={icon} value={icon}>
+                      {icon}
+                    </option>
+                  ))}
+                </select>
+                {errors.icon && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.icon}
+                  </span>
+                )}
+              </label>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-orange-300 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-bold text-amber-700">出店情報</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="block text-sm text-slate-700">
+                出店スタイル
+                <input
+                  type="text"
+                  value={form.stallStyle}
+                  onChange={handleChange("stallStyle")}
+                  placeholder="例: テント出店 / ワゴン"
+                  className={fieldClass("stallStyle")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700">
+                出店予定・営業時間{requiredMark}
+                <input
+                  type="text"
+                  value={form.schedule}
+                  onChange={handleChange("schedule")}
+                  placeholder="例: 毎週日曜 6:00-12:00"
+                  className={fieldClass("schedule")}
+                  aria-invalid={!!errors.schedule}
+                  required
+                />
+                {errors.schedule && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.schedule}
+                  </span>
+                )}
+              </label>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-orange-300 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-bold text-amber-700">商品・紹介</h2>
+            <div className="mt-3 space-y-3">
+              <label className="block text-sm text-slate-700">
+                取扱商品{requiredMark}
+                <textarea
+                  value={form.productsText}
+                  onChange={handleChange("productsText")}
+                  placeholder="例: トマト, きゅうり, 大根"
+                  rows={2}
+                  className={fieldClass("productsText")}
+                  aria-invalid={!!errors.productsText}
+                  required
+                />
+                <span className="mt-1 block text-[11px] text-slate-500">
+                  カンマ区切りで入力してください。
+                </span>
+                {errors.productsText && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.productsText}
+                  </span>
+                )}
+              </label>
+              <label className="block text-sm text-slate-700">
+                お店の説明{requiredMark}
+                <textarea
+                  value={form.description}
+                  onChange={handleChange("description")}
+                  placeholder="例: 朝採れの野菜を中心に、季節の味をお届けします。"
+                  rows={3}
+                  className={fieldClass("description")}
+                  aria-invalid={!!errors.description}
+                  required
+                />
+                {errors.description && (
+                  <span className="mt-1 block text-[11px] text-rose-600">
+                    {errors.description}
+                  </span>
+                )}
+              </label>
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="block text-sm text-slate-700">
+                  得意料理
+                  <input
+                    type="text"
+                    value={form.specialtyDish}
+                    onChange={handleChange("specialtyDish")}
+                    placeholder="例: かつおのたたき"
+                    className={fieldClass("specialtyDish")}
+                  />
+                </label>
+                <label className="block text-sm text-slate-700">
+                  出店者のこだわり
+                  <input
+                    type="text"
+                    value={form.aboutVendor}
+                    onChange={handleChange("aboutVendor")}
+                    placeholder="例: 無農薬にこだわっています"
+                    className={fieldClass("aboutVendor")}
+                  />
+                </label>
+              </div>
+              <label className="block text-sm text-slate-700">
+                メッセージ
+                <textarea
+                  value={form.message}
+                  onChange={handleChange("message")}
+                  placeholder="例: いつでも気軽に声をかけてください。"
+                  rows={2}
+                  className={fieldClass("message")}
+                />
+              </label>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-orange-300 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-bold text-amber-700">写真</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="block text-sm text-slate-700">
+                メイン画像URL
+                <input
+                  type="url"
+                  value={form.imageMain}
+                  onChange={handleChange("imageMain")}
+                  placeholder="https://example.com/main.jpg"
+                  className={fieldClass("imageMain")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700">
+                サムネイルURL
+                <input
+                  type="url"
+                  value={form.imageThumb}
+                  onChange={handleChange("imageThumb")}
+                  placeholder="https://example.com/thumb.jpg"
+                  className={fieldClass("imageThumb")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700 md:col-span-2">
+                追加画像URL
+                <input
+                  type="text"
+                  value={form.imageAdditional}
+                  onChange={handleChange("imageAdditional")}
+                  placeholder="https://example.com/1.jpg, https://example.com/2.jpg"
+                  className={fieldClass("imageAdditional")}
+                />
+                <span className="mt-1 block text-[11px] text-slate-500">
+                  カンマ区切りで最大5枚まで。
+                </span>
+              </label>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-orange-300 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-bold text-amber-700">SNS・外部リンク</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="block text-sm text-slate-700">
+                Instagram
+                <input
+                  type="url"
+                  value={form.instagram}
+                  onChange={handleChange("instagram")}
+                  placeholder="https://instagram.com/..."
+                  className={fieldClass("instagram")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700">
+                Facebook
+                <input
+                  type="url"
+                  value={form.facebook}
+                  onChange={handleChange("facebook")}
+                  placeholder="https://facebook.com/..."
+                  className={fieldClass("facebook")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700">
+                X (Twitter)
+                <input
+                  type="url"
+                  value={form.twitter}
+                  onChange={handleChange("twitter")}
+                  placeholder="https://x.com/..."
+                  className={fieldClass("twitter")}
+                />
+              </label>
+              <label className="block text-sm text-slate-700">
+                Webサイト
+                <input
+                  type="url"
+                  value={form.website}
+                  onChange={handleChange("website")}
+                  placeholder="https://example.com"
+                  className={fieldClass("website")}
+                />
+              </label>
+            </div>
+          </section>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <button
+              type="button"
+              className="rounded-full border border-orange-200 bg-white px-5 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-50"
+            >
+              下書き保存
+            </button>
+            <button
+              type="submit"
+              className="rounded-full bg-amber-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
+            >
+              送信する
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
 import { useAuth } from "@/lib/auth/AuthContext";
+import NavigationBar from "@/app/components/NavigationBar";
 import { applyShopEdits, saveShopEdits, SHOP_EDITS_UPDATED_EVENT } from "@/lib/shopEdits";
 import { shops as baseShops } from "../map/data/shops";
 import type { ShopEditableData } from "../map/types/shopData";
@@ -537,6 +538,7 @@ export default function MyShopPage() {
           </div>
         </form>
       </div>
+      <NavigationBar />
     </div>
   );
 }

--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -1,53 +1,37 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState, type FormEvent } from "react";
-import { useAuth } from "../../../lib/auth/AuthContext";
 
-export default function LoginPage() {
-  const router = useRouter();
-  const { loginWithCredentials } = useAuth();
-  const [identifier, setIdentifier] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setError("");
-    const ok = loginWithCredentials(identifier, password);
-    if (!ok) {
-      setError("メールアドレス/ユーザーネームまたはパスワードが違います。");
-      return;
-    }
-    router.push("/map");
-  };
-
+export default function SignupPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 pb-24">
       <div className="mx-auto w-full max-w-md px-4 pt-10">
         <div className="mb-6 rounded-3xl border border-orange-200 bg-white/90 p-5 shadow-sm">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-700">
-            login
+            signup
           </p>
-          <h1 className="mt-2 text-2xl font-bold text-slate-900">ログイン</h1>
+          <h1 className="mt-2 text-2xl font-bold text-slate-900">サインアップ</h1>
           <p className="mt-2 text-sm text-slate-600">
-            メールアドレスとパスワードでログインしてください。
+            メールアドレスとパスワードでアカウントを作成します。
           </p>
         </div>
 
-        <form
-          className="space-y-4 rounded-3xl border border-orange-300 bg-white p-5 shadow-sm"
-          onSubmit={handleSubmit}
-        >
+        <form className="space-y-4 rounded-3xl border border-orange-300 bg-white p-5 shadow-sm">
           <label className="block text-sm text-slate-700">
-            メールアドレス または ユーザーネーム
+            ユーザーネーム
             <input
               type="text"
               required
-              placeholder="example@domain.com / nicchyo_user"
-              value={identifier}
-              onChange={(event) => setIdentifier(event.target.value)}
+              placeholder="例: nicchyo_user"
+              className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
+            />
+          </label>
+          <label className="block text-sm text-slate-700">
+            メールアドレス
+            <input
+              type="email"
+              required
+              placeholder="example@domain.com"
               className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
             />
           </label>
@@ -57,22 +41,24 @@ export default function LoginPage() {
               type="password"
               required
               placeholder="••••••••"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
               className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
             />
           </label>
-          {error && (
-            <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-600">
-              {error}
-            </p>
-          )}
+          <label className="block text-sm text-slate-700">
+            パスワード（確認）
+            <input
+              type="password"
+              required
+              placeholder="••••••••"
+              className="mt-1 w-full rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none"
+            />
+          </label>
 
           <button
             type="submit"
             className="w-full rounded-full bg-amber-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
           >
-            ログインする
+            サインアップする
           </button>
         </form>
 

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * ハンバーガーメニュー
  *
  * - ロール別のリンクを出し分け
@@ -69,7 +69,7 @@ export default function HamburgerMenu() {
           {/* プロフィール表示 */}
           <div className="border-b border-gray-200 bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4">
             {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
+              <Link href="/my-profile" onClick={closeMenu} className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white text-xl font-bold">
                   {user.name.charAt(0)}
                 </div>
@@ -77,7 +77,8 @@ export default function HamburgerMenu() {
                   <p className="text-sm font-semibold text-gray-800">{user.name}</p>
                   <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
                     <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-2 py-0.5 border border-amber-100">
-                      <span aria-hidden>👤</span>一般ユーザー
+                      <MenuIcon name="user" className="h-3.5 w-3.5 text-amber-700" />
+                      一般ユーザー
                     </span>
                     {permissions.isSuperAdmin && (
                       <span className="rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-semibold text-white">
@@ -91,7 +92,7 @@ export default function HamburgerMenu() {
                     )}
                   </div>
                 </div>
-              </div>
+              </Link>
             ) : (
               <div className="text-sm text-gray-700">
                 ログインすると保存やbag・バッジが利用できます。
@@ -109,7 +110,7 @@ export default function HamburgerMenu() {
                       <li>
                         <div className="rounded-lg bg-red-50 px-3 py-2 mb-2">
                           <p className="text-xs font-semibold text-red-700 flex items-center gap-1">
-                            <span aria-hidden>⚙️</span>
+                            <MenuIcon name="settings" className="h-4 w-4 text-red-700" />
                             管理メニュー
                           </p>
                         </div>
@@ -120,7 +121,7 @@ export default function HamburgerMenu() {
                           onClick={closeMenu}
                           className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-red-50"
                         >
-                          <span className="text-xl">🏪</span>
+                          <MenuIcon name="shop" className="h-5 w-5 text-red-600" />
                           <div className="flex-1">
                             <p className="text-sm font-medium">店舗管理</p>
                             <p className="text-xs text-gray-500">出店情報の管理</p>
@@ -136,7 +137,7 @@ export default function HamburgerMenu() {
                           onClick={closeMenu}
                           className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-red-50"
                         >
-                          <span className="text-xl">👥</span>
+                          <MenuIcon name="users" className="h-5 w-5 text-red-600" />
                           <div className="flex-1">
                             <p className="text-sm font-medium">ユーザー管理</p>
                             <p className="text-xs text-gray-500">権限設定など</p>
@@ -152,7 +153,7 @@ export default function HamburgerMenu() {
                           onClick={closeMenu}
                           className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-red-50"
                         >
-                          <span className="text-xl">🛡️</span>
+                          <MenuIcon name="shield" className="h-5 w-5 text-red-600" />
                           <div className="flex-1">
                             <p className="text-sm font-medium">モデレーション</p>
                             <p className="text-xs text-gray-500">投稿の確認</p>
@@ -175,7 +176,7 @@ export default function HamburgerMenu() {
                         onClick={closeMenu}
                         className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
                       >
-                        <span className="text-xl">🏪</span>
+                        <MenuIcon name="shop" className="h-5 w-5 text-amber-600" />
                         <div className="flex-1">
                           <p className="text-sm font-medium">マイ店舗</p>
                           <p className="text-xs text-gray-500">Coming Soon</p>
@@ -195,7 +196,7 @@ export default function HamburgerMenu() {
                           onClick={closeMenu}
                           className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
                         >
-                          <span className="text-xl">👜</span>
+                          <MenuIcon name="bag" className="h-5 w-5 text-gray-600" />
                           <div className="flex-1">
                             <p className="text-sm font-medium">bag</p>
                             <p className="text-xs text-gray-500">気になるものを保存</p>
@@ -208,7 +209,7 @@ export default function HamburgerMenu() {
                           onClick={closeMenu}
                           className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
                         >
-                          <span className="text-xl">🏅</span>
+                          <MenuIcon name="badge" className="h-5 w-5 text-gray-600" />
                           <div className="flex-1">
                             <p className="text-sm font-medium">バッジ</p>
                             <p className="text-xs text-gray-500">獲得した来訪バッジを見る</p>
@@ -219,23 +220,6 @@ export default function HamburgerMenu() {
                   )}
 
                   <li>
-                    <Link
-                      href="/my-profile"
-                      onClick={closeMenu}
-                      className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-amber-50"
-                    >
-                      <span className="text-xl">🙍‍♂️</span>
-                      <div className="flex-1">
-                        <p className="text-sm font-medium">プロフィール</p>
-                        <p className="text-xs text-gray-500">Coming Soon</p>
-                      </div>
-                      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                        Coming Soon
-                      </span>
-                    </Link>
-                  </li>
-
-                  <li>
                     <div className="my-3 border-t border-gray-200" />
                   </li>
 
@@ -244,7 +228,7 @@ export default function HamburgerMenu() {
                       onClick={handleLogout}
                       className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-red-50 hover:text-red-600"
                     >
-                      <span className="text-xl">🚪</span>
+                      <MenuIcon name="logout" className="h-5 w-5 text-red-600" />
                       <p className="text-sm font-medium">ログアウト</p>
                     </button>
                   </li>
@@ -261,7 +245,7 @@ export default function HamburgerMenu() {
                       onClick={() => handleLogin('super_admin')}
                       className="flex w-full items-center gap-3 rounded-lg border-2 border-red-200 bg-red-50 px-4 py-3 text-gray-700 transition hover:bg-red-100"
                     >
-                      <span className="text-xl">⚙️</span>
+                      <MenuIcon name="settings" className="h-5 w-5 text-red-600" />
                       <div className="flex-1 text-left">
                         <p className="text-sm font-semibold">管理者としてログイン</p>
                         <p className="text-xs text-gray-600">店舗・ユーザー管理</p>
@@ -273,7 +257,7 @@ export default function HamburgerMenu() {
                       onClick={() => handleLogin('vendor')}
                       className="flex w-full items-center gap-3 rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 text-gray-700 transition hover:bg-blue-100"
                     >
-                      <span className="text-xl">🏪</span>
+                      <MenuIcon name="shop" className="h-5 w-5 text-blue-600" />
                       <div className="flex-1 text-left">
                         <p className="text-sm font-semibold">出店者としてログイン</p>
                         <p className="text-xs text-gray-600">デモIDで表示</p>
@@ -285,7 +269,7 @@ export default function HamburgerMenu() {
                       onClick={() => handleLogin('general_user')}
                       className="flex w-full items-center gap-3 rounded-lg border-2 border-gray-200 bg-gray-50 px-4 py-3 text-gray-700 transition hover:bg-gray-100"
                     >
-                      <span className="text-xl">👤</span>
+                      <MenuIcon name="user" className="h-5 w-5 text-gray-600" />
                       <div className="flex-1 text-left">
                         <p className="text-sm font-semibold">一般ユーザーでログイン</p>
                         <p className="text-xs text-gray-600">bag・バッジを体験</p>
@@ -310,7 +294,7 @@ export default function HamburgerMenu() {
                   onClick={closeMenu}
                   className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-gray-50"
                 >
-                  <span className="text-xl">ℹ️</span>
+                  <MenuIcon name="info" className="h-5 w-5 text-gray-600" />
                   <p className="text-sm font-medium">このサービスについて</p>
                 </Link>
               </li>
@@ -320,7 +304,7 @@ export default function HamburgerMenu() {
                   onClick={closeMenu}
                   className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-gray-50"
                 >
-                  <span className="text-xl">❓</span>
+                  <MenuIcon name="help" className="h-5 w-5 text-gray-600" />
                   <p className="text-sm font-medium">よくある質問</p>
                 </Link>
               </li>
@@ -330,7 +314,7 @@ export default function HamburgerMenu() {
                   onClick={closeMenu}
                   className="flex items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-gray-50"
                 >
-                  <span className="text-xl">✉️</span>
+                  <MenuIcon name="mail" className="h-5 w-5 text-gray-600" />
                   <p className="text-sm font-medium">お問い合わせ</p>
                 </Link>
               </li>
@@ -339,10 +323,193 @@ export default function HamburgerMenu() {
 
           {/* フッター */}
           <div className="border-t border-gray-200 px-6 py-4">
-            <p className="text-xs text-gray-500 text-center">© 2025 nicchyo</p>
+            <p className="text-xs text-gray-500 text-center">&copy; 2025 nicchyo</p>
           </div>
         </div>
       </div>
     </>
   );
 }
+
+type MenuIconName =
+  | 'user'
+  | 'settings'
+  | 'shop'
+  | 'users'
+  | 'shield'
+  | 'bag'
+  | 'badge'
+  | 'logout'
+  | 'info'
+  | 'help'
+  | 'mail';
+
+type MenuIconProps = {
+  name: MenuIconName;
+  className?: string;
+};
+
+function MenuIcon({ name, className }: MenuIconProps) {
+  const props = {
+    className,
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.5,
+    viewBox: '0 0 24 24',
+    'aria-hidden': true,
+  } as const;
+
+  switch (name) {
+    case 'user':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 20.118a7.5 7.5 0 0 1 15 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.5-1.632Z"
+          />
+        </svg>
+      );
+    case 'settings':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.094c.55 0 1.02.398 1.11.94l.149.9c.07.424.37.77.78.93l.845.34c.5.2 1.07.04 1.41-.3l.672-.672c.39-.39 1.04-.39 1.43 0l.774.774c.39.39.39 1.02 0 1.41l-.672.672c-.34.34-.5.91-.3 1.41l.34.845c.16.41.51.71.93.78l.9.149c.54.09.94.56.94 1.11v1.094c0 .55-.4 1.02-.94 1.11l-.9.149c-.42.07-.77.37-.93.78l-.34.845c-.2.5-.04 1.07.3 1.41l.672.672c.39.39.39 1.04 0 1.43l-.774.774c-.39.39-1.04.39-1.43 0l-.672-.672c-.34-.34-.91-.5-1.41-.3l-.845.34c-.41.16-.71.51-.78.93l-.149.9c-.09.54-.56.94-1.11.94h-1.094c-.55 0-1.02-.4-1.11-.94l-.149-.9c-.07-.42-.37-.77-.78-.93l-.845-.34c-.5-.2-1.07-.04-1.41.3l-.672.672c-.39.39-1.04.39-1.43 0l-.774-.774c-.39-.39-.39-1.04 0-1.43l.672-.672c.34-.34.5-.91.3-1.41l-.34-.845c-.16-.41-.51-.71-.93-.78l-.9-.149c-.54-.09-.94-.56-.94-1.11v-1.094c0-.55.4-1.02.94-1.11l.9-.149c.42-.07.77-.37.93-.78l.34-.845c.2-.5.04-1.07-.3-1.41l-.672-.672c-.39-.39-.39-1.02 0-1.41l.774-.774c.39-.39 1.04-.39 1.43 0l.672.672c.34.34.91.5 1.41.3l.845-.34c.41-.16.71-.51.78-.93l.149-.9Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      );
+    case 'shop':
+      return (
+        <svg {...props}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 9.75 12 4.5l9 5.25" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 10.5V20.25A1.5 1.5 0 0 0 6 21.75h12a1.5 1.5 0 0 0 1.5-1.5V10.5"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 21.75V15a.75.75 0 0 1 .75-.75h4.5A.75.75 0 0 1 15 15v6.75"
+          />
+        </svg>
+      );
+    case 'users':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M18 18.72a9.09 9.09 0 0 0 3.74 1.98 9.06 9.06 0 0 1-3.74.8c-2.93 0-5.62-.7-7.88-1.9"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 8.25a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 19.5a7.5 7.5 0 0 1 15 0"
+          />
+        </svg>
+      );
+    case 'shield':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3.75 5.25 6.75v6a6.75 6.75 0 0 0 13.5 0v-6L12 3.75Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 10.5" />
+        </svg>
+      );
+    case 'bag':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6 7.5V6a6 6 0 1 1 12 0v1.5"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 7.5h15l-1.2 12.6a2.25 2.25 0 0 1-2.24 2.05H7.94a2.25 2.25 0 0 1-2.24-2.05L4.5 7.5Z"
+          />
+        </svg>
+      );
+    case 'badge':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3.75 14.09 8.26 19.06 9l-3.58 3.49.85 4.96L12 15.77 7.67 17.45l.85-4.96L4.94 9l4.97-.74L12 3.75Z"
+          />
+        </svg>
+      );
+    case 'logout':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6A2.25 2.25 0 0 0 5.25 5.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M18 12H9" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 9l3 3-3 3" />
+        </svg>
+      );
+    case 'info':
+      return (
+        <svg {...props}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9h.01M11.25 12h1.5v4.5h-1.5z" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      );
+    case 'help':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.75 9a2.25 2.25 0 1 1 3.99 1.5c-.67.67-1.49 1.12-1.49 2.25v.25"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 17.25h.01" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      );
+    case 'mail':
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 6.75h18v10.5a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.25V6.75Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="m3 6.75 9 6 9-6" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -163,6 +163,11 @@ body {
   pointer-events: none;
 }
 
+.shop-side-north .shop-favorite-badge {
+  left: -12px;
+  right: auto;
+}
+
 .custom-shop-marker.is-favorite .shop-favorite-badge {
   display: inline-flex;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -144,6 +144,29 @@ body {
   z-index: 1000 !important;
 }
 
+.shop-favorite-badge {
+  position: absolute;
+  top: -14px;
+  right: -12px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 2px solid #f97316;
+  background: #ffffff;
+  color: #f97316;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+}
+
+.custom-shop-marker.is-favorite .shop-favorite-badge {
+  display: inline-flex;
+}
+
 body.shop-banner-open .hamburger-button {
   display: none;
 }

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -1,131 +1,94 @@
-/**
+﻿/**
  * 認証コンテキスト（ダミー実装）
  *
- * 【現在の実装】
  * - ローカルストレージを使った仮のログイン状態管理
- * - 実際の認証処理は行わない
- * - isLoggedIn（boolean）で状態を管理
- *
- * 【将来の実装：Firebase Authentication への移行】
- * このファイルを以下のように置き換えることで、Firebase Auth に移行できます：
- *
- * ```typescript
- * import {
- *   getAuth,
- *   signInWithEmailAndPassword,
- *   signOut,
- *   onAuthStateChanged,
- *   User,
- * } from 'firebase/auth';
- * import { app } from '@/lib/firebase/config';
- *
- * const auth = getAuth(app);
- *
- * // ログイン処理
- * const login = async (email: string, password: string) => {
- *   await signInWithEmailAndPassword(auth, email, password);
- * };
- *
- * // ログアウト処理
- * const logout = async () => {
- *   await signOut(auth);
- * };
- *
- * // 認証状態の監視
- * useEffect(() => {
- *   const unsubscribe = onAuthStateChanged(auth, (user) => {
- *     setUser(user);
- *     setIsLoggedIn(!!user);
- *   });
- *   return unsubscribe;
- * }, []);
- * ```
- *
- * 【移行時の変更点】
- * 1. login() の引数を email, password に変更
- * 2. logout() を非同期関数に変更
- * 3. user オブジェクトに Firebase User 型を使用
- * 4. onAuthStateChanged で自動的にログイン状態を監視
+ * - 実際の認証は未実装
  */
 
-'use client';
+"use client";
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import type { User, UserRole, PermissionCheck } from './types';
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import type { User, UserRole, PermissionCheck } from "./types";
 
 /**
  * ダミーアカウント定義
- *
- * 【現在の実装】
- * - 開発・テスト用に複数のroleを持つアカウントを用意
- *
- * 【将来の実装】
- * - Firebase Authentication で実際のユーザー認証
- * - Custom Claims で role を管理
- * - Firestore でユーザープロフィールを管理
  */
 export const DUMMY_ACCOUNTS: Record<UserRole, User> = {
   super_admin: {
-    id: 'dummy-super-admin',
-    name: '高知市管理者',
-    email: 'admin@kochi-city.jp',
-    role: 'super_admin',
+    id: "dummy-super-admin",
+    name: "高知市管理者",
+    email: "admin@kochi-city.jp",
+    role: "super_admin",
   },
   vendor: {
-    id: 'dummy-vendor-001',
-    name: '山田商店',
-    email: 'yamada@nicchyo-vendor.jp',
-    role: 'vendor',
-    vendorId: 1, // 仮に店舗ID=1に紐付け
+    id: "dummy-vendor-001",
+    name: "食材のお店1",
+    email: "nicchyo-owner-001@example.com",
+    role: "vendor",
+    vendorId: 1,
   },
   general_user: {
-    id: 'dummy-user-001',
-    name: '観光客太郎',
-    email: 'user@example.com',
-    role: 'general_user',
+    id: "dummy-user-001",
+    name: "観光客ユーザー",
+    email: "user@example.com",
+    role: "general_user",
   },
 };
 
-/**
- * 認証コンテキストの型定義
- */
+type DummyCredential = {
+  identifier: string;
+  password: string;
+  user: User;
+};
+
+const DUMMY_CREDENTIALS: DummyCredential[] = [
+  {
+    identifier: "admin@kochi-city.jp",
+    password: "admin",
+    user: DUMMY_ACCOUNTS.super_admin,
+  },
+  {
+    identifier: "食材のお店1",
+    password: "001",
+    user: DUMMY_ACCOUNTS.vendor,
+  },
+  {
+    identifier: "nicchyo-owner-001@example.com",
+    password: "001",
+    user: DUMMY_ACCOUNTS.vendor,
+  },
+  {
+    identifier: "user@example.com",
+    password: "guest",
+    user: DUMMY_ACCOUNTS.general_user,
+  },
+];
+
 interface AuthContextType {
-  /** ログイン状態 */
   isLoggedIn: boolean;
-
-  /** ユーザー情報 */
   user: User | null;
-
-  /** ログイン処理（ダミー：roleを指定してログイン） */
   login: (role: UserRole) => void;
-
-  /** ログアウト処理（ダミー） */
+  loginWithCredentials: (identifier: string, password: string) => boolean;
   logout: () => void;
-
-  /** ローディング状態 */
   isLoading: boolean;
-
-  /** 権限チェック用ヘルパー */
   permissions: PermissionCheck;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const STORAGE_KEY = 'nicchyo-auth-dummy';
+const STORAGE_KEY = "nicchyo-auth-dummy";
 
-/**
- * 認証プロバイダー
- *
- * アプリ全体で認証状態を共有
- */
+function normalizeIdentifier(value: string) {
+  return value.trim().toLowerCase();
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 初期化: ローカルストレージからログイン状態を復元
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
 
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
@@ -135,144 +98,82 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setIsLoggedIn(true);
       }
     } catch (error) {
-      console.error('Failed to load auth state:', error);
+      console.error("Failed to load auth state:", error);
     } finally {
       setIsLoading(false);
     }
   }, []);
 
-  /**
-   * 権限チェック用ヘルパー
-   *
-   * ログイン中のユーザーの権限を判定する各種メソッドを提供
-   */
   const permissions: PermissionCheck = {
-    isSuperAdmin: user?.role === 'super_admin',
-    isVendor: user?.role === 'vendor',
-    isGeneralUser: user?.role === 'general_user',
+    isSuperAdmin: user?.role === "super_admin",
+    isVendor: user?.role === "vendor",
+    isGeneralUser: user?.role === "general_user",
 
     canEditShop: (shopId: number) => {
-      if (user?.role === 'super_admin') return true;
-      if (user?.role === 'vendor' && user.vendorId === shopId) return true;
+      if (user?.role === "super_admin") return true;
+      if (user?.role === "vendor" && user.vendorId === shopId) return true;
       return false;
     },
 
-    canManageAllShops: user?.role === 'super_admin',
+    canManageAllShops: user?.role === "super_admin",
   };
 
-  /**
-   * ログイン処理（ダミー）
-   *
-   * 【現在】
-   * - roleを受け取り、対応するダミーアカウントでログイン
-   * - ローカルストレージに保存
-   *
-   * 【将来：Firebase Auth への移行】
-   * ```typescript
-   * const login = async (email: string, password: string) => {
-   *   setIsLoading(true);
-   *   try {
-   *     const credential = await signInWithEmailAndPassword(auth, email, password);
-   *     // onAuthStateChanged で自動的に user が更新される
-   *     // Custom Claims から role を取得
-   *     const idTokenResult = await credential.user.getIdTokenResult();
-   *     const role = idTokenResult.claims.role as UserRole;
-   *     // Firestore からユーザープロフィールを取得
-   *     const userDoc = await getDoc(doc(db, 'users', credential.user.uid));
-   *     const userData = userDoc.data();
-   *     setUser({
-   *       id: credential.user.uid,
-   *       email: credential.user.email!,
-   *       name: userData.name,
-   *       role: role,
-   *       vendorId: userData.vendorId,
-   *     });
-   *   } catch (error) {
-   *     console.error('Login failed:', error);
-   *     throw error;
-   *   } finally {
-   *     setIsLoading(false);
-   *   }
-   * };
-   * ```
-   */
-  const login = (role: UserRole) => {
-    const selectedUser = DUMMY_ACCOUNTS[role];
-
+  const persistUser = (selectedUser: User) => {
     setUser(selectedUser);
     setIsLoggedIn(true);
 
-    // ローカルストレージに保存
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify({ user: selectedUser }));
       } catch (error) {
-        console.error('Failed to save auth state:', error);
+        console.error("Failed to save auth state:", error);
       }
     }
   };
 
-  /**
-   * ログアウト処理（ダミー）
-   *
-   * 【現在】
-   * - ローカルストレージから削除
-   *
-   * 【将来：Firebase Auth への移行】
-   * ```typescript
-   * const logout = async () => {
-   *   setIsLoading(true);
-   *   try {
-   *     await signOut(auth);
-   *     // onAuthStateChanged で自動的に user が null になる
-   *   } catch (error) {
-   *     console.error('Logout failed:', error);
-   *     throw error;
-   *   } finally {
-   *     setIsLoading(false);
-   *   }
-   * };
-   * ```
-   */
+  const login = (role: UserRole) => {
+    const selectedUser = DUMMY_ACCOUNTS[role];
+    persistUser(selectedUser);
+  };
+
+  const loginWithCredentials = (identifier: string, password: string) => {
+    const normalized = normalizeIdentifier(identifier);
+    const match = DUMMY_CREDENTIALS.find(
+      (credential) =>
+        normalizeIdentifier(credential.identifier) === normalized &&
+        credential.password === password
+    );
+    if (!match) return false;
+    persistUser(match.user);
+    return true;
+  };
+
   const logout = () => {
     setUser(null);
     setIsLoggedIn(false);
 
-    // ローカルストレージから削除
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       try {
         localStorage.removeItem(STORAGE_KEY);
       } catch (error) {
-        console.error('Failed to clear auth state:', error);
+        console.error("Failed to clear auth state:", error);
       }
     }
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, user, login, logout, isLoading, permissions }}>
+    <AuthContext.Provider
+      value={{ isLoggedIn, user, login, loginWithCredentials, logout, isLoading, permissions }}
+    >
       {children}
     </AuthContext.Provider>
   );
 }
 
-/**
- * 認証フック
- *
- * コンポーネント内で認証状態を取得
- *
- * @example
- * ```typescript
- * const { isLoggedIn, user, login, logout } = useAuth();
- *
- * if (isLoggedIn) {
- *   return <div>こんにちは、{user?.name}さん</div>;
- * }
- * ```
- */
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 }

--- a/lib/shopEdits.ts
+++ b/lib/shopEdits.ts
@@ -1,0 +1,58 @@
+import type { Shop, ShopEditableData } from "@/app/(public)/map/types/shopData";
+
+export const SHOP_EDITS_STORAGE_KEY = "nicchyo-shop-edits";
+export const SHOP_EDITS_UPDATED_EVENT = "nicchyo-shop-edits-updated";
+
+type ShopEditsMap = Record<string, Partial<ShopEditableData>>;
+
+function readEditsMap(): ShopEditsMap {
+  if (typeof window === "undefined") return {};
+  const raw = localStorage.getItem(SHOP_EDITS_STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as ShopEditsMap;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return {};
+}
+
+function writeEditsMap(map: ShopEditsMap) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(SHOP_EDITS_STORAGE_KEY, JSON.stringify(map));
+}
+
+export function loadShopEdits(shopId: number): Partial<ShopEditableData> {
+  const map = readEditsMap();
+  return map[String(shopId)] ?? {};
+}
+
+export function saveShopEdits(shopId: number, edits: Partial<ShopEditableData>) {
+  const map = readEditsMap();
+  map[String(shopId)] = edits;
+  writeEditsMap(map);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(SHOP_EDITS_UPDATED_EVENT, { detail: { shopId } })
+    );
+  }
+}
+
+export function applyShopEdits(shops: Shop[]): Shop[] {
+  const map = readEditsMap();
+  return shops.map((shop) => {
+    const edits = map[String(shop.id)];
+    if (!edits) return shop;
+    return {
+      ...shop,
+      ...edits,
+      images: edits.images ? { ...shop.images, ...edits.images } : shop.images,
+      socialLinks: edits.socialLinks
+        ? { ...shop.socialLinks, ...edits.socialLinks }
+        : shop.socialLinks,
+    };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.1.1",
         "husky": "^9.1.3",
-        "jsdom": "^24.1.0",
+        "jsdom": "^27.4.0",
         "postcss": "^8.5.6",
         "prisma": "5.12.0",
         "tailwindcss": "3.4.4",
@@ -56,9 +56,16 @@
         "vitest": "^1.6.1"
       },
       "engines": {
-        "node": ">=20.9.0",
+        "node": "24.x",
         "npm": ">=10.0.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.30",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.30.tgz",
+      "integrity": "sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -80,18 +87,39 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
       }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -479,6 +507,26 @@
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.22.tgz",
+      "integrity": "sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -1054,6 +1102,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.7.0.tgz",
+      "integrity": "sha512-5i+BtvujK/vM07YCGDyz4C4AyDzLmhxHMtM5HpUyPRtJPBdFPsj290ffXW+UXY21/G7GtXeHD2nRmq0T1ShyQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4342,6 +4408,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4752,6 +4828,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -4772,25 +4862,19 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.5.tgz",
+      "integrity": "sha512-GlsEptulso7Jg0VaOZ8BXQi3AkYM5BOJKEO/rjMidSCq70FkIC5y0eawrCXeYzxgt3OCf4Ls+eoxN+/05vN0Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4806,17 +4890,17 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-url": "^15.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/data-view-buffer": {
@@ -6578,16 +6662,16 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -6662,19 +6746,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -7292,44 +7363,56 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "24.1.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
-      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.0.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
+        "webidl-conversions": "^8.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.18.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -7627,11 +7710,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/lucide-react": {
       "version": "0.562.0",
@@ -7963,6 +8049,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -8842,13 +8935,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9428,19 +9514,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9450,13 +9523,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9797,12 +9863,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -9895,13 +9964,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.54.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -10000,13 +10062,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -10796,6 +10851,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10809,32 +10884,29 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^7.0.5"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -11154,16 +11226,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -11238,17 +11300,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -11515,27 +11566,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -11549,17 +11586,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -11798,21 +11835,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
-      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=20.9.0",
+    "node": "20.x",
     "npm": ">=10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.1",
     "husky": "^9.1.3",
-    "jsdom": "^24.1.0",
+    "jsdom": "^27.4.0",
     "postcss": "^8.5.6",
     "prisma": "5.12.0",
     "tailwindcss": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "20.x",
+    "node": "24.x",
     "npm": ">=10.0.0"
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
-    "types": ["vitest/globals"],
+    "jsx": "react-jsx",
+    "types": [
+      "vitest/globals"
+    ],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
概要

  - メール/ユーザーネームでのダミーログインを実装
  - 出店者アカウント（食材のお店1）を追加し、マイ店舗へ自動反映
  - マップ側に出店者向け導線と編集導線を追加

  主な変更

  - AuthContext にダミー認証（identifier+password）を追加
  - /login で実際にログイン可能にし、失敗時メッセージを表示
  - /my-shop で自分の店舗情報を自動入力・送信でマップ反映
  - マップ初回表示時に出店者向けポップアップを表示
  - ショップバナーに「編集する」ボタン追加（自分の店のみ）

  確認ポイント

  - 出店者でログインするとマップに導線ポップアップが表示される
  - 「ショップバナーを開く」で自店舗のバナーが開く
  - 「編集する」から /my-shop に遷移できる
  - my-shop の送信でマップ情報が更新される

## ダミーアカウント（確認用）

  - 出店者: ユーザーネーム [食材のお店1] / メール nicchyo-owner-001@example.com / パスワード 001
  - 高知市: admin@kochi-city.jp / パスワード admin
  - 一般: user@example.com / パスワード guest