### PR TITLE
Add seller login page and dynamic /shops[shopCode] routing with shop code normalization

### DIFF
--- a/app/(public)/shops/[shopCode]/page.tsx
+++ b/app/(public)/shops/[shopCode]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 
-import { formatShopIdToCode, normalizeShopsPathSegmentToId } from "@/lib/shops/route";
+import { formatShopIdToCode, normalizeShopCodeToId } from "@/lib/shops/route";
 
 type ShopPageProps = {
   params: Promise<{
@@ -10,7 +10,7 @@ type ShopPageProps = {
 
 export default async function ShopPage({ params }: ShopPageProps) {
   const { shopCode } = await params;
-  const shopId = normalizeShopsPathSegmentToId(shopCode);
+  const shopId = normalizeShopCodeToId(shopCode);
 
   if (shopId === null) {
     notFound();

--- a/app/(public)/shops[shopCode]/page.tsx
+++ b/app/(public)/shops[shopCode]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+
+import { formatShopIdToCode, normalizeShopCodeToId } from "@/lib/shops/route";
+
+type ShopPageProps = {
+  params: Promise<{
+    shopCode: string;
+  }>;
+};
+
+export default async function ShopPage({ params }: ShopPageProps) {
+  const { shopCode } = await params;
+  const shopId = normalizeShopCodeToId(shopCode);
+
+  if (shopId === null) {
+    notFound();
+  }
+
+  const normalizedCode = formatShopIdToCode(shopId);
+
+  if (normalizedCode === null) {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-2xl items-center px-4 py-12">
+      <section className="w-full rounded-2xl border border-[#E5E7EB] bg-white p-6 shadow-sm">
+        <p className="text-sm font-semibold text-[#0284C7]">出店者ページ</p>
+        <h1 className="mt-2 text-2xl font-bold text-[#111827]">店舗コード {normalizedCode}</h1>
+        <p className="mt-3 text-sm text-[#4B5563]">
+          3桁コードを数値IDへ正規化しました。内部ID: <span className="font-semibold">{shopId}</span>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/(public)/shops[shopCode]/page.tsx
+++ b/app/(public)/shops[shopCode]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 
-import { formatShopIdToCode, normalizeShopCodeToId } from "@/lib/shops/route";
+import { formatShopIdToCode, normalizeShopsPathSegmentToId } from "@/lib/shops/route";
 
 type ShopPageProps = {
   params: Promise<{
@@ -10,7 +10,7 @@ type ShopPageProps = {
 
 export default async function ShopPage({ params }: ShopPageProps) {
   const { shopCode } = await params;
-  const shopId = normalizeShopCodeToId(shopCode);
+  const shopId = normalizeShopsPathSegmentToId(shopCode);
 
   if (shopId === null) {
     notFound();

--- a/app/(public)/shopslogin/page.tsx
+++ b/app/(public)/shopslogin/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+
+export default function ShopsLoginPage() {
+  return (
+    <main className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-md items-center px-4 py-12">
+      <section className="w-full rounded-2xl border border-[#E5E7EB] bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold text-[#1F2937]">出店者ログイン</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4B5563]">
+          管理画面にアクセスするため、店舗コードとパスワードを入力してください。
+        </p>
+
+        <form className="mt-6 space-y-4" aria-label="出店者ログインフォーム">
+          <div>
+            <label htmlFor="shopCode" className="mb-1 block text-sm font-medium text-[#374151]">
+              店舗コード（3桁）
+            </label>
+            <input
+              id="shopCode"
+              name="shopCode"
+              inputMode="numeric"
+              maxLength={3}
+              placeholder="例: 001"
+              className="w-full rounded-lg border border-[#D1D5DB] px-3 py-2 text-sm focus:border-[#0EA5E9] focus:outline-none focus:ring-2 focus:ring-[#BAE6FD]"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-[#374151]">
+              パスワード
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="パスワードを入力"
+              className="w-full rounded-lg border border-[#D1D5DB] px-3 py-2 text-sm focus:border-[#0EA5E9] focus:outline-none focus:ring-2 focus:ring-[#BAE6FD]"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-[#0EA5E9] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#0284C7]"
+          >
+            ログイン
+          </button>
+        </form>
+
+        <div className="mt-4 text-center text-sm text-[#6B7280]">
+          テスト導線: <Link href="/shops001" className="text-[#0284C7] underline">/shops001</Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/lib/shops/route.test.ts
+++ b/lib/shops/route.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  formatShopIdToCode,
-  normalizeShopCodeToId,
-  normalizeShopsPathSegmentToId,
-} from "./route";
+import { formatShopIdToCode, normalizeShopCodeToId } from "./route";
 
 describe("normalizeShopCodeToId", () => {
   it("3桁コードを数値IDに変換する", () => {
@@ -18,20 +14,7 @@ describe("normalizeShopCodeToId", () => {
     expect(normalizeShopCodeToId("301")).toBeNull();
     expect(normalizeShopCodeToId("abc")).toBeNull();
     expect(normalizeShopCodeToId("1")).toBeNull();
-  });
-});
-
-describe("normalizeShopsPathSegmentToId", () => {
-  it("/shops001 形式のセグメントを数値IDに変換する", () => {
-    expect(normalizeShopsPathSegmentToId("shops001")).toBe(1);
-    expect(normalizeShopsPathSegmentToId("shops300")).toBe(300);
-  });
-
-  it("不正なセグメントは null を返す", () => {
-    expect(normalizeShopsPathSegmentToId("shops000")).toBeNull();
-    expect(normalizeShopsPathSegmentToId("shops301")).toBeNull();
-    expect(normalizeShopsPathSegmentToId("shopsabc")).toBeNull();
-    expect(normalizeShopsPathSegmentToId("001")).toBeNull();
+    expect(normalizeShopCodeToId("shops001")).toBeNull();
   });
 });
 

--- a/lib/shops/route.test.ts
+++ b/lib/shops/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { formatShopIdToCode, normalizeShopCodeToId } from "./route";
+
+describe("normalizeShopCodeToId", () => {
+  it("3桁コードを数値IDに変換する", () => {
+    expect(normalizeShopCodeToId("001")).toBe(1);
+    expect(normalizeShopCodeToId("010")).toBe(10);
+    expect(normalizeShopCodeToId("300")).toBe(300);
+  });
+
+  it("範囲外や不正形式は null を返す", () => {
+    expect(normalizeShopCodeToId("000")).toBeNull();
+    expect(normalizeShopCodeToId("301")).toBeNull();
+    expect(normalizeShopCodeToId("abc")).toBeNull();
+    expect(normalizeShopCodeToId("1")).toBeNull();
+  });
+});
+
+describe("formatShopIdToCode", () => {
+  it("数値IDを3桁コードへ変換する", () => {
+    expect(formatShopIdToCode(1)).toBe("001");
+    expect(formatShopIdToCode(300)).toBe("300");
+  });
+
+  it("範囲外や整数以外は null を返す", () => {
+    expect(formatShopIdToCode(0)).toBeNull();
+    expect(formatShopIdToCode(301)).toBeNull();
+    expect(formatShopIdToCode(1.2)).toBeNull();
+  });
+});

--- a/lib/shops/route.test.ts
+++ b/lib/shops/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { formatShopIdToCode, normalizeShopCodeToId } from "./route";
+import {
+  formatShopIdToCode,
+  normalizeShopCodeToId,
+  normalizeShopsPathSegmentToId,
+} from "./route";
 
 describe("normalizeShopCodeToId", () => {
   it("3桁コードを数値IDに変換する", () => {
@@ -14,6 +18,20 @@ describe("normalizeShopCodeToId", () => {
     expect(normalizeShopCodeToId("301")).toBeNull();
     expect(normalizeShopCodeToId("abc")).toBeNull();
     expect(normalizeShopCodeToId("1")).toBeNull();
+  });
+});
+
+describe("normalizeShopsPathSegmentToId", () => {
+  it("/shops001 形式のセグメントを数値IDに変換する", () => {
+    expect(normalizeShopsPathSegmentToId("shops001")).toBe(1);
+    expect(normalizeShopsPathSegmentToId("shops300")).toBe(300);
+  });
+
+  it("不正なセグメントは null を返す", () => {
+    expect(normalizeShopsPathSegmentToId("shops000")).toBeNull();
+    expect(normalizeShopsPathSegmentToId("shops301")).toBeNull();
+    expect(normalizeShopsPathSegmentToId("shopsabc")).toBeNull();
+    expect(normalizeShopsPathSegmentToId("001")).toBeNull();
   });
 });
 

--- a/lib/shops/route.ts
+++ b/lib/shops/route.ts
@@ -2,6 +2,7 @@ export const MIN_SHOP_ID = 1;
 export const MAX_SHOP_ID = 300;
 
 const SHOP_CODE_PATTERN = /^\d{3}$/;
+const SHOPS_PATH_SEGMENT_PATTERN = /^shops(\d{3})$/;
 
 export function normalizeShopCodeToId(shopCode: string): number | null {
   if (!SHOP_CODE_PATTERN.test(shopCode)) {
@@ -15,6 +16,16 @@ export function normalizeShopCodeToId(shopCode: string): number | null {
   }
 
   return shopId;
+}
+
+export function normalizeShopsPathSegmentToId(shopSegment: string): number | null {
+  const match = shopSegment.match(SHOPS_PATH_SEGMENT_PATTERN);
+
+  if (!match) {
+    return null;
+  }
+
+  return normalizeShopCodeToId(match[1]);
 }
 
 export function formatShopIdToCode(shopId: number): string | null {

--- a/lib/shops/route.ts
+++ b/lib/shops/route.ts
@@ -2,7 +2,6 @@ export const MIN_SHOP_ID = 1;
 export const MAX_SHOP_ID = 300;
 
 const SHOP_CODE_PATTERN = /^\d{3}$/;
-const SHOPS_PATH_SEGMENT_PATTERN = /^shops(\d{3})$/;
 
 export function normalizeShopCodeToId(shopCode: string): number | null {
   if (!SHOP_CODE_PATTERN.test(shopCode)) {
@@ -16,16 +15,6 @@ export function normalizeShopCodeToId(shopCode: string): number | null {
   }
 
   return shopId;
-}
-
-export function normalizeShopsPathSegmentToId(shopSegment: string): number | null {
-  const match = shopSegment.match(SHOPS_PATH_SEGMENT_PATTERN);
-
-  if (!match) {
-    return null;
-  }
-
-  return normalizeShopCodeToId(match[1]);
 }
 
 export function formatShopIdToCode(shopId: number): string | null {

--- a/lib/shops/route.ts
+++ b/lib/shops/route.ts
@@ -1,0 +1,26 @@
+export const MIN_SHOP_ID = 1;
+export const MAX_SHOP_ID = 300;
+
+const SHOP_CODE_PATTERN = /^\d{3}$/;
+
+export function normalizeShopCodeToId(shopCode: string): number | null {
+  if (!SHOP_CODE_PATTERN.test(shopCode)) {
+    return null;
+  }
+
+  const shopId = Number.parseInt(shopCode, 10);
+
+  if (Number.isNaN(shopId) || shopId < MIN_SHOP_ID || shopId > MAX_SHOP_ID) {
+    return null;
+  }
+
+  return shopId;
+}
+
+export function formatShopIdToCode(shopId: number): string | null {
+  if (!Number.isInteger(shopId) || shopId < MIN_SHOP_ID || shopId > MAX_SHOP_ID) {
+    return null;
+  }
+
+  return shopId.toString().padStart(3, "0");
+}

--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,16 @@ const nextConfig = {
   // パフォーマンス最適化
   poweredByHeader: false, // X-Powered-By ヘッダーを無効化（セキュリティ向上）
 
+  // /shops001 -> /shops/001 へ内部リライト
+  async rewrites() {
+    return [
+      {
+        source: '/shops:shopCode(\\d{3})',
+        destination: '/shops/:shopCode',
+      },
+    ];
+  },
+
   // セキュリティヘッダー
   async headers() {
     return [


### PR DESCRIPTION
### Motivation
- Provide a dedicated login UI for sellers and avoid creating 300 static pages by supporting a single dynamic route for shop pages.
- Centralize shop code normalization and validation to ensure consistent handling of 3-digit shop codes and enforce the allowed range (001–300).
- Return a 404 for invalid shop codes to prevent invalid pages from being served and surface errors early.

### Description
- Added a new seller login page at `app/(public)/shopslogin/page.tsx` with fields for 3-digit shop code and password and a test link to `/shops001`.
- Implemented a dynamic route `app/(public)/shops[shopCode]/page.tsx` that accepts `shopCode` (3-digit string), normalizes it to a numeric ID, and calls `notFound()` for invalid values.
- Added shared helpers in `lib/shops/route.ts`: `normalizeShopCodeToId` performs 3-digit format + range checks (1–300) and `formatShopIdToCode` converts numeric IDs back to zero-padded 3-digit codes.
- Added unit tests in `lib/shops/route.test.ts` to verify valid conversions (`001`→1, `300`→300) and invalid inputs (`000`, `301`, `abc`, non-3-digit strings) and edge cases for `formatShopIdToCode`.

### Testing
- Ran `npm run test` (Vitest) and all tests passed: 77 tests across 10 files completed successfully.
- Ran `npm run build` but the build failed during prerender of `/(public)/signup/page` due to missing Supabase environment variables (`Supabase env vars are missing.`), which is unrelated to the new changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a700616fc8325926b1e1fc7b11bdb)