### PR TITLE
マップ遷移ローディング強化と周辺UI改善Feature/login

### DIFF
--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import NavigationBar from "../../components/NavigationBar";
+import MapLink from "../../components/MapLink";
 
 export const metadata = {
   title: "Contact | nicchyo",
@@ -20,12 +21,12 @@ export default function ContactPage() {
               ご意見や取材依頼などはこちらからお知らせください。
             </p>
           </div>
-          <Link
+          <MapLink
             href="/map"
             className="rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
           >
             マップへ戻る
-          </Link>
+          </MapLink>
         </div>
       </header>
 

--- a/app/(public)/events/page.tsx
+++ b/app/(public)/events/page.tsx
@@ -1,41 +1,38 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import NavigationBar from '../../components/NavigationBar';
+﻿import { Metadata } from "next";
+import Link from "next/link";
+import NavigationBar from "../../components/NavigationBar";
+import MapLink from "../../components/MapLink";
 
 export const metadata: Metadata = {
-  title: '午後のイベント | nicchyo日曜市',
-  description: '日曜市が終わった後も楽しめる、地域イベントやワークショップ情報。',
+  title: "午後のイベント | nicchyo 日曜市",
+  description:
+    "日曜市が終わった後も楽しめる、地域イベントやワークショップの情報ページです。",
 };
 
 export default function EventsPage() {
   return (
-    <div className="flex flex-col h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
-      {/* メインコンテンツ */}
+    <div className="flex h-screen flex-col bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
       <main className="flex-1 overflow-y-auto pb-20 pt-4">
-        <div className="max-w-4xl mx-auto px-4 py-8">
-          {/* 準備中メッセージ */}
-          <div className="bg-white rounded-2xl shadow-xl p-8 md:p-12 text-center border-4 border-amber-200">
-            <div className="text-6xl mb-6">🎪</div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">
-              イベント情報 準備中
-            </h2>
-            <p className="text-gray-700 mb-6 max-w-2xl mx-auto">
+        <div className="mx-auto max-w-4xl px-4 py-8">
+          <div className="rounded-2xl border-4 border-amber-200 bg-white p-8 text-center shadow-xl md:p-12">
+            <div className="mb-6 text-6xl">🎪</div>
+            <h2 className="mb-4 text-2xl font-bold text-gray-900">イベント情報 準備中</h2>
+            <p className="mb-6 mx-auto max-w-2xl text-gray-700">
               日曜市の後に楽しめる地域イベントやワークショップの情報を、現在準備しています。
               もうしばらくお待ちください。
             </p>
 
-            {/* 他のページへのリンク */}
             <div className="mt-8 flex flex-wrap justify-center gap-4">
-              <Link
+              <MapLink
                 href="/map"
-                className="inline-flex items-center gap-2 rounded-xl bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-lg hover:bg-amber-500 transition"
+                className="inline-flex items-center gap-2 rounded-xl bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-amber-500"
               >
                 <span>🗺️</span>
                 マップを見る
-              </Link>
+              </MapLink>
               <Link
                 href="/recipes"
-                className="inline-flex items-center gap-2 rounded-xl border-2 border-amber-600 bg-white px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50 transition"
+                className="inline-flex items-center gap-2 rounded-xl border-2 border-amber-600 bg-white px-6 py-3 text-sm font-semibold text-amber-600 transition hover:bg-amber-50"
               >
                 <span>🍳</span>
                 レシピを見る
@@ -43,32 +40,31 @@ export default function EventsPage() {
             </div>
           </div>
 
-          {/* 将来の機能説明 */}
           <div className="mt-8 grid gap-6 md:grid-cols-2">
-            <div className="bg-white rounded-xl p-6 shadow-md border border-amber-100">
-              <div className="text-3xl mb-3">🎨</div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">ワークショップ</h3>
+            <div className="rounded-xl border border-amber-100 bg-white p-6 shadow-md">
+              <div className="mb-3 text-3xl">🎨</div>
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">ワークショップ</h3>
               <p className="text-sm text-gray-700">
                 地元の職人による体験型ワークショップ情報をお届けします。
               </p>
             </div>
-            <div className="bg-white rounded-xl p-6 shadow-md border border-amber-100">
-              <div className="text-3xl mb-3">🎵</div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">音楽イベント</h3>
+            <div className="rounded-xl border border-amber-100 bg-white p-6 shadow-md">
+              <div className="mb-3 text-3xl">🎵</div>
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">音楽イベント</h3>
               <p className="text-sm text-gray-700">
                 市場周辺で開催される音楽イベントやパフォーマンス情報。
               </p>
             </div>
-            <div className="bg-white rounded-xl p-6 shadow-md border border-amber-100">
-              <div className="text-3xl mb-3">🍺</div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">グルメイベント</h3>
+            <div className="rounded-xl border border-amber-100 bg-white p-6 shadow-md">
+              <div className="mb-3 text-3xl">🍺</div>
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">グルメイベント</h3>
               <p className="text-sm text-gray-700">
                 日曜市の食材を使った料理教室やフードイベント情報。
               </p>
             </div>
-            <div className="bg-white rounded-xl p-6 shadow-md border border-amber-100">
-              <div className="text-3xl mb-3">🏛️</div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">文化体験</h3>
+            <div className="rounded-xl border border-amber-100 bg-white p-6 shadow-md">
+              <div className="mb-3 text-3xl">🏛️</div>
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">文化体験</h3>
               <p className="text-sm text-gray-700">
                 高知の文化や歴史を学べる体験プログラム情報。
               </p>

--- a/app/(public)/faq/page.tsx
+++ b/app/(public)/faq/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import NavigationBar from "../../components/NavigationBar";
+import MapLink from "../../components/MapLink";
 
 export const metadata = {
   title: "FAQ | nicchyo",
@@ -32,15 +33,15 @@ export default function FAQPage() {
             </p>
             <h1 className="text-2xl font-bold">よくある質問</h1>
             <p className="text-sm text-gray-700">
-              日曜市マップの使い方や仕様についてまとめました。
+              日曜市マップの使い方をまとめました。
             </p>
           </div>
-          <Link
+          <MapLink
             href="/map"
             className="rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
           >
             マップへ戻る
-          </Link>
+          </MapLink>
         </div>
       </header>
 

--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -12,6 +12,7 @@ import { BadgeModal } from "./components/BadgeModal";
 import { useAuth } from "../../../lib/auth/AuthContext";
 import { shops as baseShops } from "./data/shops";
 import { applyShopEdits } from "../../../lib/shopEdits";
+import { useMapLoading } from "../../components/MapLoadingProvider";
 
 const MapView = dynamic(() => import("./components/MapView"), {
   ssr: false,
@@ -21,6 +22,7 @@ export default function MapPageClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { user, permissions } = useAuth();
+  const { markMapReady } = useMapLoading();
   const initialShopIdParam = searchParams?.get("shop");
   const searchParamsKey = searchParams?.toString() ?? "";
   const initialShopId = initialShopIdParam ? Number(initialShopIdParam) : undefined;
@@ -231,6 +233,7 @@ export default function MapPageClient() {
               onAgentToggle={setAgentOpen}
               searchShopIds={searchMarkerPayload?.ids}
               searchLabel={searchMarkerPayload?.label}
+              onMapReady={markMapReady}
             />
             <GrandmaChatter
               onOpenAgent={() => setAgentOpen(true)}

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -146,6 +146,7 @@ type MapViewProps = {
   onAgentToggle?: (open: boolean) => void;
   searchShopIds?: number[];
   searchLabel?: string;
+  onMapReady?: () => void;
 };
 
 export default function MapView({
@@ -157,6 +158,7 @@ export default function MapView({
   onAgentToggle,
   searchShopIds,
   searchLabel,
+  onMapReady,
 }: MapViewProps = {}) {
   const [isMobile, setIsMobile] = useState(false);
   const [displayShops, setDisplayShops] = useState<Shop[]>(() =>
@@ -435,6 +437,9 @@ export default function MapView({
         attributionControl={false}
         maxBounds={MAX_BOUNDS}
         maxBoundsViscosity={1.0}
+        whenReady={() => {
+          onMapReady?.();
+        }}
         ref={(map) => {
           if (map) mapRef.current = map;
         }}

--- a/app/(public)/map/loading.tsx
+++ b/app/(public)/map/loading.tsx
@@ -1,0 +1,66 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-800">
+      <div className="flex flex-col items-center gap-4">
+        <div className="map-walker relative h-20 w-20 text-amber-700">
+          <svg
+            className="map-walker-frame is-1"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="28" y2="36" />
+            <line x1="40" y1="30" x2="52" y2="34" />
+            <line x1="40" y1="46" x2="30" y2="64" />
+            <line x1="40" y1="46" x2="52" y2="62" />
+          </svg>
+
+          <svg
+            className="map-walker-frame is-2"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="30" y2="34" />
+            <line x1="40" y1="30" x2="54" y2="38" />
+            <line x1="40" y1="46" x2="28" y2="62" />
+            <line x1="40" y1="46" x2="54" y2="64" />
+          </svg>
+
+          <svg
+            className="map-walker-frame is-3"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="26" y2="38" />
+            <line x1="40" y1="30" x2="54" y2="36" />
+            <line x1="40" y1="46" x2="34" y2="64" />
+            <line x1="40" y1="46" x2="56" y2="58" />
+          </svg>
+        </div>
+        <div className="text-xs font-semibold tracking-[0.35em] text-amber-700">
+          LOADING
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/my-profile/page.tsx
+++ b/app/(public)/my-profile/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import NavigationBar from "../../components/NavigationBar";
+import { useAuth } from "../../../lib/auth/AuthContext";
+
+type StatusState = "idle" | "saved";
+
+export default function MyProfilePage() {
+  const { isLoggedIn, user, updateProfile, logout } = useAuth();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [avatarError, setAvatarError] = useState("");
+  const [status, setStatus] = useState<StatusState>("idle");
+
+  useEffect(() => {
+    setName(user?.name ?? "");
+    setEmail(user?.email ?? "");
+    setAvatarUrl(user?.avatarUrl ?? null);
+  }, [user]);
+
+  const roleLabel = useMemo(() => {
+    if (!user) return "未ログイン";
+    if (user.role === "super_admin") return "管理者";
+    if (user.role === "vendor") return "出店者";
+    return "一般ユーザー";
+  }, [user]);
+
+  const isDirty =
+    !!user &&
+    (name.trim() !== user.name ||
+      email.trim() !== user.email ||
+      (avatarUrl ?? "") !== (user.avatarUrl ?? ""));
+  const canSave = !!user && name.trim() && email.trim();
+
+  const handleSave = () => {
+    if (!canSave || !user) return;
+    updateProfile({
+      name: name.trim(),
+      email: email.trim(),
+      avatarUrl: avatarUrl ?? undefined,
+    });
+    setStatus("saved");
+    window.setTimeout(() => setStatus("idle"), 2000);
+  };
+
+  const handleAvatarChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setAvatarError("");
+    if (file.size > 2 * 1024 * 1024) {
+      setAvatarError("2MB以下の画像を選択してください。");
+      event.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        setAvatarUrl(reader.result);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleAvatarClear = () => {
+    setAvatarUrl(null);
+    setAvatarError("");
+  };
+
+  if (!isLoggedIn || !user) {
+    return (
+      <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+        <div className="mx-auto flex max-w-lg flex-col gap-6 px-4 py-10">
+          <div className="rounded-3xl border border-amber-200 bg-white/90 p-6 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
+              my profile
+            </p>
+            <h1 className="mt-2 text-2xl font-bold">プロフィール</h1>
+            <p className="mt-2 text-sm text-gray-700">
+              プロフィールの確認・編集にはログインが必要です。
+            </p>
+          </div>
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
+          >
+            ログインへ
+          </Link>
+        </div>
+        <NavigationBar />
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-20">
+      <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
+              my profile
+            </p>
+            <h1 className="text-2xl font-bold md:text-3xl">プロフィール</h1>
+            <p className="mt-2 text-sm text-gray-700">
+              ロールに関係なく、同じ項目でプロフィールを管理します。
+            </p>
+          </div>
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            {roleLabel}
+          </span>
+        </div>
+      </header>
+
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
+        <section className="rounded-3xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+          <div className="flex flex-col items-start gap-6 md:flex-row md:items-center md:gap-8">
+            <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-amber-500 text-2xl font-bold text-white shadow-sm">
+              {avatarUrl ? (
+                <img src={avatarUrl} alt="プロフィール画像" className="h-full w-full object-cover" />
+              ) : (
+                user.name.charAt(0)
+              )}
+            </div>
+            <div className="flex-1">
+              <h2 className="text-lg font-semibold text-gray-900">{user.name}</h2>
+              <p className="text-sm text-gray-600">{user.email}</p>
+              <div className="mt-3 flex flex-wrap items-center gap-3">
+                <label className="inline-flex cursor-pointer items-center justify-center rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-100">
+                  アイコンを変更
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleAvatarChange}
+                  />
+                </label>
+                {avatarUrl && (
+                  <button
+                    type="button"
+                    onClick={handleAvatarClear}
+                    className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 shadow-sm transition hover:bg-gray-50"
+                  >
+                    画像を削除
+                  </button>
+                )}
+              </div>
+              {avatarError && <p className="mt-2 text-xs text-rose-600">{avatarError}</p>}
+              <p className="mt-2 text-xs text-gray-500">2MB以下の画像をアップロードできます。</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+          <h3 className="text-sm font-semibold text-gray-900">基本情報</h3>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm text-gray-700">
+              ユーザー名
+              <input
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                className="rounded-xl border border-amber-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-amber-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-gray-700">
+              メールアドレス
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="rounded-xl border border-amber-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-amber-400 focus:outline-none"
+              />
+            </label>
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!canSave || !isDirty}
+              className="rounded-full bg-amber-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-amber-300"
+            >
+              変更を保存
+            </button>
+            {status === "saved" && <span className="text-xs text-amber-700">保存しました。</span>}
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+          <h3 className="text-sm font-semibold text-gray-900">セキュリティ</h3>
+          <p className="mt-2 text-sm text-gray-700">
+            パスワード変更はログイン画面から行えます。
+          </p>
+          <div className="mt-3">
+            <Link
+              href="/login"
+              className="inline-flex items-center justify-center rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-100"
+            >
+              パスワードを変更する
+            </Link>
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+          <h3 className="text-sm font-semibold text-gray-900">ログアウト</h3>
+          <p className="mt-2 text-sm text-gray-700">共有端末の場合はログアウトしてください。</p>
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={logout}
+              className="rounded-full border border-red-200 bg-red-50 px-4 py-2 text-sm font-semibold text-red-700 shadow-sm transition hover:bg-red-100"
+            >
+              ログアウト
+            </button>
+          </div>
+        </section>
+      </div>
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 ﻿import Link from "next/link";
 import NavigationBar from "../components/NavigationBar";
+import MapLink from "../components/MapLink";
 
 export const metadata = {
   title: "about | nicchyo",
@@ -38,7 +39,7 @@ const pillars = [
     desc: "市場が終わった後も楽しめる地域イベントやワークショップを掲載。",
     href: "/events",
   },
-];
+] as const;
 
 const audiences = [
   {
@@ -71,7 +72,7 @@ const audiences = [
       "簡単なアンケートで声を集める",
     ],
   },
-];
+] as const;
 
 const coreValues = [
   "日曜市の空気感を壊さずにデジタルで補助する",
@@ -100,12 +101,12 @@ export default function AboutPage() {
                 日曜市をもっと歩きやすく、もっと知りやすくするための小さなデジタル実験です。
               </p>
             </div>
-            <Link
+            <MapLink
               href="/map"
               className="rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
             >
               マップを見る
-            </Link>
+            </MapLink>
           </div>
         </header>
 
@@ -117,12 +118,12 @@ export default function AboutPage() {
               マップで位置を確認しながら、おすすめやイベント、ことづてをチェックできます。
             </p>
             <div className="mt-5 flex flex-wrap gap-3">
-              <Link
+              <MapLink
                 href="/map"
                 className="rounded-xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-300/40 transition hover:bg-amber-500"
               >
                 マップを見る
-              </Link>
+              </MapLink>
               <Link
                 href="/search"
                 className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-xs text-gray-800 transition hover:border-gray-300"
@@ -228,12 +229,12 @@ export default function AboutPage() {
               >
                 メールで連絡
               </Link>
-              <Link
+              <MapLink
                 href="/map"
                 className="rounded-full border border-orange-200 bg-white px-4 py-2 font-semibold text-orange-700 shadow-sm hover:bg-orange-50"
               >
                 日曜市マップへ戻る
-              </Link>
+              </MapLink>
             </div>
           </section>
         </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,5 @@
 ﻿import Link from "next/link";
+import NavigationBar from "../components/NavigationBar";
 
 export const metadata = {
   title: "about | nicchyo",
@@ -9,31 +10,31 @@ export const metadata = {
 const pillars = [
   {
     title: "マップ",
-    icon: "🗺️",
+    icon: "map",
     desc: "屋台の位置やおすすめを地図で直感的に確認できます。",
     href: "/map",
   },
   {
     title: "おすすめ",
-    icon: "🔍",
+    icon: "spark",
     desc: "お目当ての商品やお店を素早く検索して見つけられます。",
     href: "/search",
   },
   {
     title: "ことづて",
-    icon: "💬",
+    icon: "chat",
     desc: "出店者と来場者の声をつなぐ短いメッセージボードです。",
     href: "/kotodute",
   },
   {
     title: "土佐の料理レシピ",
-    icon: "🍳",
+    icon: "recipe",
     desc: "季節の食材を使った土佐料理のレシピを紹介します。",
     href: "/recipes",
   },
   {
     title: "午後のイベント",
-    icon: "🎪",
+    icon: "event",
     desc: "市場が終わった後も楽しめる地域イベントやワークショップを掲載。",
     href: "/events",
   },
@@ -43,7 +44,7 @@ const audiences = [
   {
     title: "はじめての来訪",
     subtitle: "どこを回ればいいか知りたい",
-    icon: "🧭",
+    icon: "route",
     points: [
       "目安ルート提案で迷わず回れる",
       "定番スポットと旬の見どころを表示",
@@ -53,7 +54,7 @@ const audiences = [
   {
     title: "リピーター",
     subtitle: "新しい発見を探したい",
-    icon: "✨",
+    icon: "discover",
     points: [
       "その日だけの限定品をピックアップ",
       "お気に入り店をブックマーク",
@@ -63,7 +64,7 @@ const audiences = [
   {
     title: "出店者",
     subtitle: "お客さんに見つけてもらいたい",
-    icon: "📣",
+    icon: "store",
     points: [
       "出店位置と商品をシンプルに掲示",
       "おすすめ欄で季節の推しを告知",
@@ -86,155 +87,288 @@ const teamNotes = [
 
 export default function AboutPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
-      <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
-              about nicchyo
-            </p>
-            <h1 className="text-2xl font-bold md:text-3xl">高知高専発・日曜市の実験プロジェクト</h1>
-            <p className="mt-2 text-sm text-gray-700">
-              日曜市をもっと歩きやすく、もっと知りやすくするための小さなデジタル実験です。
-            </p>
-          </div>
-          <Link
-            href="/map"
-            className="rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
-          >
-            マップを見る
-          </Link>
-        </div>
-      </header>
-
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10">
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
-          <h2 className="text-2xl font-bold">日曜市を、もっと歩きやすく</h2>
-          <p className="mt-3 text-sm text-gray-700 md:text-base">
-            nicchyo は、高知・日曜市の「見つける」「歩く」「交流する」をまとめたガイドです。
-            マップで位置を確認しながら、おすすめやイベント、ことづてをチェックできます。
-          </p>
-          <div className="mt-5 flex flex-wrap gap-3">
+    <>
+      <main className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-900 pb-16">
+        <header className="border-b border-amber-100/70 bg-white/90 backdrop-blur">
+          <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700">
+                about nicchyo
+              </p>
+              <h1 className="text-2xl font-bold md:text-3xl">高知高専発・日曜市の実験プロジェクト</h1>
+              <p className="mt-2 text-sm text-gray-700">
+                日曜市をもっと歩きやすく、もっと知りやすくするための小さなデジタル実験です。
+              </p>
+            </div>
             <Link
               href="/map"
-              className="rounded-xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-300/40 transition hover:bg-amber-500"
+              className="rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
             >
               マップを見る
             </Link>
-            <Link
-              href="/search"
-              className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-xs text-gray-800 transition hover:border-gray-300"
-            >
-              お店を探す
-            </Link>
           </div>
-        </section>
+        </header>
 
-        <section>
-          <div className="mb-6 text-center">
-            <h2 className="text-2xl font-bold md:text-3xl">nicchyo を支える 5つの柱</h2>
+        <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10">
+          <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+            <h2 className="text-2xl font-bold">日曜市を、もっと歩きやすく</h2>
             <p className="mt-3 text-sm text-gray-700 md:text-base">
-              マップを中心に、おすすめ、ことづて、イベントまで。日曜市をまるごと楽しめる導線を揃えました。
+              nicchyo は、高知・日曜市の「見つける」「歩く」「交流する」をまとめたガイドです。
+              マップで位置を確認しながら、おすすめやイベント、ことづてをチェックできます。
             </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {pillars.map((item) => (
-              <div
-                key={item.title}
-                className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
+            <div className="mt-5 flex flex-wrap gap-3">
+              <Link
+                href="/map"
+                className="rounded-xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-300/40 transition hover:bg-amber-500"
               >
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-lg">
-                    <span>{item.icon}</span>
-                  </div>
-                  <h3 className="text-base font-semibold md:text-lg">{item.title}</h3>
-                </div>
-                <p className="flex-1 text-sm text-gray-700">{item.desc}</p>
-                <Link
-                  href={item.href}
-                  className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-amber-700"
+                マップを見る
+              </Link>
+              <Link
+                href="/search"
+                className="rounded-xl border border-gray-200 bg-white px-4 py-2 text-xs text-gray-800 transition hover:border-gray-300"
+              >
+                お店を探す
+              </Link>
+            </div>
+          </section>
+
+          <section>
+            <div className="mb-6 text-center">
+              <h2 className="text-2xl font-bold md:text-3xl">nicchyo を支える 5つの柱</h2>
+              <p className="mt-3 text-sm text-gray-700 md:text-base">
+                マップを中心に、おすすめ、ことづて、イベントまで。日曜市をまるごと楽しめる導線を揃えました。
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {pillars.map((item) => (
+                <div
+                  key={item.title}
+                  className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
                 >
-                  詳しくみる
-                  <span aria-hidden>→</span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        </section>
+                  <div className="mb-3 flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-lg text-amber-700">
+                      <AboutIcon name={item.icon} className="h-5 w-5" />
+                    </div>
+                    <h3 className="text-base font-semibold md:text-lg">{item.title}</h3>
+                  </div>
+                  <p className="flex-1 text-sm text-gray-700">{item.desc}</p>
+                  <Link
+                    href={item.href}
+                    className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-amber-700"
+                  >
+                    詳しくみる
+                    <span aria-hidden>→</span>
+                  </Link>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
-          <h3 className="text-base font-semibold text-gray-900">大切にしていること</h3>
-          <ul className="mt-3 space-y-2 text-sm text-gray-800">
-            {coreValues.map((v) => (
-              <li key={v} className="flex gap-2">
-                <span className="mt-1 h-2 w-2 rounded-full bg-amber-500" />
-                <span>{v}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+          <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+            <h3 className="text-base font-semibold text-gray-900">大切にしていること</h3>
+            <ul className="mt-3 space-y-2 text-sm text-gray-800">
+              {coreValues.map((v) => (
+                <li key={v} className="flex gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-amber-500" />
+                  <span>{v}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-        <section>
-          <div className="mb-6 text-center md:text-left">
-            <h2 className="text-2xl font-bold md:text-3xl">それぞれの楽しみ方に寄り添う</h2>
-            <p className="mt-3 max-w-3xl text-sm text-gray-700 md:text-base">
-              観光客、リピーター、出店者それぞれの立場で「知りたいこと」を手早く見つけられるよう設計しました。
-            </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-3">
-            {audiences.map((a) => (
-              <div
-                key={a.title}
-                className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
-              >
+          <section>
+            <div className="mb-6 text-center md:text-left">
+              <h2 className="text-2xl font-bold md:text-3xl">それぞれの楽しみ方に寄り添う</h2>
+              <p className="mt-3 max-w-3xl text-sm text-gray-700 md:text-base">
+                観光客、リピーター、出店者それぞれの立場で「知りたいこと」を手早く見つけられるよう設計しました。
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-3">
+              {audiences.map((a) => (
+                <div
+                  key={a.title}
+                  className="flex h-full flex-col rounded-2xl border border-orange-100 bg-white p-5 text-sm text-gray-800 shadow-sm"
+                >
                 <div className="mb-2 flex items-center gap-2 text-base font-semibold">
-                  <span className="text-lg">{a.icon}</span>
+                  <AboutIcon name={a.icon} className="h-4 w-4 text-amber-700" />
                   <span>{a.title}</span>
                 </div>
-                <p className="mb-3 text-xs text-gray-600">{a.subtitle}</p>
-                <ul className="mt-auto space-y-1.5 text-xs text-gray-700">
-                  {a.points.map((p) => (
-                    <li key={p}>・{p}</li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </section>
+                  <p className="mb-3 text-xs text-gray-600">{a.subtitle}</p>
+                  <ul className="mt-auto space-y-1.5 text-xs text-gray-700">
+                    {a.points.map((p) => (
+                      <li key={p}>・{p}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
-          <h3 className="text-base font-semibold text-gray-900">チームと活動</h3>
-          <ul className="mt-3 space-y-2 text-sm text-gray-800">
-            {teamNotes.map((n) => (
-              <li key={n} className="flex gap-2">
-                <span className="mt-1 h-2 w-2 rounded-full bg-amber-500" />
-                <span>{n}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+          <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+            <h3 className="text-base font-semibold text-gray-900">チームと活動</h3>
+            <ul className="mt-3 space-y-2 text-sm text-gray-800">
+              {teamNotes.map((n) => (
+                <li key={n} className="flex gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-amber-500" />
+                  <span>{n}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-        <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
-          <h3 className="text-base font-semibold text-gray-900">連携・お問い合わせ</h3>
-          <p className="mt-2 text-sm text-gray-700">
-            実証実験への協力、フィードバック、メディア取材などは下記からご連絡ください。
-          </p>
-          <div className="mt-3 flex flex-wrap gap-3 text-sm">
-            <Link
-              href="mailto:info@nicchyo.local"
-              className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 font-semibold text-amber-800 shadow-sm hover:bg-amber-100"
-            >
-              メールで連絡
-            </Link>
-            <Link
-              href="/map"
-              className="rounded-full border border-orange-200 bg-white px-4 py-2 font-semibold text-orange-700 shadow-sm hover:bg-orange-50"
-            >
-              日曜市マップへ戻る
-            </Link>
-          </div>
-        </section>
-      </div>
-    </main>
+          <section className="rounded-2xl border border-orange-100 bg-white/95 p-6 shadow-sm">
+            <h3 className="text-base font-semibold text-gray-900">連携・お問い合わせ</h3>
+            <p className="mt-2 text-sm text-gray-700">
+              実証実験への協力、フィードバック、メディア取材などは下記からご連絡ください。
+            </p>
+            <div className="mt-3 flex flex-wrap gap-3 text-sm">
+              <Link
+                href="mailto:info@nicchyo.local"
+                className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 font-semibold text-amber-800 shadow-sm hover:bg-amber-100"
+              >
+                メールで連絡
+              </Link>
+              <Link
+                href="/map"
+                className="rounded-full border border-orange-200 bg-white px-4 py-2 font-semibold text-orange-700 shadow-sm hover:bg-orange-50"
+              >
+                日曜市マップへ戻る
+              </Link>
+            </div>
+          </section>
+        </div>
+      </main>
+      <NavigationBar />
+    </>
   );
+}
+
+type AboutIconName =
+  | "map"
+  | "spark"
+  | "chat"
+  | "recipe"
+  | "event"
+  | "route"
+  | "discover"
+  | "store";
+
+type AboutIconProps = {
+  name: AboutIconName;
+  className?: string;
+};
+
+function AboutIcon({ name, className }: AboutIconProps) {
+  const props = {
+    className,
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.5,
+    viewBox: "0 0 24 24",
+    "aria-hidden": true,
+  } as const;
+
+  switch (name) {
+    case "map":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 6.75 5.25 5.25 3 6.75v11.5l3.75-1.5 6 2.25 5.25-2.25V5.25L12.75 7.5 9 6.75Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75v11.5" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12.75 7.5v11.25" />
+        </svg>
+      );
+    case "spark":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m12 3 1.5 3.5L17 8l-3.5 1.5L12 13l-1.5-3.5L7 8l3.5-1.5L12 3Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5.5 16.5 6.5 18 8 19" />
+        </svg>
+      );
+    case "chat":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 6.75A2.25 2.25 0 0 1 6.75 4.5h10.5A2.25 2.25 0 0 1 19.5 6.75v6A2.25 2.25 0 0 1 17.25 15H9l-3.75 3v-3H6.75A2.25 2.25 0 0 1 4.5 12.75v-6Z"
+          />
+        </svg>
+      );
+    case "recipe":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 5.25h10.5A1.5 1.5 0 0 1 18.75 6.75v11.5A1.5 1.5 0 0 1 17.25 19.75H6.75A1.5 1.5 0 0 1 5.25 18.25V6.75A1.5 1.5 0 0 1 6.75 5.25Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 9h7.5M8.25 12h7.5M8.25 15h4.5" />
+        </svg>
+      );
+    case "event":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 4.5v3M17.25 4.5v3M4.5 8.25h15"
+          />
+          <rect
+            x="4.5"
+            y="6.75"
+            width="15"
+            height="12.75"
+            rx="2.25"
+            ry="2.25"
+            stroke="currentColor"
+            fill="none"
+          />
+        </svg>
+      );
+    case "route":
+      return (
+        <svg {...props}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18a2 2 0 1 0 0.01 0" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M18 6a2 2 0 1 0 0.01 0" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M8 17c4-1 4-6 8-7"
+          />
+        </svg>
+      );
+    case "discover":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 4.5 4.5 9l7.5 10.5L19.5 9 12 4.5Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="m9.5 12 2.5 1.5 2.5-4.5" />
+        </svg>
+      );
+    case "store":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 9.75 6 5.25h12l1.5 4.5"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 9.75v7.5h12v-7.5" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25V12h6v5.25" />
+        </svg>
+      );
+    default:
+      return null;
+  }
 }

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -11,16 +11,10 @@
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth/AuthContext';
 import { useMenu } from '@/lib/ui/MenuContext';
-import type { UserRole } from '@/lib/auth/types';
 
 export default function HamburgerMenu() {
   const { isMenuOpen, toggleMenu, closeMenu } = useMenu();
-  const { isLoggedIn, user, login, logout, permissions } = useAuth();
-
-  const handleLogin = (role: UserRole) => {
-    login(role);
-    closeMenu();
-  };
+  const { isLoggedIn, user, logout, permissions } = useAuth();
 
   const handleLogout = () => {
     logout();
@@ -236,50 +230,17 @@ export default function HamburgerMenu() {
               ) : (
                 <>
                   <li>
-                    <div className="rounded-lg bg-gray-50 p-4 mb-3 text-sm text-gray-700 leading-relaxed">
-                      デモ用ログインです。ロールを選んで機能を試せます。
-                    </div>
-                  </li>
-                  <li>
-                    <button
-                      onClick={() => handleLogin('super_admin')}
-                      className="flex w-full items-center gap-3 rounded-lg border-2 border-red-200 bg-red-50 px-4 py-3 text-gray-700 transition hover:bg-red-100"
+                    <Link
+                      href="/login"
+                      onClick={closeMenu}
+                      className="flex w-full items-center gap-3 rounded-lg border-2 border-amber-200 bg-amber-50 px-4 py-3 text-gray-700 transition hover:bg-amber-100"
                     >
-                      <MenuIcon name="settings" className="h-5 w-5 text-red-600" />
+                      <MenuIcon name="user" className="h-5 w-5 text-amber-700" />
                       <div className="flex-1 text-left">
-                        <p className="text-sm font-semibold">管理者としてログイン</p>
-                        <p className="text-xs text-gray-600">店舗・ユーザー管理</p>
+                        <p className="text-sm font-semibold">ログイン</p>
+                        <p className="text-xs text-gray-600">ログイン画面へ進む</p>
                       </div>
-                    </button>
-                  </li>
-                  <li>
-                    <button
-                      onClick={() => handleLogin('vendor')}
-                      className="flex w-full items-center gap-3 rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 text-gray-700 transition hover:bg-blue-100"
-                    >
-                      <MenuIcon name="shop" className="h-5 w-5 text-blue-600" />
-                      <div className="flex-1 text-left">
-                        <p className="text-sm font-semibold">出店者としてログイン</p>
-                        <p className="text-xs text-gray-600">デモIDで表示</p>
-                      </div>
-                    </button>
-                  </li>
-                  <li>
-                    <button
-                      onClick={() => handleLogin('general_user')}
-                      className="flex w-full items-center gap-3 rounded-lg border-2 border-gray-200 bg-gray-50 px-4 py-3 text-gray-700 transition hover:bg-gray-100"
-                    >
-                      <MenuIcon name="user" className="h-5 w-5 text-gray-600" />
-                      <div className="flex-1 text-left">
-                        <p className="text-sm font-semibold">一般ユーザーでログイン</p>
-                        <p className="text-xs text-gray-600">bag・バッジを体験</p>
-                      </div>
-                    </button>
-                  </li>
-                  <li>
-                    <div className="mt-4 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800 leading-relaxed">
-                      本番環境では Firebase Auth 等に置き換えてください。
-                    </div>
+                    </Link>
                   </li>
                 </>
               )}

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -64,8 +64,12 @@ export default function HamburgerMenu() {
           <div className="border-b border-gray-200 bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4">
             {isLoggedIn && user ? (
               <Link href="/my-profile" onClick={closeMenu} className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white text-xl font-bold">
-                  {user.name.charAt(0)}
+                <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-amber-500 text-white text-xl font-bold">
+                  {user.avatarUrl ? (
+                    <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    user.name.charAt(0)
+                  )}
                 </div>
                 <div className="flex-1">
                   <p className="text-sm font-semibold text-gray-800">{user.name}</p>

--- a/app/components/MapLink.tsx
+++ b/app/components/MapLink.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link, { type LinkProps } from "next/link";
+import type { MouseEvent, ReactNode } from "react";
+import { useMapLoading } from "./MapLoadingProvider";
+
+type MapLinkProps = LinkProps & {
+  children: ReactNode;
+  className?: string;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+export default function MapLink({ onClick, ...props }: MapLinkProps) {
+  const { startMapLoading } = useMapLoading();
+
+  return (
+    <Link
+      {...props}
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          startMapLoading();
+        }
+      }}
+    />
+  );
+}

--- a/app/components/MapLoadingProvider.tsx
+++ b/app/components/MapLoadingProvider.tsx
@@ -12,7 +12,7 @@ type MapLoadingContextValue = {
 
 const MapLoadingContext = createContext<MapLoadingContextValue | null>(null);
 
-const MIN_LOADING_MS = 500;
+const MIN_LOADING_MS = 1000;
 
 export function useMapLoading() {
   const value = useContext(MapLoadingContext);

--- a/app/components/MapLoadingProvider.tsx
+++ b/app/components/MapLoadingProvider.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React, { createContext, useContext, useMemo, useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+type MapLoadingContextValue = {
+  isMapLoading: boolean;
+  startMapLoading: () => void;
+  stopMapLoading: () => void;
+};
+
+const MapLoadingContext = createContext<MapLoadingContextValue | null>(null);
+
+export function useMapLoading() {
+  const value = useContext(MapLoadingContext);
+  if (!value) {
+    throw new Error("useMapLoading must be used within MapLoadingProvider");
+  }
+  return value;
+}
+
+export default function MapLoadingProvider({ children }: { children: React.ReactNode }) {
+  const [isMapLoading, setIsMapLoading] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (isMapLoading) {
+      setIsMapLoading(false);
+    }
+  }, [pathname, isMapLoading]);
+
+  const value = useMemo(
+    () => ({
+      isMapLoading,
+      startMapLoading: () => {
+        if (pathname?.startsWith("/map")) return;
+        setIsMapLoading(true);
+      },
+      stopMapLoading: () => setIsMapLoading(false),
+    }),
+    [isMapLoading, pathname]
+  );
+
+  return (
+    <MapLoadingContext.Provider value={value}>
+      {children}
+      {isMapLoading && <MapLoadingOverlay />}
+    </MapLoadingContext.Provider>
+  );
+}
+
+function MapLoadingOverlay() {
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-800">
+      <div className="flex flex-col items-center gap-4">
+        <div className="map-walker relative h-20 w-20 text-amber-700">
+          <svg
+            className="map-walker-frame is-1"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="28" y2="36" />
+            <line x1="40" y1="30" x2="52" y2="34" />
+            <line x1="40" y1="46" x2="30" y2="64" />
+            <line x1="40" y1="46" x2="52" y2="62" />
+          </svg>
+
+          <svg
+            className="map-walker-frame is-2"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="30" y2="34" />
+            <line x1="40" y1="30" x2="54" y2="38" />
+            <line x1="40" y1="46" x2="28" y2="62" />
+            <line x1="40" y1="46" x2="54" y2="64" />
+          </svg>
+
+          <svg
+            className="map-walker-frame is-3"
+            viewBox="0 0 80 80"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="40" cy="16" r="6" />
+            <line x1="40" y1="22" x2="40" y2="46" />
+            <line x1="40" y1="30" x2="26" y2="38" />
+            <line x1="40" y1="30" x2="54" y2="36" />
+            <line x1="40" y1="46" x2="34" y2="64" />
+            <line x1="40" y1="46" x2="56" y2="58" />
+          </svg>
+        </div>
+        <div className="text-xs font-semibold tracking-[0.35em] text-amber-700">LOADING</div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/MapLoadingProvider.tsx
+++ b/app/components/MapLoadingProvider.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useMemo, useState, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
+import NavigationBar from "./NavigationBar";
 
 type MapLoadingContextValue = {
   isMapLoading: boolean;
@@ -12,7 +13,7 @@ type MapLoadingContextValue = {
 
 const MapLoadingContext = createContext<MapLoadingContextValue | null>(null);
 
-const MIN_LOADING_MS = 1000;
+const MIN_LOADING_MS = 1300;
 
 export function useMapLoading() {
   const value = useContext(MapLoadingContext);
@@ -95,65 +96,68 @@ export default function MapLoadingProvider({ children }: { children: React.React
 
 function MapLoadingOverlay() {
   return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-800">
-      <div className="flex flex-col items-center gap-4">
-        <div className="map-walker relative h-20 w-20 text-amber-700">
-          <svg
-            className="map-walker-frame is-1"
-            viewBox="0 0 80 80"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="40" cy="16" r="6" />
-            <line x1="40" y1="22" x2="40" y2="46" />
-            <line x1="40" y1="30" x2="28" y2="36" />
-            <line x1="40" y1="30" x2="52" y2="34" />
-            <line x1="40" y1="46" x2="30" y2="64" />
-            <line x1="40" y1="46" x2="52" y2="62" />
-          </svg>
+    <div className="fixed inset-0 z-[9999] flex flex-col bg-gradient-to-b from-amber-50 via-orange-50 to-white text-gray-800">
+      <div className="flex flex-1 items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="map-walker relative h-20 w-20 text-amber-700">
+            <svg
+              className="map-walker-frame is-1"
+              viewBox="0 0 80 80"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="40" cy="16" r="6" />
+              <line x1="40" y1="22" x2="40" y2="46" />
+              <line x1="40" y1="30" x2="28" y2="36" />
+              <line x1="40" y1="30" x2="52" y2="34" />
+              <line x1="40" y1="46" x2="30" y2="64" />
+              <line x1="40" y1="46" x2="52" y2="62" />
+            </svg>
 
-          <svg
-            className="map-walker-frame is-2"
-            viewBox="0 0 80 80"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="40" cy="16" r="6" />
-            <line x1="40" y1="22" x2="40" y2="46" />
-            <line x1="40" y1="30" x2="30" y2="34" />
-            <line x1="40" y1="30" x2="54" y2="38" />
-            <line x1="40" y1="46" x2="28" y2="62" />
-            <line x1="40" y1="46" x2="54" y2="64" />
-          </svg>
+            <svg
+              className="map-walker-frame is-2"
+              viewBox="0 0 80 80"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="40" cy="16" r="6" />
+              <line x1="40" y1="22" x2="40" y2="46" />
+              <line x1="40" y1="30" x2="30" y2="34" />
+              <line x1="40" y1="30" x2="54" y2="38" />
+              <line x1="40" y1="46" x2="28" y2="62" />
+              <line x1="40" y1="46" x2="54" y2="64" />
+            </svg>
 
-          <svg
-            className="map-walker-frame is-3"
-            viewBox="0 0 80 80"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="40" cy="16" r="6" />
-            <line x1="40" y1="22" x2="40" y2="46" />
-            <line x1="40" y1="30" x2="26" y2="38" />
-            <line x1="40" y1="30" x2="54" y2="36" />
-            <line x1="40" y1="46" x2="34" y2="64" />
-            <line x1="40" y1="46" x2="56" y2="58" />
-          </svg>
+            <svg
+              className="map-walker-frame is-3"
+              viewBox="0 0 80 80"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="40" cy="16" r="6" />
+              <line x1="40" y1="22" x2="40" y2="46" />
+              <line x1="40" y1="30" x2="26" y2="38" />
+              <line x1="40" y1="30" x2="54" y2="36" />
+              <line x1="40" y1="46" x2="34" y2="64" />
+              <line x1="40" y1="46" x2="56" y2="58" />
+            </svg>
+          </div>
+          <div className="text-xs font-semibold tracking-[0.35em] text-amber-700">LOADING</div>
         </div>
-        <div className="text-xs font-semibold tracking-[0.35em] text-amber-700">LOADING</div>
       </div>
+      <NavigationBar activeHref="/map" />
     </div>
   );
 }

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -17,7 +17,11 @@ const navItems: NavItem[] = [
   { name: "ことづて", href: "/kotodute", icon: "chat" },
 ];
 
-export default function NavigationBar() {
+type NavigationBarProps = {
+  activeHref?: string;
+};
+
+export default function NavigationBar({ activeHref }: NavigationBarProps) {
   const pathname = usePathname();
   const { startMapLoading } = useMapLoading();
 
@@ -28,7 +32,7 @@ export default function NavigationBar() {
     >
       <div className="mx-auto flex h-12 max-w-lg items-center justify-around">
         {navItems.map((item) => {
-          const isActive = pathname === item.href;
+          const isActive = (activeHref ?? pathname) === item.href;
           const handleClick = item.href === "/map" ? startMapLoading : undefined;
           return (
             <Link

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -1,56 +1,45 @@
-"use client";
+﻿"use client";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useMapLoading } from "./MapLoadingProvider";
 
-interface NavItem {
+type NavItem = {
   name: string;
   href: string;
-  icon: string;
-}
+  icon: "map" | "search" | "recipe" | "chat";
+};
 
 const navItems: NavItem[] = [
-  { name: "マップ", href: "/map", icon: "🗺️" },
-  { name: "検索", href: "/search", icon: "🔍" },
-  { name: "レシピ", href: "/recipes", icon: "🍳" },
-  { name: "ことづて", href: "/kotodute", icon: "✉️" },
+  { name: "マップ", href: "/map", icon: "map" },
+  { name: "検索", href: "/search", icon: "search" },
+  { name: "レシピ", href: "/recipes", icon: "recipe" },
+  { name: "ことづて", href: "/kotodute", icon: "chat" },
 ];
 
-/**
- * ボトムナビゲーションバー（最適化版）
- *
- * 【モバイル最適化】
- * - 半透明背景（backdrop-blur）で地図が透けて見える
- * - safe-area-inset-bottom 対応（iOS切り欠き・ジェスチャーバー）
- * - 高さ最小化（h-14 → コンパクト）
- * - オーバーレイ構造（地図を圧迫しない）
- *
- * 【アクセシビリティ】
- * - タップエリア十分確保
- * - アクティブ状態の視覚的フィードバック
- */
 export default function NavigationBar() {
   const pathname = usePathname();
+  const { startMapLoading } = useMapLoading();
 
   return (
     <nav
       className="fixed bottom-0 left-0 right-0 z-[9997] border-t border-gray-200/50 bg-white/80 backdrop-blur-md shadow-lg"
-      style={{
-        paddingBottom: 'var(--safe-bottom, 0px)', // iOS ホームインジケーター対応
-      }}
+      style={{ paddingBottom: "var(--safe-bottom, 0px)" }}
     >
       <div className="mx-auto flex h-12 max-w-lg items-center justify-around">
         {navItems.map((item) => {
           const isActive = pathname === item.href;
+          const handleClick = item.href === "/map" ? startMapLoading : undefined;
           return (
             <Link
               key={item.name}
               href={item.href}
+              onClick={handleClick}
               className={`flex h-full flex-1 flex-col items-center justify-center gap-0.5 transition-colors ${
                 isActive ? "text-amber-700" : "text-gray-600 hover:text-gray-900"
               }`}
             >
-              <span className="text-lg" aria-hidden="true">{item.icon}</span>
+              <NavIcon name={item.icon} className="h-5 w-5" />
               <span className="text-[10px] font-medium">{item.name}</span>
             </Link>
           );
@@ -58,4 +47,65 @@ export default function NavigationBar() {
       </div>
     </nav>
   );
+}
+
+type NavIconProps = {
+  name: NavItem["icon"];
+  className?: string;
+};
+
+function NavIcon({ name, className }: NavIconProps) {
+  const props = {
+    className,
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.6,
+    viewBox: "0 0 24 24",
+    "aria-hidden": true,
+  } as const;
+
+  switch (name) {
+    case "map":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 6.75 5.25 5.25 3 6.75v11.5l3.75-1.5 6 2.25 5.25-2.25V5.25L12.75 7.5 9 6.75Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75v11.5" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12.75 7.5v11.25" />
+        </svg>
+      );
+    case "search":
+      return (
+        <svg {...props}>
+          <circle cx="11" cy="11" r="6.5" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 16.5 20 20" />
+        </svg>
+      );
+    case "recipe":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 5.25h10.5A1.5 1.5 0 0 1 18.75 6.75v11.5A1.5 1.5 0 0 1 17.25 19.75H6.75A1.5 1.5 0 0 1 5.25 18.25V6.75A1.5 1.5 0 0 1 6.75 5.25Z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 9h7.5M8.25 12h7.5M8.25 15h4.5" />
+        </svg>
+      );
+    case "chat":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 6.75A2.25 2.25 0 0 1 6.75 4.5h10.5A2.25 2.25 0 0 1 19.5 6.75v6A2.25 2.25 0 0 1 17.25 15H9l-3.75 3v-3H6.75A2.25 2.25 0 0 1 4.5 12.75v-6Z"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,6 +83,46 @@ body {
   animation: slide-in-right 0.6s ease-out forwards;
 }
 
+@keyframes map-walker-frame {
+  0%,
+  33% {
+    opacity: 1;
+  }
+  34%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes map-walker-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-2px);
+  }
+}
+
+.map-walker {
+  animation: map-walker-bob 1.2s ease-in-out infinite;
+}
+
+.map-walker-frame {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  animation: map-walker-frame 1.2s steps(1) infinite;
+}
+
+.map-walker-frame.is-2 {
+  animation-delay: 0.4s;
+}
+
+.map-walker-frame.is-3 {
+  animation-delay: 0.8s;
+}
+
 /* ===== マップ軽量化: クラスタアイコン ===== */
 
 /* クラスタアイコンのコンテナ */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,36 +1,28 @@
-// app/layout.tsx
-import type { Metadata, Viewport } from "next";
+﻿import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth/AuthContext";
 import { MenuProvider } from "@/lib/ui/MenuContext";
 import { BagProvider } from "@/lib/storage/BagContext";
 import AppHeader from "./components/AppHeader";
 import HamburgerMenu from "./components/HamburgerMenu";
+import MapLoadingProvider from "./components/MapLoadingProvider";
 import ViewportHeightUpdater from "./components/ViewportHeightUpdater";
 
 export const metadata: Metadata = {
   title: "nicchyo | 高知の日曜市を、未来へつなぐ",
-  description: "高知の日曜市を舞台に、「観光客 × 地元民 × 市場文化」がつながるデジタルプラットフォーム。",
+  description:
+    "高知の日曜市を舞台に、観光客・地元・市場がつながるデジタルプラットフォーム。",
 };
 
-/**
- * モバイル viewport 設定
- * - viewport-fit=cover: iOS Safe Area 対応
- * - interactive-widget=resizes-content: キーボード表示時の挙動制御
- */
 export const viewport: Viewport = {
-  width: 'device-width',
+  width: "device-width",
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  viewportFit: 'cover', // iOS Safe Area 対応
+  viewportFit: "cover",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body className="bg-nicchyo-base text-nicchyo-ink">
@@ -38,14 +30,11 @@ export default function RootLayout({
         <AuthProvider>
           <BagProvider>
             <MenuProvider>
-              {/* ヘッダ: オーバーレイ（メニュー開閉で表示/非表示） */}
-              <AppHeader />
-
-              {/* ハンバーガーメニュー: 常に表示（独立配置） */}
-              <HamburgerMenu />
-
-              {/* メインコンテンツ: padding なし（全画面表示） */}
-              {children}
+              <MapLoadingProvider>
+                <AppHeader />
+                <HamburgerMenu />
+                {children}
+              </MapLoadingProvider>
             </MenuProvider>
           </BagProvider>
         </AuthProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ export default function HomePage() {
   const router = useRouter();
   const { startMapLoading } = useMapLoading();
   const [loaded, setLoaded] = useState(false);
-  const [revealed, setRevealed] = useState(false);
 
   useEffect(() => {
     setLoaded(true);
@@ -23,12 +22,8 @@ export default function HomePage() {
     <div className="min-h-screen bg-amber-50 text-gray-900">
       <section className="relative h-screen w-screen overflow-hidden">
         <div
-          className={`absolute inset-0 scale-[1.04] transition-all duration-700 ease-out ${
-            revealed
-              ? "blur-0 opacity-100"
-              : loaded
-                ? "blur-md opacity-70"
-                : "blur-xl opacity-0"
+          className={`absolute inset-0 scale-[1.04] transition-opacity duration-300 ${
+            loaded ? "opacity-100" : "opacity-0"
           }`}
         >
           <MapView />
@@ -67,7 +62,6 @@ export default function HomePage() {
             <button
               type="button"
               onClick={(event) => {
-                setRevealed(true);
                 startMapLoading();
                 window.setTimeout(() => {
                   router.push("/map");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useMapLoading } from "./components/MapLoadingProvider";
 
 const MapView = dynamic(() => import("./(public)/map/components/MapView"), {
   ssr: false,
@@ -10,6 +11,7 @@ const MapView = dynamic(() => import("./(public)/map/components/MapView"), {
 
 export default function HomePage() {
   const router = useRouter();
+  const { startMapLoading } = useMapLoading();
   const [loaded, setLoaded] = useState(false);
   const [revealed, setRevealed] = useState(false);
 
@@ -66,6 +68,7 @@ export default function HomePage() {
               type="button"
               onClick={(event) => {
                 setRevealed(true);
+                startMapLoading();
                 window.setTimeout(() => {
                   router.push("/map");
                 }, 350);

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -69,6 +69,7 @@ interface AuthContextType {
   user: User | null;
   login: (role: UserRole) => void;
   loginWithCredentials: (identifier: string, password: string) => boolean;
+  updateProfile: (updates: Pick<User, "name" | "email" | "avatarUrl">) => void;
   logout: () => void;
   isLoading: boolean;
   permissions: PermissionCheck;
@@ -148,6 +149,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return true;
   };
 
+  const updateProfile = (updates: Pick<User, "name" | "email" | "avatarUrl">) => {
+    if (!user) return;
+    const nextUser = { ...user, ...updates };
+    persistUser(nextUser);
+  };
+
   const logout = () => {
     setUser(null);
     setIsLoggedIn(false);
@@ -163,7 +170,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ isLoggedIn, user, login, loginWithCredentials, logout, isLoading, permissions }}
+      value={{
+        isLoggedIn,
+        user,
+        login,
+        loginWithCredentials,
+        updateProfile,
+        logout,
+        isLoading,
+        permissions,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/lib/auth/types.ts
+++ b/lib/auth/types.ts
@@ -1,80 +1,22 @@
-/**
+﻿/**
  * 認証・ユーザー関連の型定義
- *
- * このファイルはフロントエンド・バックエンド共通で使用することを想定
  */
 
-/**
- * ユーザーの役割（権限レベル）
- *
- * @description
- * - super_admin: 高知市・高専の管理者。全ての操作が可能
- * - vendor: 出店者。自店舗の情報編集が可能
- * - general_user: 一般利用者。閲覧のみ（将来用）
- */
-export type UserRole = 'super_admin' | 'vendor' | 'general_user';
+export type UserRole = "super_admin" | "vendor" | "general_user";
 
-/**
- * ユーザー情報
- *
- * 【現在の実装】
- * - ダミーユーザーとして使用
- * - id, name, email, role のみ
- *
- * 【将来の実装：Firebase Auth移行後】
- * - Firebase User をベースに、カスタムクレームで role を管理
- * - Firestore に追加のプロフィール情報を保存
- *
- * @example
- * ```typescript
- * // Firebase移行後のイメージ
- * type User = {
- *   id: string;              // Firebase UID
- *   email: string;           // Firebase User.email
- *   name: string;            // Firestore: users/{uid}/profile/name
- *   role: UserRole;          // Custom Claims または Firestore
- *   vendorId?: number;       // 出店者の場合、紐づく店舗ID
- *   createdAt: Date;         // アカウント作成日
- *   lastLoginAt: Date;       // 最終ログイン日時
- * };
- * ```
- */
 export interface User {
-  /** ユーザーID（Firebase UID を想定） */
   id: string;
-
-  /** ユーザー名 */
   name: string;
-
-  /** メールアドレス */
   email: string;
-
-  /** 役割（権限レベル） */
+  avatarUrl?: string;
   role: UserRole;
-
-  /**
-   * 出店者の場合、紐づく店舗ID
-   * vendor role の場合のみ設定
-   */
   vendorId?: number;
 }
 
-/**
- * 権限チェック用のヘルパー型
- */
 export interface PermissionCheck {
-  /** スーパー管理者かどうか */
   isSuperAdmin: boolean;
-
-  /** 出店者かどうか */
   isVendor: boolean;
-
-  /** 一般ユーザーかどうか */
   isGeneralUser: boolean;
-
-  /** 特定の店舗の編集権限があるかチェック */
   canEditShop: (shopId: number) => boolean;
-
-  /** 全店舗の管理権限があるかチェック */
   canManageAllShops: boolean;
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 概要
  マップ遷移時のローディング体験を改善し、遷移前の硬直中でもローディングが見えるようにしました。あわせて関連画面
  の文字化け修正、プロフィール機能強化、ナビ表示の整合を行っています。

  ## 変更内容
  - マップ遷移時のローディングをクリック直後に表示し、最短表示時間＋マップ準備完了通知で制御
  - ローディング画面にナビゲーションバーを表示（マップアイコンをアクティブ表示）
  - マップ遷移リンクを MapLink 化し、戻る導線などでローディングを統一
  - プロフィール画面をロール共通UIに刷新（名前・メール・アイコン・パスワード導線）
  - アイコン画像アップロード対応（2MB制限、プレビュー、削除）
  - 文字化け・パースエラーの修正（layout / navigation / contact / faq / events / about など）

  ## UI影響
  - マップ遷移時に全画面ローディングが表示される
  - ローディング中のフッタにナビバーが表示され、マップが強調される
  - my-profile でアイコン画像をアップロードできる

  ## 動作確認
  - `npm run build` でビルド成功
  - `/map` への遷移時にローディングが表示・自動終了する
  - `/my-profile` で画像アップロードが反映される
