### PR TITLE
feat: 投稿履歴を最新情報の発信ページ内に統合

### DIFF
--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, LogOut, BarChart2, Sparkles } from "lucide-react";
+import { Megaphone, Store, LogOut, BarChart2, Sparkles, ChevronRight } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -10,37 +10,33 @@ const MENU_ITEMS = [
     title: "最新情報の発信",
     description: "今日のおすすめ・残り数量など",
     href: "/vendor/post/new",
-    accent: "from-amber-500/40 via-amber-100/70 to-white",
+    iconBg: "bg-amber-100",
+    iconColor: "text-amber-600",
     icon: Megaphone,
-    badge: "お知らせ",
-    image: "/images/home/posters/HomePagePoster3.jpeg",
   },
   {
     title: "出店情報の更新",
     description: "商品・決済方法・出店日",
     href: "/vendor/store",
-    accent: "from-emerald-400/40 via-emerald-100/70 to-white",
+    iconBg: "bg-emerald-100",
+    iconColor: "text-emerald-600",
     icon: Store,
-    badge: "基本情報",
-    image: "/images/home/posters/HomePagePoster2.png",
   },
   {
     title: "アナリティクス",
     description: "閲覧数・人気商品・時間帯分析",
     href: "/vendor/analytics",
-    accent: "from-violet-400/40 via-violet-100/70 to-white",
+    iconBg: "bg-violet-100",
+    iconColor: "text-violet-600",
     icon: BarChart2,
-    badge: "分析",
-    image: "/images/home/posters/HomePagePoster6.jpeg",
   },
   {
     title: "AIばあちゃんに教える",
     description: "お店の情報をAIに学習させる",
     href: "/vendor/ai-knowledge",
-    accent: "from-rose-400/40 via-rose-100/70 to-white",
+    iconBg: "bg-rose-100",
+    iconColor: "text-rose-500",
     icon: Sparkles,
-    badge: "AI知識",
-    image: "/images/home/posters/HomePagePoster2.png",
   },
 ];
 
@@ -49,71 +45,63 @@ export default function MyShopPage() {
   const canAccess = isLoggedIn;
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.25),_rgba(255,255,255,0))] pb-24">
-      <div className="mx-auto w-full max-w-4xl px-4 pt-8">
-        <div className="rounded-[32px] border border-amber-100 bg-white/95 px-6 py-7 text-center shadow-sm">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-700">
-            Vendor Console
-          </p>
-          <h1 className="mt-2 text-4xl font-bold text-slate-900 md:text-5xl">
-            出店者メニュー
-          </h1>
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.18),_rgba(255,255,255,0))] pb-24">
+      {/* ヘッダー */}
+      <div className="border-b border-amber-100 bg-white/90 px-4 py-4 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-2xl items-center justify-between">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.35em] text-amber-600">
+              Vendor Console
+            </p>
+            <h1 className="text-xl font-bold text-slate-900">出店者メニュー</h1>
+          </div>
           {isLoggedIn && (
-            <div className="mt-4 flex justify-center">
-              <button
-                onClick={logout}
-                className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-4 py-1.5 text-xs font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600"
-              >
-                <LogOut size={12} />
-                ログアウト
-              </button>
-            </div>
+            <button
+              onClick={logout}
+              className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600"
+            >
+              <LogOut size={12} />
+              ログアウト
+            </button>
           )}
         </div>
+      </div>
 
