### PR TITLE
consult画面の背景とGrandmaChatterのconsultバリアントで装飾を抑制

### DIFF
--- a/app/(public)/consult/ConsultClient.tsx
+++ b/app/(public)/consult/ConsultClient.tsx
@@ -85,25 +85,15 @@ export default function ConsultClient({ shops }: ConsultClientProps) {
 
   return (
     <div
-      className="relative overflow-hidden bg-[#fbf8f3]"
+      className="relative overflow-hidden bg-[var(--consult-bg)]"
       style={{ height: "100svh" }}
     >
-      <div
-        className="pointer-events-none fixed inset-0 z-0"
-        style={{
-          backgroundImage: "url('/images/maps/placeholder-map.svg')",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          filter: "blur(8px)",
-          opacity: 0.35,
-          transform: "scale(1.05)",
-        }}
-        aria-hidden="true"
-      />
+      <div className="pointer-events-none absolute inset-0 z-0 bg-[var(--consult-bg)]" aria-hidden="true" />
       <main className="relative z-10 flex h-full w-full items-start justify-center px-3 pb-24 pt-20">
         <GrandmaChatter
           titleLabel="にちよさん"
           fullWidth
+          variant="consult"
           comments={grandmaComments}
           onAsk={handleGrandmaAsk}
           allShops={shops}

--- a/app/(public)/consult/page.tsx
+++ b/app/(public)/consult/page.tsx
@@ -18,7 +18,7 @@ async function loadShops(): Promise<Shop[]> {
 export default async function ConsultPage() {
   const shops = await loadShops();
   return (
-    <Suspense fallback={<div className="h-screen w-full bg-[#fbf8f3]" />}>
+    <Suspense fallback={<div className="h-screen w-full bg-[var(--consult-bg)]" />}>
       <ConsultClient shops={shops} />
     </Suspense>
   );

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -50,6 +50,7 @@ type GrandmaChatterProps = {
   autoAskContext?: { shopId?: number; shopName?: string };
   currentZoom?: number;
   enableSpeechInput?: boolean;
+  variant?: "default" | "consult";
 };
 
 export default function GrandmaChatter({
@@ -77,7 +78,9 @@ export default function GrandmaChatter({
   autoAskContext,
   currentZoom,
   enableSpeechInput = false,
+  variant = "default",
 }: GrandmaChatterProps) {
+  const isConsultVariant = variant === "consult";
   const pool = comments && comments.length > 0 ? comments : grandmaCommentPool;
   const [currentId, setCurrentId] = useState<string | undefined>(() => pool[0]?.id);
   const current = useMemo(
@@ -783,7 +786,11 @@ export default function GrandmaChatter({
       ? "relative z-[1000] w-full max-w-none border-0 bg-transparent px-4 py-0 text-left shadow-none pointer-events-auto"
       : "group relative z-[1000] w-full max-w-3xl rounded-2xl border-2 bg-white/95 px-4 py-4 text-left shadow-xl backdrop-blur transition hover:-translate-y-0.5 hover:shadow-2xl pointer-events-auto"
     : "group relative z-[1000] max-w-[280px] rounded-2xl border-2 bg-white/95 px-4 py-4 text-left shadow-xl backdrop-blur transition hover:-translate-y-0.5 hover:shadow-2xl sm:max-w-sm pointer-events-auto";
-  const bubbleBorderClass = isShopIntro ? "border-emerald-400" : "border-amber-400";
+  const bubbleBorderClass = isConsultVariant
+    ? "border-[var(--consult-border)]"
+    : isShopIntro
+      ? "border-emerald-400"
+      : "border-amber-400";
   const bubbleStateClass =
     holdPhase === "active"
       ? "invisible"
@@ -851,7 +858,7 @@ export default function GrandmaChatter({
             }}
           >
             <div className={labelClassName}>
-              <span className="grandma-title-label relative -top-[4px] z-[2001] inline-flex items-center whitespace-nowrap rounded-full bg-amber-500 px-3 py-1 font-semibold text-white shadow-sm">
+              <span className={`grandma-title-label relative -top-[4px] z-[2001] inline-flex items-center whitespace-nowrap rounded-full px-3 py-1 font-semibold text-white ${isConsultVariant ? "bg-slate-700" : "bg-amber-500 shadow-sm"}`}>
                 {titleLabel}
               </span>
             </div>
@@ -901,7 +908,7 @@ export default function GrandmaChatter({
                     }
                     router.push(`/consult?${params.toString()}`);
                   }}
-                  className="rounded-full bg-white/90 border border-amber-200 px-4 py-2 text-sm font-bold text-amber-800 shadow-md backdrop-blur-sm transition hover:scale-105 hover:bg-white active:scale-95 animate-in fade-in slide-in-from-bottom-4 duration-500"
+                  className={`rounded-full border px-4 py-2 text-sm font-bold backdrop-blur-sm transition hover:scale-105 active:scale-95 animate-in fade-in slide-in-from-bottom-4 duration-500 ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)] text-slate-700 hover:bg-white" : "border-amber-200 bg-white/90 text-amber-800 shadow-md hover:bg-white"}` }
                   style={{ animationDelay: `${i * 100}ms` }}
                 >
                   <span className="mr-1">💡</span>
@@ -917,7 +924,7 @@ export default function GrandmaChatter({
             aria-label="おばあちゃんとの会話"
           >
             <div className="flex items-center justify-between gap-3 pb-3">
-              <div className="text-sm font-semibold text-amber-800">にちよさんAI</div>
+              <div className={`text-sm font-semibold ${isConsultVariant ? "text-slate-700" : "text-amber-800"}`}>にちよさんAI</div>
               <div className="flex items-center gap-3">
                 {aiStatus !== "idle" && (
                   <span className="text-[11px] text-gray-500">
@@ -953,7 +960,7 @@ export default function GrandmaChatter({
               }`}
             >
               <div className="flex flex-col items-center justify-center gap-2 py-8 opacity-90">
-                <div className="h-32 w-32 overflow-hidden rounded-full border-4 border-amber-200 bg-amber-50 shadow-sm">
+                <div className={`h-32 w-32 overflow-hidden rounded-full border-4 shadow-sm ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-200 bg-amber-50"}`}>
                   <img
                     src={PLACEHOLDER_IMAGE}
                     alt="にちよさん"
@@ -962,7 +969,7 @@ export default function GrandmaChatter({
                   />
                 </div>
                 <div className="text-center">
-                  <div className="text-lg font-bold text-amber-800">にちよさん</div>
+                  <div className={`text-lg font-bold ${isConsultVariant ? "text-slate-700" : "text-amber-800"}`}>にちよさん</div>
                   <div className="text-sm text-gray-600">日曜市のことをなんでも聞いてね</div>
                 </div>
               </div>
@@ -976,7 +983,7 @@ export default function GrandmaChatter({
                 >
                   {message.role === "assistant" && (
                     <div className="flex-shrink-0">
-                      <div className="h-10 w-10 overflow-hidden rounded-full border border-amber-200 bg-amber-50 shadow-sm">
+                      <div className={`h-10 w-10 overflow-hidden rounded-full border shadow-sm ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-200 bg-amber-50"}`}>
                         <img
                           src={PLACEHOLDER_IMAGE}
                           alt="にちよさん"
@@ -990,8 +997,12 @@ export default function GrandmaChatter({
                   <div
                     className={`relative max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm ${
                       message.role === "user"
-                        ? "bg-amber-500 text-white rounded-tr-sm"
-                        : "bg-white border border-amber-100 text-slate-900 rounded-tl-sm"
+                        ? isConsultVariant
+                          ? "bg-slate-700 text-white rounded-tr-sm"
+                          : "bg-amber-500 text-white rounded-tr-sm"
+                        : isConsultVariant
+                          ? "bg-[var(--consult-surface)] border border-[var(--consult-border)] text-slate-900 rounded-tl-sm"
+                          : "bg-white border border-amber-100 text-slate-900 rounded-tl-sm"
                     }`}
                   >
                     <p className="whitespace-pre-wrap">{message.text}</p>
@@ -1055,7 +1066,7 @@ export default function GrandmaChatter({
               {aiStatus === "thinking" && (
                 <div className="flex justify-start items-start gap-2">
                   <div className="flex-shrink-0">
-                    <div className="h-10 w-10 overflow-hidden rounded-full border border-amber-200 bg-amber-50 shadow-sm">
+                    <div className={`h-10 w-10 overflow-hidden rounded-full border shadow-sm ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-200 bg-amber-50"}`}>
                       <img
                         src={PLACEHOLDER_IMAGE}
                         alt="にちよさん"
@@ -1286,13 +1297,13 @@ export default function GrandmaChatter({
             </button>
           )}
           {aiSuggestedShops && aiSuggestedShops.length > 0 && !isKeyboardOpen && !isChatOpen && (
-            <div className="rounded-2xl border-2 border-orange-300 bg-white/95 p-4 shadow-sm translate-y-[5px]">
+            <div className={`rounded-2xl border-2 p-4 shadow-sm translate-y-[5px] ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-orange-300 bg-white/95"}`}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <span className="ai-label-playful text-lg text-pink-600">AIおすすめ</span>
+                  <span className={`ai-label-playful text-lg ${isConsultVariant ? "text-slate-600" : "text-pink-600"}`}>AIおすすめ</span>
                   <span className="text-lg font-bold text-gray-900">提案されたお店</span>
                 </div>
-                <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 border border-amber-100">
+                <span className={`rounded-full px-3 py-1 text-xs font-semibold border ${isConsultVariant ? "bg-slate-100 text-slate-700 border-[var(--consult-border)]" : "bg-amber-50 text-amber-800 border-amber-100"}`}>
                   {aiSuggestedShops.length}店
                 </span>
               </div>
@@ -1324,7 +1335,7 @@ export default function GrandmaChatter({
             </div>
           )}
           <div
-            className={`rounded-2xl border-2 border-amber-300 bg-white/95 p-3 shadow-sm transition-transform duration-200 ${
+            className={`rounded-2xl border-2 p-3 shadow-sm transition-transform duration-200 ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-300 bg-white/95"} ${
               isChatOpen ? "scale-100" : "scale-95"
             }`}
           >
@@ -1339,14 +1350,14 @@ export default function GrandmaChatter({
                   <button
                     type="button"
                     onClick={() => handleAskSubmit(activeConsultExample, { source: "suggestion" })}
-                    className="group inline-flex w-full items-center justify-between gap-2 rounded-xl border border-amber-100 bg-white/80 px-3 py-1.5 text-left text-[11px] text-slate-500 shadow-inner transition hover:border-amber-200 hover:bg-amber-50/70"
+                    className={`group inline-flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-1.5 text-left text-[11px] text-slate-500 shadow-inner transition ${isConsultVariant ? "border-[var(--consult-border)] bg-white hover:bg-slate-50" : "border-amber-100 bg-white/80 hover:border-amber-200 hover:bg-amber-50/70"}` }
                     aria-label={`質問例: ${activeConsultExample}`}
                   >
                     <span className="flex items-center gap-2">
-                      <span className="text-[10px] font-semibold text-amber-600">質問例</span>
+                      <span className={`text-[10px] font-semibold ${isConsultVariant ? "text-slate-600" : "text-amber-600"}`}>質問例</span>
                       <span className="text-slate-600">{activeConsultExample}</span>
                     </span>
-                    <span className="text-[11px] text-amber-500">送信</span>
+                    <span className={`text-[11px] ${isConsultVariant ? "text-slate-500" : "text-amber-500"}`}>送信</span>
                   </button>
                 )}
               </div>
@@ -1388,7 +1399,9 @@ export default function GrandmaChatter({
                   className={`w-full rounded-xl border px-3 py-2 text-base shadow-sm focus:outline-none focus:ring-2 ${
                     aiStatus === "thinking"
                       ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
-                      : "border-amber-200 bg-white text-gray-900 focus:ring-amber-400"
+                      : isConsultVariant
+                        ? "border-[var(--consult-border)] bg-white text-gray-900 focus:ring-slate-400"
+                        : "border-amber-200 bg-white text-gray-900 focus:ring-amber-400"
                   }`}
                   placeholder={smartContext.placeholder}
                 />
@@ -1402,7 +1415,9 @@ export default function GrandmaChatter({
                         ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
                         : isListening
                           ? "border-red-300 bg-red-50 text-red-600 hover:bg-red-100"
-                          : "border-amber-200 bg-white text-amber-700 hover:bg-amber-50"
+                          : isConsultVariant
+                            ? "border-[var(--consult-border)] bg-white text-slate-700 hover:bg-slate-50"
+                            : "border-amber-200 bg-white text-amber-700 hover:bg-amber-50"
                     }`}
                     aria-label={isListening ? "音声入力を停止" : "音声入力を開始"}
                   >
@@ -1434,7 +1449,9 @@ export default function GrandmaChatter({
                   className={`flex h-10 w-10 items-center justify-center rounded-xl border shadow-sm transition ${
                     aiStatus === "thinking"
                       ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
-                      : "border-amber-200 bg-amber-600 text-white hover:bg-amber-500"
+                      : isConsultVariant
+                        ? "border-[var(--consult-border)] bg-slate-700 text-white hover:bg-slate-600"
+                        : "border-amber-200 bg-amber-600 text-white hover:bg-amber-500"
                   }`}
                   aria-label="メッセージを送る"
                 >

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,9 @@
  */
 :root {
   --vh: 1vh; /* JavaScriptで動的に更新 */
+  --consult-bg: radial-gradient(120% 120% at 10% 0%, #f3f6fb 0%, #e8edf5 45%, #dce4ef 100%);
+  --consult-surface: rgba(255, 255, 255, 0.94);
+  --consult-border: rgba(148, 163, 184, 0.45);
 }
 
 /* safe-area対応！EOS刁E��欠き�EAndroid ジェスチャーバ�E�E�E*/


### PR DESCRIPTION
### Motivation
- consultモードで地図の固定ぼかし背景（`placeholder-map.svg`）が強すぎるため、より落ち着いた背景と高コントラスト面で統一したい。 
- GrandmaChatterの amber 系の強い装飾（太ボーダー・強い影・多色バッジ）は相談モードでは抑制して視認性を安定させたい。 

### Description
- `app/(public)/consult/ConsultClient.tsx` から固定ぼかし背景の `placeholder-map.svg` を削除し、コンテナの背景を `--consult-bg` に変更して `variant="consult"` を `GrandmaChatter` に渡すように変更しました。 
- `app/globals.css` に consult 専用トークン `--consult-bg` / `--consult-surface` / `--consult-border` を追加して背景・面・境界のテーマを一元化しました。 
- `app/(public)/map/components/GrandmaChatter.tsx` に `variant?: "default" | "consult"` を追加し、`variant === "consult"` 時はラベル・バッジ・ボタン・吹き出し境界などの amber 系強装飾を consult トークン寄りの落ち着いたスタイルへ切り替える分岐を実装しました。 
- `app/(public)/consult/page.tsx` の `Suspense` fallback 背景を consult テーマに合わせて `bg-[var(--consult-bg)]` に更新しました。 

### Testing
- `npm run build` を実行しコンパイルと TypeScript チェックは通過しましたが、`/(public)/signup` のプリレンダーで `Supabase env vars are missing.` によりビルドが終了しました（環境依存の既知の失敗）。 
- `npm run dev` でローカル起動を確認し `/consult` ページは問題なく表示されることを目視確認しました。 
- Playwright を使ったスクリーンショット取得スクリプトを実行して `/consult` の見た目を画像で取得しアーティファクトを生成しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b86a15b88325ae5217d50493b323)