### PR TITLE
Limit consult form validation to blur or submit

### DIFF
--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -99,6 +99,7 @@ export default function GrandmaChatter({
   const [selectedImageName, setSelectedImageName] = useState<string | null>(null);
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [selectedImagePreview, setSelectedImagePreview] = useState<string | null>(null);
+  const [shouldShowValidation, setShouldShowValidation] = useState(false);
   const [aiBubbleText, setAiBubbleText] = useState(
     grandmaAiInstructorLines[0] ?? "質問を入力してね。"
   );
@@ -440,6 +441,8 @@ export default function GrandmaChatter({
     }
   };
 
+  const shouldValidateInput = layout === "page";
+
   const handleAskSubmit = async (
     text?: string,
     context?: { shopId?: number; shopName?: string; source?: "suggestion" | "input" },
@@ -447,7 +450,12 @@ export default function GrandmaChatter({
   ) => {
     if (aiStatus === "thinking") return;
     const value = (text ?? askText).trim();
-    if (!value && !selectedImageFile) return;
+    if (!value && !selectedImageFile) {
+      if (shouldValidateInput) {
+        setShouldShowValidation(true);
+      }
+      return;
+    }
     if (openChat && !isChatOpen) {
       setIsChatOpen(true);
     }
@@ -457,6 +465,7 @@ export default function GrandmaChatter({
     setSelectedImageName(null);
     setSelectedImageFile(null);
     setSelectedImagePreview(null);
+    setShouldShowValidation(false);
     if (imageInputRef.current) {
       imageInputRef.current.value = "";
     }
@@ -516,11 +525,15 @@ export default function GrandmaChatter({
       setSelectedImageName(null);
       setSelectedImageFile(null);
       setSelectedImagePreview(null);
+      if (shouldValidateInput && !askText.trim()) {
+        setShouldShowValidation(true);
+      }
       return;
     }
     setSelectedImageName(file.name);
     setSelectedImageFile(file);
     setSelectedImagePreview(URL.createObjectURL(file));
+    setShouldShowValidation(false);
   };
 
   const handleAvatarPointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
@@ -1246,9 +1259,20 @@ export default function GrandmaChatter({
                   ref={inputRef}
                   type="text"
                   value={askText}
-                  onChange={(e) => setAskText(e.target.value)}
+                  onChange={(e) => {
+                    const nextValue = e.target.value;
+                    setAskText(nextValue);
+                    if (shouldValidateInput && nextValue.trim()) {
+                      setShouldShowValidation(false);
+                    }
+                  }}
                   onFocus={() => setIsInputFocused(true)}
-                  onBlur={() => setIsInputFocused(false)}
+                  onBlur={() => {
+                    setIsInputFocused(false);
+                    if (shouldValidateInput && !askText.trim() && !selectedImageFile) {
+                      setShouldShowValidation(true);
+                    }
+                  }}
                   disabled={aiStatus === "thinking"}
                   className={`w-full rounded-xl border px-3 py-2 text-base shadow-sm focus:outline-none focus:ring-2 ${
                     aiStatus === "thinking"
@@ -1286,6 +1310,11 @@ export default function GrandmaChatter({
               {selectedImageName && (
                 <div className="text-[11px] text-slate-600">
                   画像: {selectedImageName}
+                </div>
+              )}
+              {shouldShowValidation && (
+                <div className="text-[11px] font-semibold text-rose-500">
+                  質問内容を入力するか写真を選んでね。
                 </div>
               )}
             </div>


### PR DESCRIPTION
### Motivation
- The consult/chat input was showing validation too eagerly; validation should not appear on initial render and should be revealed progressively based on user actions.
- The consult page (`layout === "page"`) needs stricter UX so empty submissions show feedback only after the user blurs the field or tries to submit.

### Description
- Added a local boolean state `shouldShowValidation` and a `shouldValidateInput` check scoped to `layout === "page"` in `app/(public)/map/components/GrandmaChatter.tsx`.
- Updated `handleAskSubmit` to show validation when a submit occurs with empty text and no image, and to clear validation on successful submit.
- Updated the text input handlers so `onChange` clears validation when the user types, and `onBlur` sets validation when the field is empty and no image is selected.
- Updated `handleImagePick` to clear validation when an image is chosen and to set validation when an image is removed and the input is empty, and added a small validation message UI under the input.

### Testing
- Ran `npm run build`, which failed due to missing Supabase environment variables and therefore the production build could not complete (expected unrelated env issue).
- Started the dev server and ran an automated Playwright script that loaded `/consult` and produced a screenshot (`artifacts/consult-validation.png`), confirming the consult page UI renders and the new validation appears only after blur/submit as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833bcc9918832592e01db036a550b4)