+      <div className="mx-auto w-full max-w-2xl px-4 pt-5">
         {!canAccess ? (
-        <div className="mt-6 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          出店者としてログインしてください。ログインは
-          <Link href="/login" className="ml-1 font-semibold underline">
-            出店者ログイン
-          </Link>
-          から行えます。
-        </div>
+          <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            出店者としてログインしてください。ログインは
+            <Link href="/login" className="ml-1 font-semibold underline">
+              出店者ログイン
+            </Link>
+            から行えます。
+          </div>
         ) : (
           <>
             {!permissions.isVendor && (
-              <div className="mt-6 rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              <div className="mb-4 rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-800">
                 現在のアカウントに出店者ロールが設定されていません。表示はできますが、保存時に制限が出る場合があります。
               </div>
             )}
-            <div className="mt-6 grid gap-5 md:grid-cols-3">
-              {MENU_ITEMS.map((item) => {
+            <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+              {MENU_ITEMS.map((item, index) => {
                 const Icon = item.icon;
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
-                    className="group relative overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+                    className={`flex items-center gap-4 px-4 py-4 transition active:bg-slate-50 ${
+                      index !== MENU_ITEMS.length - 1 ? "border-b border-slate-100" : ""
+                    }`}
                   >
-                    <div
-                      className="absolute inset-0 bg-cover bg-center opacity-70"
-                      style={{ backgroundImage: `url(${item.image})` }}
-                      aria-hidden="true"
-                    />
-                    <div className={`absolute inset-0 bg-gradient-to-br ${item.accent}`} />
-                    <div className="absolute inset-0 bg-white/30 backdrop-blur-[1px]" aria-hidden="true" />
-                    <div className="relative flex h-full min-h-[170px] flex-col gap-3 px-6 py-5">
-                      <div className="flex items-center justify-end">
-                        <span className="rounded-3xl border border-white/70 bg-white/80 p-3 text-slate-700 shadow-md">
-                          <Icon size={32} />
-                        </span>
-                      </div>
-                      <div className="text-center">
-                        <div className="text-3xl font-semibold text-slate-900 md:text-[32px]">
-                          {item.title}
-                        </div>
-                      </div>
+                    <div className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl ${item.iconBg}`}>
+                      <Icon size={22} className={item.iconColor} />
                     </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-slate-900">{item.title}</p>
+                      <p className="text-xs text-slate-500">{item.description}</p>
+                    </div>
+                    <ChevronRight size={18} className="flex-shrink-0 text-slate-300" />
                   </Link>
                 );
               })}

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, BarChart2, Sparkles, LogOut } from "lucide-react";
+import { Megaphone, Store, BarChart2, Sparkles } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -41,7 +41,7 @@ const MENU_ITEMS = [
 ];
 
 export default function MyShopPage() {
-  const { isLoggedIn, permissions, logout } = useAuth();
+  const { isLoggedIn, permissions } = useAuth();
   const canAccess = isLoggedIn;
 
   return (
@@ -68,17 +68,6 @@ export default function MyShopPage() {
             <h1 className="mt-2 text-4xl font-bold text-slate-900 md:text-5xl">
               出店者メニュー
             </h1>
-            {isLoggedIn && (
-              <div className="mt-4 flex justify-center">
-                <button
-                  onClick={logout}
-                  className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-4 py-1.5 text-xs font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600"
-                >
-                  <LogOut size={12} />
-                  ログアウト
-                </button>
-              </div>
-            )}
           </div>
         </div>
 

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, FileText, LogOut, BarChart2, Sparkles } from "lucide-react";
+import { Megaphone, Store, LogOut, BarChart2, Sparkles } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -14,15 +14,6 @@ const MENU_ITEMS = [
     icon: Megaphone,
     badge: "お知らせ",
     image: "/images/home/posters/HomePagePoster3.jpeg",
-  },
-  {
-    title: "投稿履歴",
-    description: "過去の投稿を確認・再投稿",
-    href: "/vendor/posts",
-    accent: "from-sky-400/40 via-sky-100/70 to-white",
-    icon: FileText,
-    badge: "履歴",
-    image: "/images/home/posters/HomePagePoster6.jpeg",
   },
   {
     title: "出店情報の更新",

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, LogOut, BarChart2, Sparkles } from "lucide-react";
+import { Megaphone, Store, BarChart2, Sparkles } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -41,7 +41,7 @@ const MENU_ITEMS = [
 ];
 
 export default function MyShopPage() {
-  const { isLoggedIn, permissions, logout } = useAuth();
+  const { isLoggedIn, permissions } = useAuth();
   const canAccess = isLoggedIn;
 
   return (
@@ -55,15 +55,6 @@ export default function MyShopPage() {
             </p>
             <h1 className="text-xl font-bold text-slate-900">出店者メニュー</h1>
           </div>
-          {isLoggedIn && (
-            <button
-              onClick={logout}
-              className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600"
-            >
-              <LogOut size={12} />
-              ログアウト
-            </button>
-          )}
         </div>
       </div>
 

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, BarChart2, Sparkles } from "lucide-react";
+import { Megaphone, Store, BarChart2, Sparkles, LogOut } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -41,14 +41,14 @@ const MENU_ITEMS = [
 ];
 
 export default function MyShopPage() {
-  const { isLoggedIn, permissions } = useAuth();
+  const { isLoggedIn, permissions, logout } = useAuth();
   const canAccess = isLoggedIn;
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.18),_rgba(255,255,255,0))] pb-24">
-      {/* ヘッダー */}
-      <div className="border-b border-amber-100 bg-white/90 px-4 py-4 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-2xl items-center justify-between">
+      {/* モバイル用ヘッダー */}
+      <div className="border-b border-amber-100 bg-white/90 px-4 py-4 backdrop-blur-sm md:hidden">
+        <div className="flex items-center">
           <div>
             <p className="text-[10px] font-semibold uppercase tracking-[0.35em] text-amber-600">
               Vendor Console
@@ -58,7 +58,30 @@ export default function MyShopPage() {
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-2xl px-4 pt-5 md:max-w-4xl">
+      <div className="mx-auto w-full max-w-2xl px-4 pt-5 md:max-w-4xl md:pt-8">
+        {/* デスクトップ用ヘッダー */}
+        <div className="hidden md:block">
+          <div className="rounded-[32px] border border-amber-100 bg-white/95 px-6 py-7 text-center shadow-sm">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-700">
+              Vendor Console
+            </p>
+            <h1 className="mt-2 text-4xl font-bold text-slate-900 md:text-5xl">
+              出店者メニュー
+            </h1>
+            {isLoggedIn && (
+              <div className="mt-4 flex justify-center">
+                <button
+                  onClick={logout}
+                  className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-4 py-1.5 text-xs font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600"
+                >
+                  <LogOut size={12} />
+                  ログアウト
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
         {!canAccess ? (
           <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
             出店者としてログインしてください。ログインは

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Megaphone, Store, LogOut, BarChart2, Sparkles, ChevronRight } from "lucide-react";
+import { Megaphone, Store, LogOut, BarChart2, Sparkles } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import NavigationBar from "@/app/components/NavigationBar";
 
@@ -10,33 +10,33 @@ const MENU_ITEMS = [
     title: "最新情報の発信",
     description: "今日のおすすめ・残り数量など",
     href: "/vendor/post/new",
-    iconBg: "bg-amber-100",
-    iconColor: "text-amber-600",
+    accent: "from-amber-500/40 via-amber-100/70 to-white",
     icon: Megaphone,
+    image: "/images/home/posters/HomePagePoster3.jpeg",
   },
   {
     title: "出店情報の更新",
     description: "商品・決済方法・出店日",
     href: "/vendor/store",
-    iconBg: "bg-emerald-100",
-    iconColor: "text-emerald-600",
+    accent: "from-emerald-400/40 via-emerald-100/70 to-white",
     icon: Store,
+    image: "/images/home/posters/HomePagePoster2.png",
   },
   {
     title: "アナリティクス",
     description: "閲覧数・人気商品・時間帯分析",
     href: "/vendor/analytics",
-    iconBg: "bg-violet-100",
-    iconColor: "text-violet-600",
+    accent: "from-violet-400/40 via-violet-100/70 to-white",
     icon: BarChart2,
+    image: "/images/home/posters/HomePagePoster6.jpeg",
   },
   {
     title: "AIばあちゃんに教える",
     description: "お店の情報をAIに学習させる",
     href: "/vendor/ai-knowledge",
-    iconBg: "bg-rose-100",
-    iconColor: "text-rose-500",
+    accent: "from-rose-400/40 via-rose-100/70 to-white",
     icon: Sparkles,
+    image: "/images/home/posters/HomePagePoster2.png",
   },
 ];
 
@@ -83,25 +83,34 @@ export default function MyShopPage() {
                 現在のアカウントに出店者ロールが設定されていません。表示はできますが、保存時に制限が出る場合があります。
               </div>
             )}
-            <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-              {MENU_ITEMS.map((item, index) => {
+            <div className="grid gap-5 md:grid-cols-3">
+              {MENU_ITEMS.map((item) => {
                 const Icon = item.icon;
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
-                    className={`flex items-center gap-4 px-4 py-4 transition active:bg-slate-50 ${
-                      index !== MENU_ITEMS.length - 1 ? "border-b border-slate-100" : ""
-                    }`}
+                    className="group relative overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
                   >
-                    <div className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl ${item.iconBg}`}>
-                      <Icon size={22} className={item.iconColor} />
+                    <div
+                      className="absolute inset-0 bg-cover bg-center opacity-70"
+                      style={{ backgroundImage: `url(${item.image})` }}
+                      aria-hidden="true"
+                    />
+                    <div className={`absolute inset-0 bg-gradient-to-br ${item.accent}`} />
+                    <div className="absolute inset-0 bg-white/30 backdrop-blur-[1px]" aria-hidden="true" />
+                    <div className="relative flex h-full min-h-[170px] flex-col gap-3 px-6 py-5">
+                      <div className="flex items-center justify-end">
+                        <span className="rounded-3xl border border-white/70 bg-white/80 p-3 text-slate-700 shadow-md">
+                          <Icon size={32} />
+                        </span>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-3xl font-semibold text-slate-900 md:text-[32px]">
+                          {item.title}
+                        </div>
+                      </div>
                     </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-semibold text-slate-900">{item.title}</p>
-                      <p className="text-xs text-slate-500">{item.description}</p>
-                    </div>
-                    <ChevronRight size={18} className="flex-shrink-0 text-slate-300" />
                   </Link>
                 );
               })}

--- a/app/(public)/my-shop/page.tsx
+++ b/app/(public)/my-shop/page.tsx
@@ -67,7 +67,7 @@ export default function MyShopPage() {
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-2xl px-4 pt-5">
+      <div className="mx-auto w-full max-w-2xl px-4 pt-5 md:max-w-4xl">
         {!canAccess ? (
           <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
             出店者としてログインしてください。ログインは

--- a/app/vendor/_services/postsService.ts
+++ b/app/vendor/_services/postsService.ts
@@ -22,6 +22,18 @@ function contentToPost(c: DbContent): Post {
   };
 }
 
+export async function fetchPostById(postId: string): Promise<Post | null> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("vendor_contents")
+    .select("id, vendor_id, body, image_url, expires_at, created_at")
+    .eq("id", postId)
+    .single();
+
+  if (error || !data) return null;
+  return contentToPost(data as DbContent);
+}
+
 export async function fetchVendorPosts(vendorId: string): Promise<Post[]> {
   const supabase = createClient();
   const { data, error } = await supabase
@@ -38,10 +50,11 @@ export async function createPost(
   vendorId: string,
   text: string,
   expiresAt: Date,
-  imageFile?: File
+  imageFile?: File,
+  existingImageUrl?: string
 ): Promise<Post> {
   const supabase = createClient();
-  let imageUrl: string | null = null;
+  let imageUrl: string | null = existingImageUrl ?? null;
 
   if (imageFile) {
     const ext = imageFile.name.split(".").pop() ?? "jpg";

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -16,6 +16,7 @@ import {
   CheckCircle2,
   AlertCircle,
   Loader2,
+  History,
 } from "lucide-react";
 
 type ExpirationOption = { preset: ExpirationPreset; label: string; desc: string; icon: typeof Clock };
@@ -131,6 +132,11 @@ export default function VendorPostNewPage() {
             <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-amber-600">New Post</p>
             <h1 className="text-xl font-bold text-slate-900">最新情報を発信</h1>
           </div>
+          <Link href="/vendor/posts"
+            className="ml-auto flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-50"
+          >
+            <History size={14} />投稿履歴
+          </Link>
         </div>
       </div>
 

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useRef, useEffect, type ChangeEvent, type FormEvent } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import NavigationBar from "@/app/components/NavigationBar";
 import { useAuth } from "@/lib/auth/AuthContext";
-import { createPost, fetchVendorPosts, repostContent } from "../../_services/postsService";
+import { createPost, fetchVendorPosts, fetchPostById, repostContent } from "../../_services/postsService";
 import type { ExpirationPreset, Post, PostStatus } from "../../_types";
 import {
   ArrowLeft,
@@ -122,6 +122,7 @@ function formatExpirationLabel(preset: ExpirationPreset, customDateTime: string)
 export default function VendorPostNewPage() {
   const { user } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [activeTab, setActiveTab] = useState<ActiveTab>("new");
@@ -130,12 +131,14 @@ export default function VendorPostNewPage() {
   const [text, setText]                         = useState("");
   const [imageFile, setImageFile]               = useState<File | null>(null);
   const [imagePreview, setImagePreview]         = useState<string | null>(null);
+  const [existingImageUrl, setExistingImageUrl] = useState<string | null>(null);
   const [expirationPreset, setExpirationPreset] = useState<ExpirationPreset>("today");
   const [customDateTime, setCustomDateTime]     = useState("");
   const [isSubmitting, setIsSubmitting]         = useState(false);
   const [isSubmitted, setIsSubmitted]           = useState(false);
   const [showPreview, setShowPreview]           = useState(false);
   const [formError, setFormError]               = useState<string | null>(null);
+  const [isRepost, setIsRepost]                 = useState(false);
 
   // 投稿履歴の状態
   const [filterTab, setFilterTab]   = useState<FilterTab>("all");
@@ -144,6 +147,21 @@ export default function VendorPostNewPage() {
   const [historyLoaded, setHistoryLoaded]   = useState(false);
   const [historyError, setHistoryError]     = useState<string | null>(null);
   const [showRepostToast, setShowRepostToast] = useState(false);
+
+  // 編集再投稿：URLの ?repost=ID から投稿内容を事前入力
+  useEffect(() => {
+    const repostId = searchParams.get("repost");
+    if (!repostId) return;
+    fetchPostById(repostId).then((post) => {
+      if (!post) return;
+      setText(post.text);
+      if (post.image_url) {
+        setImagePreview(post.image_url);
+        setExistingImageUrl(post.image_url);
+      }
+      setIsRepost(true);
+    });
+  }, [searchParams]);
 
   // 投稿履歴タブに切り替えたときに一度だけ取得
   useEffect(() => {
@@ -183,6 +201,7 @@ export default function VendorPostNewPage() {
     const file = e.target.files?.[0];
     if (!file) return;
     setImageFile(file);
+    setExistingImageUrl(null);
     const reader = new FileReader();
     reader.onload = (ev) => setImagePreview(ev.target?.result as string);
     reader.readAsDataURL(file);
@@ -191,6 +210,7 @@ export default function VendorPostNewPage() {
   function handleRemoveImage() {
     setImageFile(null);
     setImagePreview(null);
+    setExistingImageUrl(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
@@ -201,7 +221,7 @@ export default function VendorPostNewPage() {
     setFormError(null);
     try {
       const expiresAt = calcExpirationTime(expirationPreset, customDateTime);
-      await createPost(user.id, text, expiresAt, imageFile ?? undefined);
+      await createPost(user.id, text, expiresAt, imageFile ?? undefined, existingImageUrl ?? undefined);
       setIsSubmitted(true);
       setHistoryLoaded(false); // 次回履歴タブ開時に再取得
     } catch {
@@ -279,6 +299,11 @@ export default function VendorPostNewPage() {
       {/* 新規投稿フォーム */}
       {activeTab === "new" && (
         <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-4 px-4 pt-5">
+          {isRepost && (
+            <div className="flex items-center gap-2 rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+              <Pencil size={14} />過去の投稿を編集して再投稿します
+            </div>
+          )}
           {formError && (
             <div className="flex items-center gap-2 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
               <AlertCircle size={14} />{formError}

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -160,6 +160,7 @@ export default function VendorPostNewPage() {
         setExistingImageUrl(post.image_url);
       }
       setIsRepost(true);
+      setActiveTab("new");
     });
   }, [searchParams]);
 

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useRef, type ChangeEvent, type FormEvent } from "react";
+import { useState, useRef, useEffect, type ChangeEvent, type FormEvent } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import NavigationBar from "@/app/components/NavigationBar";
 import { useAuth } from "@/lib/auth/AuthContext";
-import { createPost } from "../../_services/postsService";
-import type { ExpirationPreset } from "../../_types";
+import { createPost, fetchVendorPosts, repostContent } from "../../_services/postsService";
+import type { ExpirationPreset, Post, PostStatus } from "../../_types";
 import {
   ArrowLeft,
   Image as ImageIcon,
@@ -16,15 +17,88 @@ import {
   CheckCircle2,
   AlertCircle,
   Loader2,
-  History,
+  RotateCcw,
+  Pencil,
+  XCircle,
+  PlusCircle,
 } from "lucide-react";
+
+type ActiveTab = "new" | "history";
+type FilterTab = "all" | "active" | "expired";
+
+// ── 投稿履歴用ユーティリティ ──────────────────────────────
+
+function timeAgo(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const m = Math.floor(diff / 60000);
+  const h = Math.floor(m / 60);
+  const d = Math.floor(h / 24);
+  if (d > 0) return `${d}日前`;
+  if (h > 0) return `${h}時間前`;
+  if (m > 0) return `${m}分前`;
+  return "たった今";
+}
+
+function StatusBadge({ status }: { status: PostStatus }) {
+  if (status === "active") {
+    return (
+      <span className="flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+        <CheckCircle2 size={10} />公開中
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-500">
+      <XCircle size={10} />期限切れ
+    </span>
+  );
+}
+
+function PostCard({ post, onRepost, onEditRepost }: { post: Post; onRepost: (post: Post) => void; onEditRepost: (post: Post) => void }) {
+  return (
+    <div className={`rounded-2xl border bg-white p-4 shadow-sm transition ${post.status === "active" ? "border-amber-100" : "border-slate-200"}`}>
+      <div className="flex items-start gap-3">
+        {post.image_url ? (
+          <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100" style={{ backgroundImage: `url(${post.image_url})`, backgroundSize: "cover", backgroundPosition: "center" }} />
+        ) : (
+          <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-300">
+            <ImageIcon size={20} />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="line-clamp-3 text-sm leading-relaxed text-slate-800">{post.text}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <StatusBadge status={post.status} />
+            <span className="flex items-center gap-1 text-[11px] text-slate-400">
+              <Clock size={10} />{timeAgo(post.created_at)}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 flex gap-2 border-t border-slate-100 pt-3">
+        <button onClick={() => onRepost(post)}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-amber-200 bg-amber-50 py-2 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
+        >
+          <RotateCcw size={13} />そのまま再投稿
+        </button>
+        <button onClick={() => onEditRepost(post)}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-slate-200 bg-slate-50 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
+        >
+          <Pencil size={13} />編集して再投稿
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── 新規投稿用ユーティリティ ──────────────────────────────
 
 type ExpirationOption = { preset: ExpirationPreset; label: string; desc: string; icon: typeof Clock };
 
 const EXPIRATION_OPTIONS: ExpirationOption[] = [
-  { preset: "1h",     label: "1時間",  desc: "今すぐ来てほしい情報に", icon: Clock },
-  { preset: "today",  label: "本日",   desc: "当日限りの情報に",       icon: Calendar },
-  { preset: "custom", label: "カスタム",desc: "時間を自分で設定",       icon: Clock },
+  { preset: "1h",     label: "1時間",   desc: "今すぐ来てほしい情報に", icon: Clock },
+  { preset: "today",  label: "本日",    desc: "当日限りの情報に",       icon: Calendar },
+  { preset: "custom", label: "カスタム", desc: "時間を自分で設定",       icon: Clock },
 ];
 
 function calcExpirationTime(preset: ExpirationPreset, customDateTime: string): Date {
@@ -43,22 +117,67 @@ function formatExpirationLabel(preset: ExpirationPreset, customDateTime: string)
   return `${h}:${m}まで`;
 }
 
+// ── メインコンポーネント ──────────────────────────────────
+
 export default function VendorPostNewPage() {
   const { user } = useAuth();
+  const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const [text, setText]                       = useState("");
-  const [imageFile, setImageFile]             = useState<File | null>(null);
-  const [imagePreview, setImagePreview]       = useState<string | null>(null);
-  const [expirationPreset, setExpirationPreset] = useState<ExpirationPreset>("today");
-  const [customDateTime, setCustomDateTime]   = useState("");
-  const [isSubmitting, setIsSubmitting]       = useState(false);
-  const [isSubmitted, setIsSubmitted]         = useState(false);
-  const [showPreview, setShowPreview]         = useState(false);
-  const [error, setError]                     = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("new");
 
-  const isValid = text.trim().length > 0;
-  const MAX_CHARS = 300;
+  // 新規投稿フォームの状態
+  const [text, setText]                         = useState("");
+  const [imageFile, setImageFile]               = useState<File | null>(null);
+  const [imagePreview, setImagePreview]         = useState<string | null>(null);
+  const [expirationPreset, setExpirationPreset] = useState<ExpirationPreset>("today");
+  const [customDateTime, setCustomDateTime]     = useState("");
+  const [isSubmitting, setIsSubmitting]         = useState(false);
+  const [isSubmitted, setIsSubmitted]           = useState(false);
+  const [showPreview, setShowPreview]           = useState(false);
+  const [formError, setFormError]               = useState<string | null>(null);
+
+  // 投稿履歴の状態
+  const [filterTab, setFilterTab]   = useState<FilterTab>("all");
+  const [posts, setPosts]           = useState<Post[]>([]);
+  const [isLoadingPosts, setIsLoadingPosts] = useState(false);
+  const [historyLoaded, setHistoryLoaded]   = useState(false);
+  const [historyError, setHistoryError]     = useState<string | null>(null);
+  const [showRepostToast, setShowRepostToast] = useState(false);
+
+  // 投稿履歴タブに切り替えたときに一度だけ取得
+  useEffect(() => {
+    if (activeTab !== "history" || historyLoaded || !user) return;
+    setIsLoadingPosts(true);
+    fetchVendorPosts(user.id)
+      .then(setPosts)
+      .catch(() => setHistoryError("投稿の読み込みに失敗しました"))
+      .finally(() => { setIsLoadingPosts(false); setHistoryLoaded(true); });
+  }, [activeTab, historyLoaded, user]);
+
+  const filtered = filterTab === "all" ? posts : posts.filter((p) => p.status === filterTab);
+
+  const FILTER_TABS: { key: FilterTab; label: string; count: number }[] = [
+    { key: "all",     label: "すべて",   count: posts.length },
+    { key: "active",  label: "公開中",   count: posts.filter((p) => p.status === "active").length },
+    { key: "expired", label: "期限切れ", count: posts.filter((p) => p.status === "expired").length },
+  ];
+
+  async function handleRepost(post: Post) {
+    if (!user) return;
+    try {
+      const newPost = await repostContent(user.id, post);
+      setPosts((prev) => [newPost, ...prev]);
+      setShowRepostToast(true);
+      setTimeout(() => setShowRepostToast(false), 3000);
+    } catch {
+      setHistoryError("再投稿に失敗しました");
+    }
+  }
+
+  function handleEditRepost(post: Post) {
+    router.push(`/vendor/post/new?repost=${post.id}`);
+  }
 
   function handleImageChange(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -77,20 +196,25 @@ export default function VendorPostNewPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (!isValid || isSubmitting || !user) return;
+    if (!text.trim() || isSubmitting || !user) return;
     setIsSubmitting(true);
-    setError(null);
+    setFormError(null);
     try {
       const expiresAt = calcExpirationTime(expirationPreset, customDateTime);
       await createPost(user.id, text, expiresAt, imageFile ?? undefined);
       setIsSubmitted(true);
+      setHistoryLoaded(false); // 次回履歴タブ開時に再取得
     } catch {
-      setError("投稿に失敗しました。もう一度お試しください。");
+      setFormError("投稿に失敗しました。もう一度お試しください。");
     } finally {
       setIsSubmitting(false);
     }
   }
 
+  const MAX_CHARS = 300;
+  const isValid = text.trim().length > 0;
+
+  // 投稿完了画面
   if (isSubmitted) {
     return (
       <div className="min-h-screen bg-[#FFFAF0] pb-24">
@@ -123,154 +247,219 @@ export default function VendorPostNewPage() {
 
   return (
     <div className="min-h-screen bg-[#FFFAF0] pb-24">
+      {/* ヘッダー */}
       <div className="border-b border-amber-100 bg-white/90 px-4 py-4 backdrop-blur-sm">
         <div className="mx-auto flex max-w-2xl items-center gap-3">
           <Link href="/my-shop" className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50">
             <ArrowLeft size={18} />
           </Link>
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-amber-600">New Post</p>
-            <h1 className="text-xl font-bold text-slate-900">最新情報を発信</h1>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-amber-600">Post</p>
+            <h1 className="text-xl font-bold text-slate-900">最新情報の発信</h1>
           </div>
-          <Link href="/vendor/posts"
-            className="ml-auto flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-50"
+        </div>
+
+        {/* タブバー */}
+        <div className="mx-auto mt-3 flex max-w-2xl gap-1 rounded-xl border border-slate-200 bg-slate-100 p-1">
+          <button
+            onClick={() => setActiveTab("new")}
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition ${activeTab === "new" ? "bg-white text-amber-600 shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
           >
-            <History size={14} />投稿履歴
-          </Link>
+            <PlusCircle size={13} />新規投稿
+          </button>
+          <button
+            onClick={() => setActiveTab("history")}
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition ${activeTab === "history" ? "bg-white text-amber-600 shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
+          >
+            <Clock size={13} />投稿履歴
+          </button>
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-4 px-4 pt-5">
-
-        {error && (
-          <div className="flex items-center gap-2 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-            <AlertCircle size={14} />{error}
-          </div>
-        )}
-
-        {/* テキスト入力 */}
-        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-          <div className="px-4 pt-4">
-            <label className="mb-2 block text-xs font-semibold uppercase tracking-wider text-slate-400">投稿内容</label>
-            <textarea
-              value={text} onChange={(e) => setText(e.target.value)}
-              placeholder="今日のおすすめ情報・残り数量・特別メニューなど..."
-              maxLength={MAX_CHARS} rows={5}
-              className="w-full resize-none rounded-xl bg-slate-50 px-3 py-3 text-sm text-slate-800 placeholder-slate-400 outline-none focus:ring-2 focus:ring-amber-300"
-            />
-          </div>
-          <div className="flex items-center justify-between px-4 pb-3">
-            <span className={`text-xs ${text.length > MAX_CHARS * 0.9 ? "text-red-500" : "text-slate-400"}`}>
-              {text.length} / {MAX_CHARS}
-            </span>
-            {text.length === 0 && (
-              <span className="flex items-center gap-1 text-xs text-slate-400">
-                <AlertCircle size={11} />テキストを入力してください
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* 画像アップロード */}
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <label className="mb-3 block text-xs font-semibold uppercase tracking-wider text-slate-400">画像（任意）</label>
-          {imagePreview ? (
-            <div className="relative">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={imagePreview} alt="プレビュー" className="h-48 w-full rounded-xl object-cover" />
-              <button type="button" onClick={handleRemoveImage}
-                className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/50 text-white transition hover:bg-black/70"
-              >
-                <X size={14} />
-              </button>
+      {/* 新規投稿フォーム */}
+      {activeTab === "new" && (
+        <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-4 px-4 pt-5">
+          {formError && (
+            <div className="flex items-center gap-2 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+              <AlertCircle size={14} />{formError}
             </div>
-          ) : (
-            <button type="button" onClick={() => fileInputRef.current?.click()}
-              className="flex h-32 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 text-slate-400 transition hover:border-amber-300 hover:bg-amber-50 hover:text-amber-500"
-            >
-              <ImageIcon size={24} />
-              <span className="text-sm font-medium">タップして画像を追加</span>
-              <span className="text-xs text-slate-400">JPG / PNG / WEBP（5MB以内）</span>
-            </button>
           )}
-          <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
-        </div>
 
-        {/* 表示期間 */}
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <label className="mb-3 block text-xs font-semibold uppercase tracking-wider text-slate-400">表示期間</label>
-          <div className="grid grid-cols-3 gap-2">
-            {EXPIRATION_OPTIONS.map((opt) => {
-              const Icon = opt.icon;
-              const isSelected = expirationPreset === opt.preset;
-              return (
-                <button key={opt.preset} type="button" onClick={() => setExpirationPreset(opt.preset)}
-                  className={`flex flex-col items-center gap-1.5 rounded-xl border-2 px-2 py-3 text-center transition ${isSelected ? "border-amber-400 bg-amber-50 text-amber-700" : "border-slate-200 bg-white text-slate-600 hover:border-amber-200 hover:bg-amber-50/50"}`}
-                >
-                  <Icon size={18} />
-                  <span className="text-xs font-semibold">{opt.label}</span>
-                  <span className="text-[10px] leading-tight text-slate-400">{opt.desc}</span>
-                </button>
-              );
-            })}
-          </div>
-          {expirationPreset === "custom" && (
-            <div className="mt-3">
-              <label className="mb-1.5 block text-xs text-slate-500">終了日時を選択</label>
-              <input type="datetime-local" value={customDateTime} onChange={(e) => setCustomDateTime(e.target.value)}
-                min={new Date().toISOString().slice(0, 16)}
-                className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none focus:ring-2 focus:ring-amber-300"
+          {/* テキスト入力 */}
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div className="px-4 pt-4">
+              <label className="mb-2 block text-xs font-semibold uppercase tracking-wider text-slate-400">投稿内容</label>
+              <textarea
+                value={text} onChange={(e) => setText(e.target.value)}
+                placeholder="今日のおすすめ情報・残り数量・特別メニューなど..."
+                maxLength={MAX_CHARS} rows={5}
+                className="w-full resize-none rounded-xl bg-slate-50 px-3 py-3 text-sm text-slate-800 placeholder-slate-400 outline-none focus:ring-2 focus:ring-amber-300"
               />
             </div>
-          )}
-          {(expirationPreset !== "custom" || customDateTime) && (
-            <div className="mt-3 flex items-center gap-2 rounded-xl bg-amber-50 px-3 py-2">
-              <Clock size={14} className="text-amber-600" />
-              <span className="text-xs text-amber-700">
-                表示ラベル：<span className="font-semibold">「{formatExpirationLabel(expirationPreset, customDateTime)}」</span>
+            <div className="flex items-center justify-between px-4 pb-3">
+              <span className={`text-xs ${text.length > MAX_CHARS * 0.9 ? "text-red-500" : "text-slate-400"}`}>
+                {text.length} / {MAX_CHARS}
               </span>
+              {text.length === 0 && (
+                <span className="flex items-center gap-1 text-xs text-slate-400">
+                  <AlertCircle size={11} />テキストを入力してください
+                </span>
+              )}
             </div>
-          )}
-        </div>
+          </div>
 
-        {/* プレビュー */}
-        {text.trim().length > 0 && (
-          <div>
-            <button type="button" onClick={() => setShowPreview(!showPreview)}
-              className="mb-2 text-sm font-medium text-amber-600 hover:underline"
-            >
-              {showPreview ? "プレビューを閉じる" : "投稿プレビューを確認"}
-            </button>
-            {showPreview && (
-              <div className="rounded-2xl border border-amber-100 bg-white p-4 shadow-sm">
-                <div className="flex items-center gap-2 border-b border-slate-100 pb-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700">出</div>
-                  <div>
-                    <p className="text-sm font-semibold text-slate-800">あなたの店舗</p>
-                    <p className="text-[10px] text-slate-400">{formatExpirationLabel(expirationPreset, customDateTime)}</p>
-                  </div>
-                  <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">公開中</span>
-                </div>
-                <p className="mt-3 whitespace-pre-wrap text-sm text-slate-800">{text}</p>
-                {imagePreview && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={imagePreview} alt="投稿画像" className="mt-3 w-full rounded-xl object-cover" style={{ maxHeight: "200px" }} />
-                )}
+          {/* 画像アップロード */}
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <label className="mb-3 block text-xs font-semibold uppercase tracking-wider text-slate-400">画像（任意）</label>
+            {imagePreview ? (
+              <div className="relative">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={imagePreview} alt="プレビュー" className="h-48 w-full rounded-xl object-cover" />
+                <button type="button" onClick={handleRemoveImage}
+                  className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/50 text-white transition hover:bg-black/70"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ) : (
+              <button type="button" onClick={() => fileInputRef.current?.click()}
+                className="flex h-32 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 text-slate-400 transition hover:border-amber-300 hover:bg-amber-50 hover:text-amber-500"
+              >
+                <ImageIcon size={24} />
+                <span className="text-sm font-medium">タップして画像を追加</span>
+                <span className="text-xs text-slate-400">JPG / PNG / WEBP（5MB以内）</span>
+              </button>
+            )}
+            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
+          </div>
+
+          {/* 表示期間 */}
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <label className="mb-3 block text-xs font-semibold uppercase tracking-wider text-slate-400">表示期間</label>
+            <div className="grid grid-cols-3 gap-2">
+              {EXPIRATION_OPTIONS.map((opt) => {
+                const Icon = opt.icon;
+                const isSelected = expirationPreset === opt.preset;
+                return (
+                  <button key={opt.preset} type="button" onClick={() => setExpirationPreset(opt.preset)}
+                    className={`flex flex-col items-center gap-1.5 rounded-xl border-2 px-2 py-3 text-center transition ${isSelected ? "border-amber-400 bg-amber-50 text-amber-700" : "border-slate-200 bg-white text-slate-600 hover:border-amber-200 hover:bg-amber-50/50"}`}
+                  >
+                    <Icon size={18} />
+                    <span className="text-xs font-semibold">{opt.label}</span>
+                    <span className="text-[10px] leading-tight text-slate-400">{opt.desc}</span>
+                  </button>
+                );
+              })}
+            </div>
+            {expirationPreset === "custom" && (
+              <div className="mt-3">
+                <label className="mb-1.5 block text-xs text-slate-500">終了日時を選択</label>
+                <input type="datetime-local" value={customDateTime} onChange={(e) => setCustomDateTime(e.target.value)}
+                  min={new Date().toISOString().slice(0, 16)}
+                  className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none focus:ring-2 focus:ring-amber-300"
+                />
+              </div>
+            )}
+            {(expirationPreset !== "custom" || customDateTime) && (
+              <div className="mt-3 flex items-center gap-2 rounded-xl bg-amber-50 px-3 py-2">
+                <Clock size={14} className="text-amber-600" />
+                <span className="text-xs text-amber-700">
+                  表示ラベル：<span className="font-semibold">「{formatExpirationLabel(expirationPreset, customDateTime)}」</span>
+                </span>
               </div>
             )}
           </div>
-        )}
 
-        {/* 送信ボタン */}
-        <button type="submit" disabled={!isValid || isSubmitting}
-          className={`flex w-full items-center justify-center gap-2 rounded-2xl py-4 text-base font-bold shadow transition ${
-            isValid && !isSubmitting ? "bg-amber-500 text-white hover:bg-amber-400" : "cursor-not-allowed bg-slate-200 text-slate-400"
-          }`}
-        >
-          {isSubmitting ? <><Loader2 size={18} className="animate-spin" />投稿中...</> : <><Send size={18} />投稿する</>}
-        </button>
+          {/* プレビュー */}
+          {text.trim().length > 0 && (
+            <div>
+              <button type="button" onClick={() => setShowPreview(!showPreview)}
+                className="mb-2 text-sm font-medium text-amber-600 hover:underline"
+              >
+                {showPreview ? "プレビューを閉じる" : "投稿プレビューを確認"}
+              </button>
+              {showPreview && (
+                <div className="rounded-2xl border border-amber-100 bg-white p-4 shadow-sm">
+                  <div className="flex items-center gap-2 border-b border-slate-100 pb-3">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700">出</div>
+                    <div>
+                      <p className="text-sm font-semibold text-slate-800">あなたの店舗</p>
+                      <p className="text-[10px] text-slate-400">{formatExpirationLabel(expirationPreset, customDateTime)}</p>
+                    </div>
+                    <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">公開中</span>
+                  </div>
+                  <p className="mt-3 whitespace-pre-wrap text-sm text-slate-800">{text}</p>
+                  {imagePreview && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={imagePreview} alt="投稿画像" className="mt-3 w-full rounded-xl object-cover" style={{ maxHeight: "200px" }} />
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
-      </form>
+          {/* 送信ボタン */}
+          <button type="submit" disabled={!isValid || isSubmitting}
+            className={`flex w-full items-center justify-center gap-2 rounded-2xl py-4 text-base font-bold shadow transition ${
+              isValid && !isSubmitting ? "bg-amber-500 text-white hover:bg-amber-400" : "cursor-not-allowed bg-slate-200 text-slate-400"
+            }`}
+          >
+            {isSubmitting ? <><Loader2 size={18} className="animate-spin" />投稿中...</> : <><Send size={18} />投稿する</>}
+          </button>
+        </form>
+      )}
+
+      {/* 投稿履歴 */}
+      {activeTab === "history" && (
+        <div className="mx-auto max-w-2xl px-4 pt-4">
+          {historyError && (
+            <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700">{historyError}</div>
+          )}
+
+          <div className="mb-4 flex gap-1.5 rounded-2xl border border-slate-200 bg-white p-1 shadow-sm">
+            {FILTER_TABS.map((tab) => (
+              <button key={tab.key} onClick={() => setFilterTab(tab.key)}
+                className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-xs font-semibold transition ${filterTab === tab.key ? "bg-amber-500 text-white shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
+              >
+                {tab.label}
+                <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold ${filterTab === tab.key ? "bg-amber-400 text-white" : "bg-slate-100 text-slate-400"}`}>
+                  {tab.count}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {isLoadingPosts ? (
+            <div className="flex justify-center py-12">
+              <Loader2 size={28} className="animate-spin text-amber-500" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-sm text-slate-400">投稿がありません</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {filtered.map((post) => (
+                <PostCard key={post.id} post={post} onRepost={handleRepost} onEditRepost={handleEditRepost} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 再投稿トースト */}
+      {showRepostToast && (
+        <div className="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 transform">
+          <div className="flex items-center gap-2 rounded-2xl bg-emerald-600 px-5 py-3 shadow-lg">
+            <CheckCircle2 size={16} className="text-white" />
+            <span className="text-sm font-semibold text-white">再投稿しました！</span>
+            <button onClick={() => setShowRepostToast(false)} className="ml-2 text-emerald-200 hover:text-white">
+              <XCircle size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+
       <NavigationBar />
     </div>
   );


### PR DESCRIPTION
- 出店者メニューから「投稿履歴」を独立メニューとして削除
- 「最新情報の発信」ページのヘッダーに投稿履歴へのリンクボタンを追加