### PR TITLE
地図表示の調整とショップコメント表示の改善Feature/nichiyo

### DIFF
--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -39,24 +39,16 @@ type MapPageClientProps = {
   >;
 };
 
-const INTRO_PRODUCT_COUNT = 2;
 const NEARBY_RADIUS_METERS = 120;
 const NEARBY_MAX_SHOPS = 10;
 const INTRO_TAP_HINT = "";
+const INTRO_STRENGTH_FALLBACK =
+  "あら、ここのお店、最近行ってないねぇ。今日は何が出ちゅうか、ちょっと見てきてくれん？";
 
 function buildShopIntroText(shop: Shop): string {
   const name = shop.name?.trim() || `お店${shop.id}`;
-  const category = shop.category?.trim() || "いろいろ";
-  const icon = shop.icon?.trim() || "";
-  const categoryLabel = icon ? `${category} ${icon}` : category;
-  const products = (shop.products ?? []).filter((item) => item && item.trim().length > 0);
-  if (products.length === 0) {
-    return `${name}\n${categoryLabel}のお店やきね。\n主な商品: いろいろ${INTRO_TAP_HINT}`;
-  }
-  const picked = products.slice(0, INTRO_PRODUCT_COUNT);
-  const joined = picked.length === 1 ? picked[0] : `${picked[0]}や${picked[1]}`;
-  const suffix = products.length > INTRO_PRODUCT_COUNT ? "など" : "";
-  return `${name}\n${categoryLabel}のお店やきね。\n主な商品: ${joined}${suffix}${INTRO_TAP_HINT}`;
+  const strength = shop.shopStrength?.trim() || INTRO_STRENGTH_FALLBACK;
+  return `${name}\n${strength}${INTRO_TAP_HINT}`;
 }
 
 function distanceMeters(

--- a/app/(public)/map/components/ShopDetailBanner.tsx
+++ b/app/(public)/map/components/ShopDetailBanner.tsx
@@ -43,6 +43,8 @@ type BagItem = {
 const STORAGE_KEY = "nicchyo-fridge-items";
 const KOTODUTE_PREVIEW_LIMIT = 3;
 const KOTODUTE_TAG_REGEX = /\s*#\d+|\s*#all/gi;
+const OSEKKAI_FALLBACK =
+  "あら、ここのお店、最近行ってないねぇ。今日は何が出ちゅうか、ちょっと見てきてくれん？";
 
 const buildBagKey = (name: string, shopId?: number) =>
   `${name.trim().toLowerCase()}-${shopId ?? "any"}`;
@@ -474,6 +476,25 @@ export default function ShopDetailBanner({
             <section className="py-8 text-xl text-slate-700">
               <p className="text-base font-semibold text-slate-500">主な商品</p>
               <p className="mt-2 text-2xl font-semibold text-slate-900">{shop.category}</p>
+              <p className="mt-4 text-base font-semibold text-slate-500">にちよのおせっかい</p>
+              <div className="mt-3 flex items-start gap-4">
+                <div className="shrink-0">
+                  <Image
+                    src="/images/obaasan_transparent.png"
+                    alt="おせっかいばあちゃん"
+                    width={88}
+                    height={88}
+                    className="h-20 w-20 opacity-70"
+                  />
+                </div>
+                <div className="relative w-full rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-xl leading-relaxed text-slate-700">
+                  <span
+                    className="absolute -left-2 top-6 h-4 w-4 rotate-45 border-b border-l border-amber-200 bg-amber-50"
+                    aria-hidden
+                  />
+                  {shop.shopStrength?.trim() || OSEKKAI_FALLBACK}
+                </div>
+              </div>
             </section>
 
           {/* 商品名 */}

--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -31,6 +31,7 @@ type ShopRow = {
   schedule: string | null;
   message: string | null;
   topic: string[] | null;
+  shop_strength: string | null;
 };
 
 const CHOME_VALUES = new Set([
@@ -76,6 +77,7 @@ export default async function MapPage() {
         'schedule',
         'message',
         'topic',
+        'shop_strength',
       ].join(',')
     )
     .order('legacy_id', { ascending: true });
@@ -103,6 +105,7 @@ export default async function MapPage() {
           schedule: row.schedule ?? '',
           message: row.message ?? undefined,
           topic: Array.isArray(row.topic) ? row.topic : undefined,
+          shopStrength: row.shop_strength ?? undefined,
         }))
     : staticShops;
 

--- a/app/(public)/map/types/shopData.ts
+++ b/app/(public)/map/types/shopData.ts
@@ -80,6 +80,9 @@ export interface ShopEditableData {
   /** 出店者からのメッセージ（任意） */
   message?: string;
 
+  /** おせっかいコメント（任意） */
+  shopStrength?: string;
+
   /** 来訪者に聞いてほしいトピック */
   topic?: string[];
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -371,7 +371,7 @@ body.grandma-chat-open .leaflet-container {
 .shop-simple-banner {
   position: absolute;
   left: 50%;
-  bottom: 40px;
+  bottom: 52px;
   transform: translateX(-50%);
   display: none;
   width: 220px;
@@ -386,12 +386,12 @@ body.grandma-chat-open .leaflet-container {
 }
 
 .shop-side-north .shop-simple-banner {
-  transform: translateX(calc(-50% - 90px));
-  flex-direction: row-reverse;
+  transform: translateX(calc(-50% + 10px));
 }
 
 .shop-side-south .shop-simple-banner {
-  transform: translateX(calc(-50% + 90px));
+  transform: translateX(calc(-50% - 10px));
+  flex-direction: row-reverse;
 }
 
 .shop-simple-banner-image {

--- a/app/globals.css
+++ b/app/globals.css
@@ -345,9 +345,9 @@ body.grandma-chat-open .leaflet-container {
 
 .shop-product-icon {
   position: absolute;
-  top: -38px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   width: 86px;
   height: 52px;
   padding: 0;
@@ -362,6 +362,16 @@ body.grandma-chat-open .leaflet-container {
   pointer-events: none;
   overflow: hidden;
   display: none;
+}
+
+.shop-side-north .shop-product-icon {
+  left: calc(100% + 8px);
+  transform: translate(0, -50%);
+}
+
+.shop-side-south .shop-product-icon {
+  left: -8px;
+  transform: translate(-100%, -50%);
 }
 
 .shop-product-icon-visible .shop-product-icon {


### PR DESCRIPTION
## 概要
  - 地図の初期中心と道路座標を更新
  - ショップバナー／紹介コメントに shop_strength を反映
  - ミニショップバナーと商品アイコンの表示位置を調整

  ## 変更内容
  - Mapの中心座標と道路bounds/segmentsを指定座標に合わせて更新
  - Supabaseのshop_strengthを取得し、紹介コメントとバナーに表示
  - ミニバナーの位置・左右入れ替え・表示高さを調整
  - アイコンを店舗の外側に移動

  ## 動作確認
  - 未実施（必要なら実施します）