### PR TITLE
test(lib): add comprehensive unit tests for lib/admin/toast.ts

### DIFF
--- a/lib/admin/toast.test.ts
+++ b/lib/admin/toast.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import toast from 'react-hot-toast';
+import { showToast, withToast } from './toast';
+
+// Mock react-hot-toast
+vi.mock('react-hot-toast', () => {
+  return {
+    default: {
+      success: vi.fn(),
+      error: vi.fn(),
+      loading: vi.fn(() => 'test-toast-id'),
+      dismiss: vi.fn(),
+      promise: vi.fn(),
+    }
+  };
+});
+
+describe('toast utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('showToast', () => {
+    it('success - should handle empty string input', () => {
+      showToast.success('');
+      expect(toast.success).toHaveBeenCalledWith('');
+    });
+
+    it('success - should call toast.success with normal data', () => {
+      showToast.success('Operation successful');
+      expect(toast.success).toHaveBeenCalledWith('Operation successful');
+    });
+
+    it('error - should handle empty string input', () => {
+      showToast.error('');
+      expect(toast.error).toHaveBeenCalledWith('');
+    });
+
+    it('error - should call toast.error with normal data', () => {
+      showToast.error('Operation failed');
+      expect(toast.error).toHaveBeenCalledWith('Operation failed');
+    });
+
+    it('loading - should handle empty string input', () => {
+      const id = showToast.loading('');
+      expect(toast.loading).toHaveBeenCalledWith('');
+      expect(id).toBe('test-toast-id');
+    });
+
+    it('loading - should call toast.loading with normal data and return id', () => {
+      const id = showToast.loading('Loading...');
+      expect(toast.loading).toHaveBeenCalledWith('Loading...');
+      expect(id).toBe('test-toast-id');
+    });
+
+    it('dismiss - should call toast.dismiss with normal data', () => {
+      showToast.dismiss('test-toast-id');
+      expect(toast.dismiss).toHaveBeenCalledWith('test-toast-id');
+    });
+
+    it('promise - should call toast.promise with empty messages', async () => {
+      const promise = Promise.resolve('data');
+      showToast.promise(promise, { loading: '', success: '', error: '' });
+      expect(toast.promise).toHaveBeenCalledWith(promise, { loading: '', success: '', error: '' });
+    });
+
+    it('promise - should call toast.promise with normal messages', async () => {
+      const promise = Promise.resolve('data');
+      const messages = { loading: 'Loading...', success: 'Success!', error: 'Error!' };
+      showToast.promise(promise, messages);
+      expect(toast.promise).toHaveBeenCalledWith(promise, messages);
+    });
+  });
+
+  describe('withToast', () => {
+    const messages = {
+      loading: 'Processing...',
+      success: 'Done!',
+      error: 'Failed!'
+    };
+
+    it('should resolve and show success toast for normal data', async () => {
+      const operation = vi.fn().mockResolvedValue('result data');
+
+      const result = await withToast(operation, messages);
+
+      expect(toast.loading).toHaveBeenCalledWith('Processing...');
+      expect(operation).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith('Done!', { id: 'test-toast-id' });
+      expect(result).toBe('result data');
+    });
+
+    it('should handle operation returning empty string', async () => {
+      const operation = vi.fn().mockResolvedValue('');
+
+      const result = await withToast(operation, messages);
+
+      expect(toast.loading).toHaveBeenCalledWith('Processing...');
+      expect(operation).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith('Done!', { id: 'test-toast-id' });
+      expect(result).toBe('');
+    });
+
+    it('should handle operation returning null', async () => {
+      const operation = vi.fn().mockResolvedValue(null);
+
+      const result = await withToast(operation, messages);
+
+      expect(toast.loading).toHaveBeenCalledWith('Processing...');
+      expect(operation).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith('Done!', { id: 'test-toast-id' });
+      expect(result).toBeNull();
+    });
+
+    it('should handle empty message strings', async () => {
+      const operation = vi.fn().mockResolvedValue('result');
+      const emptyMessages = { loading: '', success: '', error: '' };
+
+      const result = await withToast(operation, emptyMessages);
+
+      expect(toast.loading).toHaveBeenCalledWith('');
+      expect(toast.success).toHaveBeenCalledWith('', { id: 'test-toast-id' });
+      expect(result).toBe('result');
+    });
+
+    it('should reject and show error toast on exception', async () => {
+      const testError = new Error('Test error');
+      const operation = vi.fn().mockRejectedValue(testError);
+
+      await expect(withToast(operation, messages)).rejects.toThrow('Test error');
+
+      expect(toast.loading).toHaveBeenCalledWith('Processing...');
+      expect(operation).toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('Failed!', { id: 'test-toast-id' });
+      // success should not be called
+      expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('should use default error message when error message is not provided on exception', async () => {
+      const testError = new Error('Test error');
+      const operation = vi.fn().mockRejectedValue(testError);
+
+      const messagesWithoutError = {
+        loading: 'Processing...',
+        success: 'Done!'
+      };
+
+      await expect(withToast(operation, messagesWithoutError)).rejects.toThrow('Test error');
+
+      expect(toast.loading).toHaveBeenCalledWith('Processing...');
+      expect(operation).toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('エラーが発生しました', { id: 'test-toast-id' });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@types/node": "^20.19.33",
         "@types/react": "^18.3.28",
         "@types/react-dom": "18.3.7",
+        "@vitest/coverage-v8": "^1.6.1",
         "autoprefixer": "^10.4.24",
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.1.6",
@@ -92,6 +93,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -418,6 +433,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@capacitor/cli": {
       "version": "8.1.0",
@@ -1892,6 +1914,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -4159,6 +4191,34 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -6740,6 +6800,13 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7291,6 +7358,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7419,6 +7493,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -7992,6 +8078,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -8447,6 +8587,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -9841,6 +10009,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -10006,6 +10184,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -11811,6 +11999,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -12859,6 +13084,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/node": "^20.19.33",
     "@types/react": "^18.3.28",
     "@types/react-dom": "18.3.7",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.24",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",


### PR DESCRIPTION
## すること
- テスト未作成のコンポーネントに対する単体テストの追加
- 境界値テストおよび正常系・異常系パターンの網羅

## したこと
- `lib/admin/toast.ts` に対するテストファイル (`lib/admin/toast.test.ts`) を作成しました。
- 以下のテストケースを実装しました：
    - 入力が空の場合の挙動 (例: `showToast.success('')`, `withToast` における空メッセージ設定)
    - 正常なデータが渡された場合の返り値検証 (例: 各 `showToast` メソッドの呼び出し検証, `withToast` の Promise resolve 時の動作と戻り値の確認)
    - エラー発生時の例外処理確認 (例: `withToast` で渡された関数が reject した場合の `toast.error` 呼び出しおよび例外のスロー)
- 実行のために不足していた `@vitest/coverage-v8` を依存関係に追加し、カバレッジが 100% になることを確認しました。

## 目的
- プロジェクトのテストカバレッジを向上させるため
- 将来的なリファクタリング時の安全性を担保するため
- バグの早期発見を促進するため

## 影響
- プロダクションコードへの変更はありません。
- CI/CDパイプラインの実行時間が若干増加する可能性があります。

---
*PR created automatically by Jules for task [7186310568963285754](https://jules.google.com/task/7186310568963285754) started by @Yutodesuy*