### PR TITLE
Protect vendor shop routes with shared authorization rules

### DIFF
--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -1,9 +1,9 @@
 ﻿"use client";
 
 import React, { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react";
-import type { User, UserRole, PermissionCheck } from "./types";
-import type { User as SupabaseUser } from "@supabase/supabase-js";
+import type { User, PermissionCheck } from "./types";
 import { createClient } from "@/utils/supabase/client";
+import { canAccessVendorShop, mapSupabaseUser } from "./authorization";
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -20,48 +20,6 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-function normalizeRole(value?: string | null): UserRole {
-  if (value === "super_admin") return "super_admin";
-  if (value === "moderator") return "moderator";
-  if (value === "vendor") return "vendor";
-  return "general_user";
-}
-
-function getVendorId(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
-}
-
-function mapSupabaseUser(user: SupabaseUser): User {
-  const appMeta = user.app_metadata as { role?: string } | undefined;
-  const userMeta = user.user_metadata as {
-    role?: string;
-    vendorId?: unknown;
-    name?: string;
-    full_name?: string;
-    avatarUrl?: string;
-    avatar_url?: string;
-  } | undefined;
-
-  const role = normalizeRole(appMeta?.role ?? userMeta?.role);
-  const vendorId = getVendorId(userMeta?.vendorId);
-  const name = userMeta?.name ?? userMeta?.full_name ?? (user.email ? user.email.split("@")[0] : "user");
-  const avatarUrl = userMeta?.avatarUrl ?? userMeta?.avatar_url;
-
-  return {
-    id: user.id,
-    name,
-    email: user.email ?? "",
-    avatarUrl,
-    role,
-    vendorId,
-  };
-}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const supabaseRef = useRef<ReturnType<typeof createClient> | null>(null);
@@ -129,7 +87,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     canEditShop: (shopId: number) => {
       if (user?.role === "super_admin") return true;
-      if (user?.role === "vendor" && user.vendorId === shopId) return true;
+      if (canAccessVendorShop(user, shopId)) return true;
       return false;
     },
 

--- a/lib/auth/authorization.test.ts
+++ b/lib/auth/authorization.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { canAccessVendorShop, getShopCodeFromPathname, getVendorId, normalizeRole } from "./authorization";
+
+describe("normalizeRole", () => {
+  it("既知のロールを正規化する", () => {
+    expect(normalizeRole("vendor")).toBe("vendor");
+    expect(normalizeRole("super_admin")).toBe("super_admin");
+  });
+
+  it("未知ロールは general_user にフォールバックする", () => {
+    expect(normalizeRole("unknown")).toBe("general_user");
+    expect(normalizeRole(undefined)).toBe("general_user");
+  });
+});
+
+describe("getVendorId", () => {
+  it("number/string の vendorId を受け取る", () => {
+    expect(getVendorId(10)).toBe(10);
+    expect(getVendorId("10")).toBe(10);
+  });
+
+  it("不正値は undefined を返す", () => {
+    expect(getVendorId("abc")).toBeUndefined();
+    expect(getVendorId(null)).toBeUndefined();
+  });
+});
+
+describe("canAccessVendorShop", () => {
+  it("vendor かつ vendorId 一致のみ許可する", () => {
+    expect(canAccessVendorShop({ role: "vendor", vendorId: 2 }, 2)).toBe(true);
+    expect(canAccessVendorShop({ role: "vendor", vendorId: 3 }, 2)).toBe(false);
+    expect(canAccessVendorShop({ role: "super_admin", vendorId: 2 }, 2)).toBe(false);
+  });
+});
+
+describe("getShopCodeFromPathname", () => {
+  it("/shops001 と /shops/001 の両方から shopCode を取得する", () => {
+    expect(getShopCodeFromPathname("/shops001")).toBe("001");
+    expect(getShopCodeFromPathname("/shops/001")).toBe("001");
+  });
+
+  it("対象外パスは null を返す", () => {
+    expect(getShopCodeFromPathname("/shopslogin")).toBeNull();
+    expect(getShopCodeFromPathname("/shops/abc")).toBeNull();
+  });
+});

--- a/lib/auth/authorization.ts
+++ b/lib/auth/authorization.ts
@@ -1,0 +1,66 @@
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+
+import type { User, UserRole } from "./types";
+
+const SHOP_CODE_PATH_PATTERN = /^\/shops(\d{3})$/;
+
+export function normalizeRole(value?: string | null): UserRole {
+  if (value === "super_admin") return "super_admin";
+  if (value === "moderator") return "moderator";
+  if (value === "vendor") return "vendor";
+  return "general_user";
+}
+
+export function getVendorId(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function mapSupabaseUser(user: SupabaseUser): User {
+  const appMeta = user.app_metadata as { role?: string } | undefined;
+  const userMeta = user.user_metadata as {
+    role?: string;
+    vendorId?: unknown;
+    name?: string;
+    full_name?: string;
+    avatarUrl?: string;
+    avatar_url?: string;
+  } | undefined;
+
+  const role = normalizeRole(appMeta?.role ?? userMeta?.role);
+  const vendorId = getVendorId(userMeta?.vendorId);
+  const name = userMeta?.name ?? userMeta?.full_name ?? (user.email ? user.email.split("@")[0] : "user");
+  const avatarUrl = userMeta?.avatarUrl ?? userMeta?.avatar_url;
+
+  return {
+    id: user.id,
+    name,
+    email: user.email ?? "",
+    avatarUrl,
+    role,
+    vendorId,
+  };
+}
+
+export function canAccessVendorShop(user: Pick<User, "role" | "vendorId"> | null, shopId: number): boolean {
+  return user?.role === "vendor" && user.vendorId === shopId;
+}
+
+export function getShopCodeFromPathname(pathname: string): string | null {
+  const compactMatch = pathname.match(SHOP_CODE_PATH_PATTERN);
+  if (compactMatch) {
+    return compactMatch[1];
+  }
+
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts.length === 2 && parts[0] === "shops" && /^\d{3}$/.test(parts[1])) {
+    return parts[1];
+  }
+
+  return null;
+}
+

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,8 +1,40 @@
-﻿import { type NextRequest } from "next/server";
+﻿import { NextResponse, type NextRequest } from "next/server";
+
+import { canAccessVendorShop, getShopCodeFromPathname, mapSupabaseUser } from "@/lib/auth/authorization";
+import { normalizeShopCodeToId } from "@/lib/shops/route";
 import { createClient } from "./utils/supabase/middleware";
 
-export function proxy(request: NextRequest) {
-  const { response } = createClient(request);
+export async function proxy(request: NextRequest) {
+  const { supabase, response } = createClient(request);
+  const { pathname } = request.nextUrl;
+
+  const shopCode = getShopCodeFromPathname(pathname);
+  if (!shopCode) {
+    return response;
+  }
+
+  const shopId = normalizeShopCodeToId(shopCode);
+  if (shopId === null) {
+    return NextResponse.redirect(new URL("/shopslogin?error=forbidden", request.url));
+  }
+
+  const { data, error } = await supabase.auth.getUser();
+  const user = data?.user ? mapSupabaseUser(data.user) : null;
+
+  if (error || !user) {
+    return NextResponse.redirect(new URL("/shopslogin", request.url));
+  }
+
+  if (!canAccessVendorShop(user, shopId)) {
+    return NextResponse.redirect(new URL("/shopslogin?error=forbidden", request.url));
+  }
+
+  if (pathname === `/shops${shopCode}`) {
+    const rewriteUrl = request.nextUrl.clone();
+    rewriteUrl.pathname = `/shops/${shopCode}`;
+    return NextResponse.rewrite(rewriteUrl, { headers: response.headers });
+  }
+
   return response;
 }
 


### PR DESCRIPTION
### Motivation
- Enforce access control for vendor-only pages under `/shops` (both `/shops001` and `/shops/001`) so only the correct logged-in vendor may access their shop admin pages.
- Keep client and server authorization logic identical by extracting parsing/role mapping into a shared helper.
- Normalize compact shop URLs (`/shops001`) to canonical routes after authorization to avoid accidental public access.

### Description
- Added `lib/auth/authorization.ts` which centralizes `normalizeRole`, `getVendorId`, `mapSupabaseUser`, `canAccessVendorShop`, and `getShopCodeFromPathname` for reuse on client and server.
- Updated `proxy.ts` to call `createClient(request)`, detect `/shops` targets via `getShopCodeFromPathname`, validate the shop code with `normalizeShopCodeToId`, check Supabase session with `supabase.auth.getUser()`, redirect unauthenticated users to `/shopslogin`, redirect unauthorized users to `/shopslogin?error=forbidden`, and rewrite compact URLs (`/shops001`) to `/shops/001` after successful authorization.
- Updated `lib/auth/AuthContext.tsx` to reuse `mapSupabaseUser` and `canAccessVendorShop` so `canEditShop` and client-side permissions align with server checks.
- Added unit tests `lib/auth/authorization.test.ts` covering role normalization, vendorId parsing, vendor-shop access checks, and shop-path parsing for both `/shops001` and `/shops/001`.

### Testing
- Ran unit tests with `npm run test -- lib/auth/authorization.test.ts`, and the test file passed (7 tests) ✅.
- Attempted `npm run build`; Next.js compiled but the build failed during prerender of `/(public)/signup/page` due to missing Supabase environment variables in this environment, so a full production build could not complete (expected in CI with env configured) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a769a47a0832598ad7d5292aee6ef)