### PR TITLE
Replace hardcoded user name in UserProfileButton

### DIFF
--- a/app/(public)/map/__tests__/UserProfileButton.test.tsx
+++ b/app/(public)/map/__tests__/UserProfileButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import UserProfileButton from '../components/UserProfileButton';
+import { useAuth } from '@/lib/auth/AuthContext';
+
+// Mock the module
+vi.mock('@/lib/auth/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('UserProfileButton', () => {
+  it('renders user name and email when logged in', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        avatarUrl: null,
+      },
+    });
+
+    render(<UserProfileButton />);
+
+    // Open the menu
+    const toggleButton = screen.getByRole('button', { name: 'ユーザーメニューを開く' });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText('Test User')).toBeDefined();
+    expect(screen.getByText('test@example.com')).toBeDefined();
+  });
+
+  it('renders "ゲストさん" when not logged in', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      user: null,
+    });
+
+    render(<UserProfileButton />);
+
+    // Open the menu
+    const toggleButton = screen.getByRole('button', { name: 'ユーザーメニューを開く' });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText('ゲストさん')).toBeDefined();
+  });
+});

--- a/app/(public)/map/components/UserProfileButton.tsx
+++ b/app/(public)/map/components/UserProfileButton.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useCallback } from "react";
 import Link from "next/link";
+import { useAuth } from "@/lib/auth/AuthContext";
 
 export default function UserProfileButton() {
   const [open, setOpen] = useState(false);
+  const { user } = useAuth();
 
   const toggleMenu = useCallback(() => {
     setOpen((prev) => !prev);
@@ -19,21 +21,37 @@ export default function UserProfileButton() {
       <button
         type="button"
         onClick={toggleMenu}
-        className="flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/90 text-lg shadow-lg shadow-amber-200/60 transition hover:-translate-y-0.5 hover:shadow-xl active:scale-95"
+        className="flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/90 text-lg shadow-lg shadow-amber-200/60 transition hover:-translate-y-0.5 hover:shadow-xl active:scale-95 overflow-hidden"
         aria-label="ユーザーメニューを開く"
       >
-        👤
+        {user?.avatarUrl ? (
+          <img
+            src={user.avatarUrl}
+            alt={user.name}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          "👤"
+        )}
       </button>
 
       {open && (
         <div className="mt-2 w-64 rounded-2xl border border-amber-100 bg-white/95 p-3 text-sm text-gray-800 shadow-2xl backdrop-blur">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-xl">
-              👤
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-xl overflow-hidden">
+              {user?.avatarUrl ? (
+                <img
+                  src={user.avatarUrl}
+                  alt={user.name}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                "👤"
+              )}
             </div>
-            <div>
-              <p className="text-sm font-semibold">市場さん（仮）</p>
-              <p className="text-xs text-gray-500">kochi_sunday@example.com</p>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold truncate">{user?.name || "ゲストさん"}</p>
+              <p className="text-xs text-gray-500 truncate">{user?.email || ""}</p>
             </div>
           </div>
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Replaced the hardcoded placeholder name "市場さん（仮）" in `app/(public)/map/components/UserProfileButton.tsx` with dynamic user data from `AuthContext`.
Also added a unit test to verify the component renders correctly for both logged-in and logged-out states.
Updated `vitest.config.ts` to correctly resolve `@/` aliases for tests.

---
*PR created automatically by Jules for task [8484576116057283967](https://jules.google.com/task/8484576116057283967) started by @Yutodesuy*