### PR TITLE
Add bottom-fixed CTA bar to consult page

### DIFF
--- a/app/(public)/consult/ConsultClient.tsx
+++ b/app/(public)/consult/ConsultClient.tsx
@@ -13,6 +13,7 @@ type ConsultClientProps = {
 
 export default function ConsultClient({ shops }: ConsultClientProps) {
   const [aiSuggestedShops, setAiSuggestedShops] = useState<Shop[]>([]);
+  const [hasInputProgress, setHasInputProgress] = useState(false);
   const searchParams = useSearchParams();
 
   const handleGrandmaAsk = useCallback(async (
@@ -82,6 +83,25 @@ export default function ConsultClient({ shops }: ConsultClientProps) {
     autoAskShopId || autoAskShopName
       ? { shopId: Number.isFinite(autoAskShopId) ? autoAskShopId : undefined, shopName: autoAskShopName }
       : undefined;
+  const hasSuggestedShops = aiSuggestedShops.length > 0;
+  const showSecondaryCta = hasInputProgress || hasSuggestedShops;
+
+  const handlePrimaryCtaClick = useCallback(() => {
+    const input = document.getElementById("consult-input") as HTMLInputElement | null;
+    if (!input) return;
+    input.scrollIntoView({ behavior: "smooth", block: "center" });
+    input.focus();
+  }, []);
+
+  const handleSecondaryCtaClick = useCallback(() => {
+    const targetId = hasSuggestedShops ? "consult-suggestions" : "consult-input";
+    const target = document.getElementById(targetId);
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (targetId === "consult-input" && target instanceof HTMLInputElement) {
+      target.focus();
+    }
+  }, [hasSuggestedShops]);
 
   return (
     <div
@@ -100,7 +120,7 @@ export default function ConsultClient({ shops }: ConsultClientProps) {
         }}
         aria-hidden="true"
       />
-      <main className="relative z-10 flex h-full w-full items-start justify-center px-3 pb-24 pt-20">
+      <main className="relative z-10 flex h-full w-full items-start justify-center px-3 pb-[calc(112px+env(safe-area-inset-bottom))] pt-20">
         <GrandmaChatter
           titleLabel="にちよさん"
           fullWidth
@@ -113,8 +133,30 @@ export default function ConsultClient({ shops }: ConsultClientProps) {
           onClear={() => setAiSuggestedShops([])}
           autoAskText={autoAskText}
           autoAskContext={autoAskContext}
+          onInputProgressChange={setHasInputProgress}
+          pageBottomOffset={96}
         />
       </main>
+      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-amber-100 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-xl items-center gap-3 px-4 py-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]">
+          <button
+            type="button"
+            onClick={handlePrimaryCtaClick}
+            className="flex-1 rounded-full bg-amber-600 px-4 py-3 text-base font-semibold text-white shadow-sm shadow-amber-200/70 transition hover:bg-amber-500"
+          >
+            相談を入力する
+          </button>
+          {showSecondaryCta && (
+            <button
+              type="button"
+              onClick={handleSecondaryCtaClick}
+              className="rounded-full border border-amber-200 bg-white px-4 py-3 text-sm font-semibold text-amber-700 shadow-sm transition hover:bg-amber-50"
+            >
+              {hasSuggestedShops ? "提案を見る" : "入力を続ける"}
+            </button>
+          )}
+        </div>
+      </div>
       <NavigationBar activeHref="/consult" position="absolute" />
     </div>
   );

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -48,6 +48,8 @@ type GrandmaChatterProps = {
   autoAskText?: string | null;
   autoAskContext?: { shopId?: number; shopName?: string };
   currentZoom?: number;
+  onInputProgressChange?: (hasProgress: boolean) => void;
+  pageBottomOffset?: number;
 };
 
 export default function GrandmaChatter({
@@ -74,6 +76,8 @@ export default function GrandmaChatter({
   autoAskText,
   autoAskContext,
   currentZoom,
+  onInputProgressChange,
+  pageBottomOffset,
 }: GrandmaChatterProps) {
   const pool = comments && comments.length > 0 ? comments : grandmaCommentPool;
   const [currentId, setCurrentId] = useState<string | undefined>(() => pool[0]?.id);
@@ -181,6 +185,15 @@ export default function GrandmaChatter({
     }
     setSmartContext({ placeholder, chip });
   }, []);
+
+  useEffect(() => {
+    const hasProgress =
+      askText.trim().length > 0 ||
+      !!selectedImageFile ||
+      hasUserAsked ||
+      chatMessages.length > 0;
+    onInputProgressChange?.(hasProgress);
+  }, [askText, selectedImageFile, hasUserAsked, chatMessages.length, onInputProgressChange]);
 
   useEffect(() => {
     if (!pool.length) return;
@@ -705,7 +718,7 @@ export default function GrandmaChatter({
     layout === "page"
       ? isKeyboardOpen
         ? Math.max(8, keyboardOffset + 28)
-        : 50
+        : pageBottomOffset ?? 50
       : undefined;
   const bubbleText = isChatOpen
     ? aiBubbleText
@@ -1161,7 +1174,10 @@ export default function GrandmaChatter({
             </button>
           )}
           {aiSuggestedShops && aiSuggestedShops.length > 0 && !isKeyboardOpen && !isChatOpen && (
-            <div className="rounded-2xl border-2 border-orange-300 bg-white/95 p-4 shadow-sm translate-y-[5px]">
+            <div
+              id="consult-suggestions"
+              className="rounded-2xl border-2 border-orange-300 bg-white/95 p-4 shadow-sm translate-y-[5px]"
+            >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="ai-label-playful text-lg text-pink-600">AIおすすめ</span>
@@ -1243,6 +1259,7 @@ export default function GrandmaChatter({
                   +
                 </button>
                 <input
+                  id="consult-input"
                   ref={inputRef}
                   type="text"
                   value={askText}


### PR DESCRIPTION
### Motivation

- Ensure the consult page always presents a primary CTA fixed to the bottom of the screen and reveal a secondary CTA when user input progress or AI suggestions exist so users can continue interaction easily.
- Prevent the CTA from overlapping chat input by adjusting page bottom spacing using Tailwind and a configurable bottom offset.

### Description

- Add a bottom-fixed CTA bar in `app/(public)/consult/ConsultClient.tsx` with a primary action (`相談を入力する`) and a conditional secondary action which shows when input progress or AI suggestions exist, plus smooth scroll/focus helpers for both actions.
- Track input progress via a new `hasInputProgress` state in `ConsultClient` and wire `onInputProgressChange` to receive progress updates from `GrandmaChatter`.
- Update `app/(public)/map/components/GrandmaChatter.tsx` to accept `onInputProgressChange` and `pageBottomOffset` props, compute `hasProgress` from `askText`, `selectedImageFile`, `hasUserAsked`, and `chatMessages`, and call the callback when that value changes.
- Add anchor IDs `consult-input` and `consult-suggestions` so CTA buttons can scroll/focus the input or suggestions sections, and use `pageBottomOffset` to avoid input/chat overlap with the fixed bar.

### Testing

- Ran `npm run build`; TypeScript compiled successfully but the build exited with a prerender error because Supabase environment variables are missing (build failed on prerendering `/login`).
- Started the dev server with `npm run dev` successfully and validated the UI by visiting `/consult` and taking a screenshot with Playwright saved to `artifacts/consult-cta-bar.png`.
- No automated unit tests exist or were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833b8a06fc83259e5c6a8e1b0b13a8)