### PR TITLE
Refactor Navigation Bar to standard flat design

### DIFF
--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -37,10 +37,10 @@ export default function NavigationBar({
 
   return (
     <nav
-      className={`navigation-bar ${position} bottom-0 left-0 right-0 z-[9997] border-t border-gray-200/50 bg-white text-sm leading-none shadow-lg`}
+      className={`navigation-bar ${position} bottom-0 left-0 right-0 z-[9997] border-t border-gray-200/60 bg-white/90 backdrop-blur-md text-sm leading-none shadow-sm`}
       style={{ paddingBottom: "var(--safe-bottom, 0px)" }}
     >
-      <div className="mx-auto flex h-12 max-w-lg items-center justify-around">
+      <div className="mx-auto flex h-14 max-w-lg items-center justify-around">
         {navItems.map((item) => {
           const isActive = (activeHref ?? pathname) === item.href;
           const handleClick = item.href === "/map" ? startMapLoading : undefined;
@@ -55,16 +55,20 @@ export default function NavigationBar({
                 item.href === "/kotodute" ||
                 item.href === "/consult"
               }
-              className={`flex h-full flex-1 flex-col items-center justify-center gap-0.5 transition-colors ${
-                isActive ? "text-amber-700" : "text-gray-600 hover:text-gray-900"
-              } ${item.href === "/map" ? "nav-map-arc" : ""}`}
+              className={`group flex h-full flex-1 flex-col items-center justify-center gap-1 transition-all duration-200 ${
+                isActive
+                  ? "text-amber-600"
+                  : "text-gray-400 hover:bg-gray-50/50 hover:text-gray-600"
+              }`}
             >
-              {item.href === "/map" && (
-                <span className="nav-map-arc-ring" aria-hidden="true" />
-              )}
-              <span className="nav-map-arc-content">
-                <NavIcon name={item.icon} className="h-5 w-5" />
-                <span className="text-[10px] font-medium leading-none">{item.name}</span>
+              <NavIcon
+                name={item.icon}
+                className={`h-6 w-6 transition-transform duration-200 ${
+                  isActive ? "scale-105" : "group-hover:scale-105"
+                }`}
+              />
+              <span className="text-[10px] font-medium leading-none tracking-tight">
+                {item.name}
               </span>
             </Link>
           );

--- a/app/globals.css
+++ b/app/globals.css
@@ -564,37 +564,6 @@ body.home-poster-zoom-open .hamburger-button {
   height: 100%;
 }
 
-.nav-map-arc {
-  position: relative;
-  z-index: 1;
-}
-
-.nav-map-arc-content {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.nav-map-arc-ring {
-  position: absolute;
-  left: 50%;
-  bottom: -2px;
-  width: 120px;
-  height: 68px;
-  border: 2px solid rgba(34, 197, 94, 0.9);
-  border-bottom: none;
-  border-top-left-radius: 9999px;
-  border-top-right-radius: 9999px;
-  background: rgba(220, 252, 231, 0.85);
-  transform: translateX(-50%);
-  pointer-events: none;
-  z-index: 0;
-  box-shadow: 0 -8px 18px rgba(34, 197, 94, 0.22);
-}
-
 .map-building-tilted {
   transform: rotate(90deg);
   transform-origin: center;


### PR DESCRIPTION
This change refactors the main `NavigationBar` component to address the issue of the "Map" navigation button protruding awkwardly from the bar. 

Key changes:
1.  **Refactored `NavigationBar.tsx`**: Removed the conditional logic for the "arc" effect and the ring element. Standardized the button layout using Flexbox (`flex-1`) to ensure all items are equal width and height.
2.  **Updated Styling**: Implemented a glassmorphism effect using Tailwind's `backdrop-blur-md` and `bg-white/90`. Added a subtle top border (`border-gray-200/60`) for better separation.
3.  **Improved UX**: Increased icon sizes to `h-6 w-6` for better touch targets and visibility. Refined the active vs. inactive states with clearer color differentiation and subtle scale animations.
4.  **CSS Cleanup**: Removed unused CSS classes (`nav-map-arc` and friends) from `app/globals.css`.

Verified the changes visually using Playwright screenshots and ensured existing tests pass. The new design is "User-friendly and Smart" as requested, providing a clean, unobtrusive navigation experience.

---
*PR created automatically by Jules for task [1581807617346276988](https://jules.google.com/task/1581807617346276988) started by @Yutodesuy*