### PR TITLE
Add /computer true/false quiz page with weighted question selection and local stats

### DIFF
--- a/app/(public)/computer/ComputerQuizClient.tsx
+++ b/app/(public)/computer/ComputerQuizClient.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { computerQuizItems, type ComputerQuizItem } from "./computerProblemData";
+
+type QuizHistoryEntry = {
+  id: string;
+  correct: boolean;
+  timestamp: number;
+};
+
+type QuizStats = {
+  correctCounts: Record<string, number>;
+  history: QuizHistoryEntry[];
+};
+
+const STORAGE_KEY = "computer-quiz-stats";
+
+const DEFAULT_STATS: QuizStats = {
+  correctCounts: {},
+  history: [],
+};
+
+const QUIZ_SIZES = [10, 20, 30] as const;
+
+const getStoredStats = (): QuizStats => {
+  if (typeof window === "undefined") {
+    return DEFAULT_STATS;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_STATS;
+    }
+    const parsed = JSON.parse(raw) as QuizStats;
+    return {
+      correctCounts: parsed.correctCounts ?? {},
+      history: parsed.history ?? [],
+    };
+  } catch (error) {
+    console.warn("Failed to load quiz stats.", error);
+    return DEFAULT_STATS;
+  }
+};
+
+const storeStats = (stats: QuizStats) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+};
+
+const getCorrectCount = (stats: QuizStats, id: string) =>
+  stats.correctCounts[id] ?? 0;
+
+const selectWeightedQuestions = (
+  items: ComputerQuizItem[],
+  total: number,
+  stats: QuizStats
+) => {
+  const pool = [...items];
+  const selected: ComputerQuizItem[] = [];
+
+  while (selected.length < total && pool.length > 0) {
+    const weights = pool.map((item) => 1 / (getCorrectCount(stats, item.id) + 1));
+    const weightSum = weights.reduce((sum, weight) => sum + weight, 0);
+    let target = Math.random() * weightSum;
+    let index = 0;
+    for (let i = 0; i < pool.length; i += 1) {
+      target -= weights[i];
+      if (target <= 0) {
+        index = i;
+        break;
+      }
+    }
+    selected.push(pool[index]);
+    pool.splice(index, 1);
+  }
+
+  return selected;
+};
+
+export default function ComputerQuizClient() {
+  const [stats, setStats] = useState<QuizStats>(DEFAULT_STATS);
+  const [quizSize, setQuizSize] = useState<(typeof QUIZ_SIZES)[number]>(10);
+  const [quizItems, setQuizItems] = useState<ComputerQuizItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [submitted, setSubmitted] = useState(false);
+  const [batchResults, setBatchResults] = useState<
+    { id: string; correct: boolean; explanation: string; isTrue: boolean }[]
+  >([]);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const stored = getStoredStats();
+    setStats(stored);
+  }, []);
+
+  const accuracy = useMemo(() => {
+    if (stats.history.length === 0) {
+      return 0;
+    }
+    const recent = stats.history.slice(-100);
+    const correctCount = recent.filter((entry) => entry.correct).length;
+    return Math.round((correctCount / recent.length) * 100);
+  }, [stats.history]);
+
+  const achievementRate = useMemo(() => {
+    const eligible = computerQuizItems.filter(
+      (item) => getCorrectCount(stats, item.id) <= 1
+    );
+    if (eligible.length === 0) {
+      return 0;
+    }
+    const achieved = eligible.filter(
+      (item) => getCorrectCount(stats, item.id) === 1
+    );
+    return Math.round((achieved.length / eligible.length) * 100);
+  }, [stats]);
+
+  const currentBatch = useMemo(
+    () => quizItems.slice(currentIndex, currentIndex + 4),
+    [quizItems, currentIndex]
+  );
+
+  const totalAnswered = useMemo(
+    () => Math.min(currentIndex, quizItems.length),
+    [currentIndex, quizItems.length]
+  );
+
+  const handleStart = useCallback(() => {
+    const selected = selectWeightedQuestions(
+      computerQuizItems,
+      quizSize,
+      stats
+    );
+    setQuizItems(selected);
+    setCurrentIndex(0);
+    setSelectedIds(new Set());
+    setSubmitted(false);
+    setBatchResults([]);
+    setScore(0);
+  }, [quizSize, stats]);
+
+  const toggleSelection = (id: string) => {
+    if (submitted) {
+      return;
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (submitted || currentBatch.length === 0) {
+      return;
+    }
+
+    const updatedStats: QuizStats = {
+      correctCounts: { ...stats.correctCounts },
+      history: [...stats.history],
+    };
+
+    let batchScore = 0;
+    const results = currentBatch.map((item) => {
+      const selected = selectedIds.has(item.id);
+      const correct = item.isTrue ? selected : !selected;
+      if (correct) {
+        batchScore += 1;
+        updatedStats.correctCounts[item.id] =
+          getCorrectCount(updatedStats, item.id) + 1;
+      }
+      updatedStats.history.push({
+        id: item.id,
+        correct,
+        timestamp: Date.now(),
+      });
+      return {
+        id: item.id,
+        correct,
+        explanation: item.explanation,
+        isTrue: item.isTrue,
+      };
+    });
+
+    updatedStats.history = updatedStats.history.slice(-100);
+    setStats(updatedStats);
+    storeStats(updatedStats);
+
+    setScore((prev) => prev + batchScore);
+    setBatchResults(results);
+    setSubmitted(true);
+  };
+
+  const handleNext = () => {
+    setCurrentIndex((prev) => prev + 4);
+    setSelectedIds(new Set());
+    setSubmitted(false);
+    setBatchResults([]);
+  };
+
+  const isFinished = quizItems.length > 0 && currentIndex >= quizItems.length;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5">
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+              学習ステータス
+            </p>
+            <h2 className="mt-2 text-lg font-bold text-gray-900">
+              直近100問の正解率: {accuracy}%
+            </h2>
+            <p className="mt-2 text-sm text-gray-600">
+              正解数が0〜1の問題で、正解数が1になっている割合: {achievementRate}%
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {QUIZ_SIZES.map((size) => (
+              <button
+                key={size}
+                type="button"
+                onClick={() => setQuizSize(size)}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  quizSize === size
+                    ? "bg-amber-600 text-white"
+                    : "bg-amber-50 text-amber-700 hover:bg-amber-100"
+                }`}
+              >
+                {size}問
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={handleStart}
+              className="rounded-full bg-gray-900 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
+            >
+              問題を解く
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {quizItems.length > 0 && !isFinished && (
+        <section className="space-y-4 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5">
+          <div className="flex items-center justify-between text-sm text-gray-500">
+            <span>
+              {totalAnswered + 1} -{" "}
+              {Math.min(currentIndex + currentBatch.length, quizItems.length)} /
+              {quizItems.length}
+            </span>
+            <span>現在の正解数: {score}</span>
+          </div>
+          <div className="space-y-4">
+            {currentBatch.map((item) => {
+              const selected = selectedIds.has(item.id);
+              const result = batchResults.find((entry) => entry.id === item.id);
+              return (
+                <div
+                  key={item.id}
+                  className={`rounded-xl border p-4 transition ${
+                    submitted
+                      ? result?.correct
+                        ? "border-emerald-200 bg-emerald-50"
+                        : "border-rose-200 bg-rose-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                >
+                  <label className="flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+                      checked={selected}
+                      onChange={() => toggleSelection(item.id)}
+                      disabled={submitted}
+                    />
+                    <div className="space-y-2">
+                      <p className="text-sm text-gray-900">{item.statement}</p>
+                      {submitted && result && (
+                        <div className="text-xs text-gray-700">
+                          <p>
+                            {result.correct ? "✅ 正解" : "❌ 不正解"}（この問題は{" "}
+                            {result.isTrue ? "正しい記述" : "誤った記述"}）
+                          </p>
+                          <p className="mt-1">{result.explanation}</p>
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+          <div className="flex flex-col gap-2">
+            {!submitted ? (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className="rounded-full bg-amber-600 px-5 py-2 text-sm font-semibold text-white hover:bg-amber-500"
+              >
+                答え合わせ
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleNext}
+                className="rounded-full bg-gray-900 px-5 py-2 text-sm font-semibold text-white hover:bg-gray-800"
+              >
+                次の4問へ
+              </button>
+            )}
+          </div>
+        </section>
+      )}
+
+      {isFinished && (
+        <section className="rounded-2xl bg-white p-5 text-center shadow-sm ring-1 ring-black/5">
+          <h3 className="text-lg font-bold text-gray-900">クイズ終了！</h3>
+          <p className="mt-2 text-sm text-gray-600">
+            正解数: {score} / {quizItems.length}
+          </p>
+          <button
+            type="button"
+            onClick={handleStart}
+            className="mt-4 rounded-full bg-amber-600 px-5 py-2 text-sm font-semibold text-white hover:bg-amber-500"
+          >
+            もう一度解く
+          </button>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/(public)/computer/computerProblemData.ts
+++ b/app/(public)/computer/computerProblemData.ts
@@ -1,0 +1,521 @@
+export type ComputerQuizItem = {
+  id: string;
+  statement: string;
+  isTrue: boolean;
+  explanation: string;
+};
+
+export const computerQuizItems: ComputerQuizItem[] = [
+  {
+    id: "server-true",
+    statement:
+      "サーバとは ネットワーク上で 何らかのサービスを提供する役割を持つデバイスやソフトウェアである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。サーバはサービス提供側として振る舞います。",
+  },
+  {
+    id: "server-false",
+    statement:
+      "サーバとは ネットワーク上でサービスを受け取る側のデバイスやソフトウェアである。",
+    isTrue: false,
+    explanation:
+      "誤りです。サービスを提供するのがサーバで、受け取る側はクライアントです。",
+  },
+  {
+    id: "client-true",
+    statement:
+      "クライアントとは サーバを利用するデバイスやソフトウェアである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。クライアントはサーバの機能を利用します。",
+  },
+  {
+    id: "request-response-true",
+    statement:
+      "リクエスト・レスポンス方式とは クライアントの要求に対して サーバが応答を返す通信方式である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。クライアントの要求に対してサーバが応答します。",
+  },
+  {
+    id: "request-response-false",
+    statement:
+      "リクエスト・レスポンス方式とは サーバが一方的に送信し続ける通信方式である。",
+    isTrue: false,
+    explanation:
+      "誤りです。リクエスト・レスポンスはクライアントの要求とサーバの応答が前提です。",
+  },
+  {
+    id: "host-true",
+    statement: "ホストとは IP アドレスが割り当てられたデバイスである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。IP アドレスを持つ端末がホストと呼ばれます。",
+  },
+  {
+    id: "protocol-true",
+    statement: "プロトコルとは ネットワークの決まり事をまとめたものである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。通信の取り決めがプロトコルです。",
+  },
+  {
+    id: "confidentiality-true",
+    statement:
+      "機密性の高いネットワークには 第 3 者に通信を盗聴されないよう 暗号化する機能が求められる。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。機密性の確保には暗号化が有効です。",
+  },
+  {
+    id: "confidentiality-false",
+    statement:
+      "機密性の高いネットワークには 通信経路の冗長化だけが求められる。",
+    isTrue: false,
+    explanation:
+      "誤りです。冗長化は可用性向上の手段であり、機密性には暗号化が必要です。",
+  },
+  {
+    id: "availability-true",
+    statement:
+      "可用性の高いネットワークには 回線の一部に障害が発生しても 送信先と通信できる機能が求められる。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。障害時も通信できることが可用性です。",
+  },
+  {
+    id: "star-true",
+    statement:
+      "スター型のネットワークとは 中心となるデバイスから 放射状に他のデバイスが接続されたものを指す。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。中心装置から放射状に接続される構成です。",
+  },
+  {
+    id: "star-false",
+    statement:
+      "スター型のネットワークとは 中心となるデバイスを持たない構成を指す。",
+    isTrue: false,
+    explanation:
+      "誤りです。中心装置があるのがスター型です。",
+  },
+  {
+    id: "mesh-true",
+    statement:
+      "メッシュ型のネットワークとは デバイス同士が対等に接続され 中心が存在しないものを指す。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。メッシュは中心に依存しない構成です。",
+  },
+  {
+    id: "mesh-false",
+    statement:
+      "メッシュ型のネットワークとは すべての通信が中央装置を必ず経由する構成である。",
+    isTrue: false,
+    explanation:
+      "誤りです。中央装置を前提にしないのがメッシュ型です。",
+  },
+  {
+    id: "unicast-true",
+    statement: "ユニキャストとは 送信元が 特定の 1 つの端末にデータを送ることである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。宛先が 1 つの通信がユニキャストです。",
+  },
+  {
+    id: "unicast-false",
+    statement:
+      "ユニキャストとは 送信元が 同じネットワーク上のすべての端末にデータを送ることである。",
+    isTrue: false,
+    explanation:
+      "誤りです。全端末に送るのはブロードキャストです。",
+  },
+  {
+    id: "broadcast-true",
+    statement:
+      "ブロードキャストとは 送信元が 同じネットワーク上のすべての端末にデータを送ることである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。ブロードキャストは全端末への送信です。",
+  },
+  {
+    id: "tcpip-true",
+    statement:
+      "TCP/IP とは インターネットで標準的に使用されているプロトコルの集合である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。インターネット標準のプロトコル群です。",
+  },
+  {
+    id: "osi-true",
+    statement:
+      "プロトコルの機能の分類には しばしば 7 層構造の OSI 参照モデル が使われる。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。OSI 参照モデルは 7 層構造です。",
+  },
+  {
+    id: "tcp-layer-true",
+    statement: "TCP は OSI 参照モデルの L4 に分類されるプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。TCP はトランスポート層のプロトコルです。",
+  },
+  {
+    id: "tcp-layer-false",
+    statement: "TCP は OSI 参照モデルの L3 に分類されるプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。TCP は L4（トランスポート層）です。",
+  },
+  {
+    id: "ip-layer-true",
+    statement: "IP は OSI 参照モデルの L3 に分類されるプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。IP はネットワーク層のプロトコルです。",
+  },
+  {
+    id: "ip-layer-false",
+    statement: "IP は OSI 参照モデルの L4 に分類されるプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。IP は L3（ネットワーク層）です。",
+  },
+  {
+    id: "ethernet-layer-true",
+    statement: "Ethernet は OSI 参照モデルの L2 に分類されるプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。Ethernet はデータリンク層のプロトコルです。",
+  },
+  {
+    id: "ethernet-layer-false",
+    statement: "Ethernet は OSI 参照モデルの L3 に分類されるプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。Ethernet は L2（データリンク層）です。",
+  },
+  {
+    id: "pdu-true",
+    statement: "PDU とは 各通信プロトコル層で送受信されるデータの単位を指す。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。PDU は各層でのデータ単位です。",
+  },
+  {
+    id: "l7-message-true",
+    statement: "L7 では，HTTP や SMTP などのプロトコルによって メッセージ が生成される。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。アプリケーション層でメッセージが作られます。",
+  },
+  {
+    id: "l4-segment-true",
+    statement:
+      "L4 では，メッセージに TCP や UDP のヘッダ が付加されセグメント（またはデータグラム）が生成される。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。L4 でセグメントやデータグラムが作られます。",
+  },
+  {
+    id: "l3-packet-true",
+    statement:
+      "L3 では，セグメント（またはデータグラム）などに IP ヘッダ が付加され，パケットが生成される。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。IP ヘッダ追加でパケットになります。",
+  },
+  {
+    id: "l2-frame-true",
+    statement:
+      "L2 では，IP パケットなどに ヘッダとトレーラ が付加され，フレームが生成される。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。L2 でフレームが生成されます。",
+  },
+  {
+    id: "plaintext-true",
+    statement:
+      "平文とは 意味の分かるデータであり それと相互に変換可能な意味不明のデータを暗号文と呼ぶ。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。平文と暗号文は相互に変換可能です。",
+  },
+  {
+    id: "hash-false",
+    statement: "ハッシュ化とは 元のデータに復元できる形に変換することである。",
+    isTrue: false,
+    explanation:
+      "誤りです。ハッシュ化は原則として元に戻せない変換です。",
+  },
+  {
+    id: "hash-true",
+    statement:
+      "ハッシュ化とは 元のデータに復元できない形かつ一定の長さの形に変換することである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。ハッシュ値は一定長で不可逆です。",
+  },
+  {
+    id: "symmetric-true",
+    statement:
+      "共通鍵暗号方式とは 暗号化・復号に用いる 1 種類の鍵を 送信元と先で共有する 1 対 1 の暗号方式である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。共通鍵暗号は同じ鍵を共有します。",
+  },
+  {
+    id: "symmetric-false",
+    statement:
+      "共通鍵暗号方式とは 2 種類の鍵を使い 公開鍵だけを共有する暗号方式である。",
+    isTrue: false,
+    explanation:
+      "誤りです。2 種類の鍵を使うのは公開鍵暗号方式です。",
+  },
+  {
+    id: "asymmetric-true",
+    statement:
+      "公開鍵暗号方式とは 2 本 1 組の暗号鍵と復号鍵の一方を 送信元と先で共有する 1 対多の暗号方式である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。公開鍵暗号は鍵ペアの片方を共有します。",
+  },
+  {
+    id: "asymmetric-false",
+    statement:
+      "公開鍵暗号方式では 復号鍵を第三者にも公開して使う。",
+    isTrue: false,
+    explanation:
+      "誤りです。公開するのは暗号鍵（公開鍵）で、復号鍵（秘密鍵）は公開しません。",
+  },
+  {
+    id: "smtp-true",
+    statement:
+      "SMTP とは，主に「電子メールをメールサーバからメールサーバへと転送する手順」を示したプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。SMTP はメールの送信・転送に使われます。",
+  },
+  {
+    id: "smtp-false",
+    statement:
+      "SMTP は メールサーバ上のメールを確認するためのプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。メールを確認するのは POP3 や IMAP です。",
+  },
+  {
+    id: "pop3-true",
+    statement:
+      "「POP3」や「IMAP」とは，メールサーバ上の電子メールを，メーラで確認するためのプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。POP3/IMAP はメール取得に使われます。",
+  },
+  {
+    id: "http-true",
+    statement:
+      "HTTP は，HTML ファイルなど，Web ページを構成するファイルを転送するためのプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。HTTP は Web コンテンツ転送のプロトコルです。",
+  },
+  {
+    id: "http-port-true",
+    statement: "HTTP サーバにリクエストする際は，送信先ポート番号に 80 番が使われる。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。HTTP の標準ポートは 80 番です。",
+  },
+  {
+    id: "http-port-false",
+    statement: "HTTP サーバにリクエストする際は，送信先ポート番号に 443 番が使われる。",
+    isTrue: false,
+    explanation:
+      "誤りです。443 番は HTTPS の標準ポートで、HTTP は 80 番です。",
+  },
+  {
+    id: "https-true",
+    statement: "HTTP 通信を SSL/TLS によって暗号化したものを HTTPS と呼ぶ。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。HTTPS は暗号化された HTTP です。",
+  },
+  {
+    id: "https-false",
+    statement: "HTTPS は HTTP を圧縮するためのプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。HTTPS は暗号化のために SSL/TLS を使います。",
+  },
+  {
+    id: "get-true",
+    statement:
+      "HTTP リクエストの GET メソッドは，指定した URL のデータを取得するためのメソッドである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。GET は取得が目的のメソッドです。",
+  },
+  {
+    id: "post-false",
+    statement:
+      "HTTP リクエストの POST メソッドは，URL の内容を閲覧するためだけのメソッドである。",
+    isTrue: false,
+    explanation:
+      "誤りです。POST はデータ送信に利用されるメソッドです。",
+  },
+  {
+    id: "status-200-true",
+    statement:
+      "HTTP レスポンスのステータスコードの内 200 番台は，リクエストが正常に処理されたことを示す。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。2xx は成功を表します。",
+  },
+  {
+    id: "status-400-false",
+    statement:
+      "HTTP レスポンスのステータスコードの内 400 番台は，リクエストが正常に処理されたことを示す。",
+    isTrue: false,
+    explanation:
+      "誤りです。4xx はクライアント側のエラーを示します。",
+  },
+  {
+    id: "ssh-true",
+    statement:
+      "SSH は 暗号化された通信を使って サーバを遠隔操作するためのプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。SSH は安全な遠隔操作に使われます。",
+  },
+  {
+    id: "ssh-false",
+    statement: "SSH は GUI だけを使った操作をサポートするプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。SSH は主に CUI のコマンド入出力を扱います。",
+  },
+  {
+    id: "icmp-true",
+    statement:
+      "ICMP のエコー要求とエコー応答を利用して通信の到達確認を行うコマンドが ping である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。ping は ICMP エコーを使います。",
+  },
+  {
+    id: "icmp-false",
+    statement: "ICMP は ファイル転送を行うためのプロトコルである。",
+    isTrue: false,
+    explanation:
+      "誤りです。ICMP は主にエラー通知や到達確認に使われます。",
+  },
+  {
+    id: "dhcp-true",
+    statement:
+      "DHCP は，ネットワークに接続されたデバイスに対して IP アドレスを自動で割り当てるプロトコルである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。DHCP は IP アドレスの自動割当てを行います。",
+  },
+  {
+    id: "dhcp-false",
+    statement: "DHCP の各メッセージは TCP のセグメントに格納されて送受信される。",
+    isTrue: false,
+    explanation:
+      "誤りです。DHCP は UDP のデータグラムで送受信されます。",
+  },
+  {
+    id: "nat-true",
+    statement:
+      "NAT / NAPT は ルータが LAN の内側からのリクエストに対して、プライベート IP アドレスとグローバル IP アドレスを変換する方式である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。NAT はアドレス変換を行います。",
+  },
+  {
+    id: "nat-false",
+    statement: "NAT は MAC アドレス同士を変換する方式である。",
+    isTrue: false,
+    explanation:
+      "誤りです。NAT は IP アドレスを変換する方式です。",
+  },
+  {
+    id: "mac-true",
+    statement: "MAC アドレスは 長さが 48bit のビット列である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。MAC アドレスは 48bit です。",
+  },
+  {
+    id: "mac-false",
+    statement: "MAC アドレスは 長さが 32bit のビット列である。",
+    isTrue: false,
+    explanation:
+      "誤りです。MAC アドレスは 48bit です。",
+  },
+  {
+    id: "l2-switch-true",
+    statement:
+      "L2 スイッチは フレーム中の宛先 MAC アドレスを参考に 転送先のポートを決定する。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。L2 スイッチは MAC アドレスで転送先を選びます。",
+  },
+  {
+    id: "l2-switch-false",
+    statement:
+      "L2 スイッチは IP アドレスだけを見て転送先のポートを決定する。",
+    isTrue: false,
+    explanation:
+      "誤りです。L2 スイッチは MAC アドレスで転送先を決めます。",
+  },
+  {
+    id: "ethernet-header-true",
+    statement: "Ethernet のヘッダの長さは，固定長の 14 オクテットである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。Ethernet ヘッダは 14 バイトです。",
+  },
+  {
+    id: "ethernet-header-false",
+    statement: "Ethernet のヘッダの長さは，固定長の 18 オクテットである。",
+    isTrue: false,
+    explanation:
+      "誤りです。Ethernet ヘッダは 14 オクテットです。",
+  },
+  {
+    id: "payload-true",
+    statement:
+      "Ethernet のペイロード（データの本体）の長さは，可変長で最大 1500 オクテットである。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。Ethernet のペイロード最大は 1500 バイトです。",
+  },
+  {
+    id: "payload-false",
+    statement:
+      "Ethernet のペイロードの長さは，最大 500 オクテットに固定されている。",
+    isTrue: false,
+    explanation:
+      "誤りです。Ethernet のペイロード最大は 1500 オクテットです。",
+  },
+  {
+    id: "fcs-true",
+    statement:
+      "フレームの末尾に付与される FCS は，フレームの破損を確認するための情報である。",
+    isTrue: true,
+    explanation:
+      "正しい記述です。FCS は誤り検出のための情報です。",
+  },
+  {
+    id: "fcs-false",
+    statement:
+      "フレームの末尾に付与される FCS は，フレームを暗号化するための情報である。",
+    isTrue: false,
+    explanation:
+      "誤りです。FCS は誤り検出のための情報で、暗号化ではありません。",
+  },
+];

--- a/app/(public)/computer/page.tsx
+++ b/app/(public)/computer/page.tsx
@@ -1,0 +1,34 @@
+import NavigationBar from "../../components/NavigationBar";
+import ComputerQuizClient from "./ComputerQuizClient";
+
+export const metadata = {
+  title: "コンピュータ正誤クイズ | nicchyo",
+  description: "コンピュータネットワークの正誤クイズに挑戦できます。",
+};
+
+export default function ComputerPage() {
+  return (
+    <main className="min-h-screen bg-[#FDFBF7] pb-24 text-gray-900">
+      <div className="bg-gradient-to-b from-amber-100/50 to-transparent pb-6 pt-safe-top">
+        <div className="mx-auto flex max-w-lg flex-col px-4 pt-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900">
+              コンピュータ正誤クイズ
+            </h1>
+          </div>
+          <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-black/5">
+            <p className="text-sm leading-relaxed text-gray-600">
+              4問ずつ出題される正誤クイズです。正しい記述だけチェックし、答え合わせで解説も確認できます。
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-lg px-4">
+        <ComputerQuizClient />
+      </div>
+
+      <NavigationBar />
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive correct/incorrect quiz derived from the supplied `computerProblem.docx` content with intentionally incorrect variants for learning and explanation. 
- Present questions in 4-question batches and support full quizzes of `10`, `20`, and `30` questions with random selection and prioritization of weak items. 
- Track per-question correct counts and recent performance so learners can focus on items they often miss and see summarized progress (last 100 answers and achievement rate). 

### Description
- Added a question bank `app/(public)/computer/computerProblemData.ts` containing true/false statements and explanations (includes intentionally incorrect variants). 
- Implemented a client-side quiz component `app/(public)/computer/ComputerQuizClient.tsx` that: selects weighted random questions favoring items with lower correct counts, presents 4-question batches, lets the user check only correct statements, reveals per-question correctness with explanations on submit, persists stats to `localStorage`, and shows last-100 accuracy and the achievement rate for items with correct counts 0→1. 
- Added the page shell `app/(public)/computer/page.tsx` with the UI header, `10/20/30` selection buttons, a `問題を解く` button, and integrates `ComputerQuizClient`. 
- Included a screenshot artifact captured during development to show the UI state. 

### Testing
- Started the dev server with `npm run dev` and loaded `/computer`, which returned `200` and the new quiz UI rendered successfully. 
- Captured a screenshot of the running page using a Playwright script (artifact: `artifacts/computer-quiz.png`). 
- Ran `npm run build`, which failed during prerender of `/login` due to missing Supabase environment variables, so a full production build could not complete (this is unrelated to the new client-side quiz which is client-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843d8e3d488325bcf629ceeaf79cc7)