### PR TITLE
test: add unit tests for favoriteShops and searchMapStorage

### DIFF
--- a/lib/favoriteShops.test.ts
+++ b/lib/favoriteShops.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  loadFavoriteShopIds,
+  saveFavoriteShopIds,
+  toggleFavoriteShopId,
+  FAVORITE_SHOPS_KEY,
+  FAVORITE_SHOPS_UPDATED_EVENT,
+} from './favoriteShops';
+
+describe('favoriteShops', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('loadFavoriteShopIds', () => {
+    it('returns empty array when storage is empty', () => {
+      expect(loadFavoriteShopIds()).toEqual([]);
+    });
+
+    it('returns parsed ids when storage has valid json', () => {
+      localStorage.setItem(FAVORITE_SHOPS_KEY, JSON.stringify([1, 2, 3]));
+      expect(loadFavoriteShopIds()).toEqual([1, 2, 3]);
+    });
+
+    it('normalizes values: converts strings to numbers, handles distinct values', () => {
+      // "2" -> 2
+      // null -> 0 (Number(null) === 0)
+      // Duplicate 1 -> filtered by Set
+      localStorage.setItem(FAVORITE_SHOPS_KEY, JSON.stringify([1, "2", null, 1, 3]));
+      expect(loadFavoriteShopIds()).toEqual([1, 2, 0, 3]);
+    });
+
+    it('filters out invalid numbers', () => {
+      // "abc" -> NaN
+      localStorage.setItem(FAVORITE_SHOPS_KEY, JSON.stringify([1, "abc", 3]));
+      expect(loadFavoriteShopIds()).toEqual([1, 3]);
+    });
+
+    it('returns empty array if JSON is invalid', () => {
+      localStorage.setItem(FAVORITE_SHOPS_KEY, '{invalid-json}');
+      expect(loadFavoriteShopIds()).toEqual([]);
+    });
+  });
+
+  describe('saveFavoriteShopIds', () => {
+    it('saves ids to localStorage', () => {
+      saveFavoriteShopIds([10, 20]);
+      expect(localStorage.getItem(FAVORITE_SHOPS_KEY)).toBe(JSON.stringify([10, 20]));
+    });
+
+    it('dispatches update event', () => {
+      const listener = vi.fn();
+      window.addEventListener(FAVORITE_SHOPS_UPDATED_EVENT, listener);
+
+      saveFavoriteShopIds([5]);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0][0] as CustomEvent;
+      expect(event.detail).toEqual([5]);
+
+      window.removeEventListener(FAVORITE_SHOPS_UPDATED_EVENT, listener);
+    });
+
+    it('normalizes inputs before saving', () => {
+      // @ts-expect-error testing runtime behavior with invalid inputs
+      saveFavoriteShopIds([1, "2", "abc"]);
+      expect(localStorage.getItem(FAVORITE_SHOPS_KEY)).toBe(JSON.stringify([1, 2]));
+    });
+  });
+
+  describe('toggleFavoriteShopId', () => {
+    it('adds id if not present', () => {
+      localStorage.setItem(FAVORITE_SHOPS_KEY, JSON.stringify([1, 2]));
+      const result = toggleFavoriteShopId(3);
+
+      expect(result).toEqual([1, 2, 3]);
+      expect(loadFavoriteShopIds()).toEqual([1, 2, 3]);
+    });
+
+    it('removes id if present', () => {
+      localStorage.setItem(FAVORITE_SHOPS_KEY, JSON.stringify([1, 2, 3]));
+      const result = toggleFavoriteShopId(2);
+
+      expect(result).toEqual([1, 3]);
+      expect(loadFavoriteShopIds()).toEqual([1, 3]);
+    });
+
+    it('handles empty initial state correctly', () => {
+      const result = toggleFavoriteShopId(100);
+      expect(result).toEqual([100]);
+      expect(loadFavoriteShopIds()).toEqual([100]);
+    });
+  });
+});

--- a/lib/searchMapStorage.test.ts
+++ b/lib/searchMapStorage.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  loadSearchMapPayload,
+  saveSearchMapPayload,
+  SEARCH_MAP_STORAGE_KEY,
+  type SearchMapPayload,
+} from './searchMapStorage';
+
+describe('searchMapStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('saveSearchMapPayload', () => {
+    it('saves payload to localStorage', () => {
+      const payload: SearchMapPayload = { ids: [1, 2], label: 'Test' };
+      saveSearchMapPayload(payload);
+      expect(localStorage.getItem(SEARCH_MAP_STORAGE_KEY)).toBe(JSON.stringify(payload));
+    });
+
+    it('handles potential storage errors gracefully', () => {
+        // Mock setItem to throw
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('QuotaExceeded');
+        });
+        const payload: SearchMapPayload = { ids: [1], label: 'Test' };
+        // Should not throw
+        expect(() => saveSearchMapPayload(payload)).not.toThrow();
+    });
+  });
+
+  describe('loadSearchMapPayload', () => {
+    it('returns null when storage is empty', () => {
+      expect(loadSearchMapPayload()).toBeNull();
+    });
+
+    it('returns payload when valid json exists', () => {
+      const payload = { ids: [1, 2], label: 'Test' };
+      localStorage.setItem(SEARCH_MAP_STORAGE_KEY, JSON.stringify(payload));
+      expect(loadSearchMapPayload()).toEqual(payload);
+    });
+
+    it('returns null when json is invalid', () => {
+      localStorage.setItem(SEARCH_MAP_STORAGE_KEY, '{invalid');
+      expect(loadSearchMapPayload()).toBeNull();
+    });
+
+    it('returns null when structure is invalid (missing ids)', () => {
+      localStorage.setItem(SEARCH_MAP_STORAGE_KEY, JSON.stringify({ label: 'Test' }));
+      expect(loadSearchMapPayload()).toBeNull();
+    });
+
+    it('returns null when structure is invalid (missing label)', () => {
+      localStorage.setItem(SEARCH_MAP_STORAGE_KEY, JSON.stringify({ ids: [1] }));
+      expect(loadSearchMapPayload()).toBeNull();
+    });
+
+    it('returns null when structure is invalid (ids not array)', () => {
+      localStorage.setItem(SEARCH_MAP_STORAGE_KEY, JSON.stringify({ ids: "bad", label: 'Test' }));
+      expect(loadSearchMapPayload()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## すること
- テスト未作成のコンポーネントに対する単体テストの追加
- 境界値テストおよび正常系・異常系パターンの網羅

## したこと
- `lib/favoriteShops.test.ts` および `lib/searchMapStorage.test.ts` に対するテストファイルを作成しました。
- 以下のテストケースを実装しました：
    - 入力が空の場合の挙動
    - 正常なデータが渡された場合の返り値検証
    - エラー発生時の例外処理確認（localStorageの読み書きエラーなど）

## 目的
- プロジェクトのテストカバレッジを向上させるため
- 将来的なリファクタリング時の安全性を担保するため
- バグの早期発見を促進するため

## 影響
- プロダクションコードへの変更はありません。
- CI/CDパイプラインの実行時間が若干増加する可能性があります。

---
*PR created automatically by Jules for task [2297370644747804615](https://jules.google.com/task/2297370644747804615) started by @Yutodesuy*