### PR TITLE
consult向けチャットUIをプリミティブ化し読みやすさ優先で整理

### DIFF
--- a/app/(public)/consult/components/MessageBubble.tsx
+++ b/app/(public)/consult/components/MessageBubble.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+
+import type { ReactNode } from "react";
+
+type MessageBubbleProps = {
+  role: "user" | "assistant";
+  children: ReactNode;
+  variant?: "default" | "consult";
+  className?: string;
+};
+
+export default function MessageBubble({
+  role,
+  children,
+  variant = "default",
+  className,
+}: MessageBubbleProps) {
+  const isConsult = variant === "consult";
+
+  return (
+    <div
+      className={cn(
+        "relative max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap break-words",
+        role === "user"
+          ? isConsult
+            ? "rounded-tr-sm bg-slate-700 text-white"
+            : "rounded-tr-sm bg-amber-500 text-white"
+          : isConsult
+            ? "rounded-tl-sm border border-[var(--consult-border)] bg-[var(--consult-surface)] text-slate-900"
+            : "rounded-tl-sm border border-amber-100 bg-white text-slate-900",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -4,6 +4,12 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import MessageBubble from "../../consult/components/MessageBubble";
 import { grandmaAiInstructorLines } from "../data/grandmaComments";
 import { grandmaCommentPool, pickNextComment } from "../services/grandmaCommentService";
 import type { Shop } from "../data/shops";
@@ -125,7 +131,7 @@ export default function GrandmaChatter({
   const rafRef = useRef<number | null>(null);
   const pendingOffsetRef = useRef<{ x: number; y: number } | null>(null);
   const holdTimerRef = useRef<number | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const askRequestRef = useRef(0);
   const lastAvatarOffsetRef = useRef({ x: 0, y: 0 });
@@ -908,7 +914,7 @@ export default function GrandmaChatter({
                     }
                     router.push(`/consult?${params.toString()}`);
                   }}
-                  className={`rounded-full border px-4 py-2 text-sm font-bold backdrop-blur-sm transition hover:scale-105 active:scale-95 animate-in fade-in slide-in-from-bottom-4 duration-500 ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)] text-slate-700 hover:bg-white" : "border-amber-200 bg-white/90 text-amber-800 shadow-md hover:bg-white"}` }
+                  className={`rounded-full border px-4 py-2 text-sm font-bold backdrop-blur-sm transition ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)] text-slate-700 hover:bg-white" : "border-amber-200 bg-white/90 text-amber-800 shadow-md hover:bg-white hover:scale-105 active:scale-95 animate-in fade-in slide-in-from-bottom-4 duration-500"}` }
                   style={{ animationDelay: `${i * 100}ms` }}
                 >
                   <span className="mr-1">💡</span>
@@ -927,13 +933,15 @@ export default function GrandmaChatter({
               <div className={`text-sm font-semibold ${isConsultVariant ? "text-slate-700" : "text-amber-800"}`}>にちよさんAI</div>
               <div className="flex items-center gap-3">
                 {aiStatus !== "idle" && (
-                  <span className="text-[11px] text-gray-500">
+                  <Badge variant="secondary" className="text-[11px]">
                     {aiStatus === "thinking" ? "考え中…" : "続けて聞いてね"}
-                  </span>
+                  </Badge>
                 )}
                 {layout === "page" && chatMessages.length > 0 && (
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
+                    size="default"
                     onClick={() => {
                       if (window.confirm("これまでの会話を消してもいいですか？")) {
                         setChatMessages([]);
@@ -944,16 +952,16 @@ export default function GrandmaChatter({
                         }
                       }
                     }}
-                    className="rounded-full bg-slate-100 px-2 py-1 text-[10px] font-medium text-slate-500 hover:bg-slate-200"
+                    className="h-auto rounded-full px-2 py-1 text-[10px] font-medium text-slate-500"
                   >
                     最初から話す
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>
-            <div
+            <ScrollArea
               ref={chatScrollRef}
-              className={`mt-2 flex flex-col gap-4 overflow-y-auto pr-1 ${
+              className={`mt-2 flex flex-col gap-4 pr-1 ${
                 layout === "page"
                   ? "h-[calc(100svh-72px-var(--safe-bottom,0px))] pb-40"
                   : "max-h-[calc(100vh-240px)]"
@@ -994,18 +1002,8 @@ export default function GrandmaChatter({
                     </div>
                   )}
 
-                  <div
-                    className={`relative max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm ${
-                      message.role === "user"
-                        ? isConsultVariant
-                          ? "bg-slate-700 text-white rounded-tr-sm"
-                          : "bg-amber-500 text-white rounded-tr-sm"
-                        : isConsultVariant
-                          ? "bg-[var(--consult-surface)] border border-[var(--consult-border)] text-slate-900 rounded-tl-sm"
-                          : "bg-white border border-amber-100 text-slate-900 rounded-tl-sm"
-                    }`}
-                  >
-                    <p className="whitespace-pre-wrap">{message.text}</p>
+                  <MessageBubble role={message.role} variant={isConsultVariant ? "consult" : "default"} className="shadow-sm">
+                    {message.text}
                     {message.localImageUrl && (
                       <div className="mt-2 overflow-hidden rounded-xl border border-amber-100 bg-white">
                         <img
@@ -1060,7 +1058,7 @@ export default function GrandmaChatter({
                         />
                       </button>
                     )}
-                  </div>
+                  </MessageBubble>
                 </div>
               ))}
               {aiStatus === "thinking" && (
@@ -1086,7 +1084,7 @@ export default function GrandmaChatter({
                   </div>
                 </div>
               )}
-            </div>
+            </ScrollArea>
             {showScrollToBottom && (
               <button
                 type="button"
@@ -1334,10 +1332,10 @@ export default function GrandmaChatter({
               )}
             </div>
           )}
-          <div
-            className={`rounded-2xl border-2 p-3 shadow-sm transition-transform duration-200 ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-300 bg-white/95"} ${
-              isChatOpen ? "scale-100" : "scale-95"
-            }`}
+          <Card
+            className={`rounded-2xl border-2 p-3 ${isConsultVariant ? "border-[var(--consult-border)] bg-[var(--consult-surface)]" : "border-amber-300 bg-white/95"} ${
+              isConsultVariant ? "transition-colors duration-150" : "transition-transform duration-200"
+            } ${!isConsultVariant && !isChatOpen ? "scale-95" : "scale-100"}`}
           >
             <div className="flex flex-col gap-2">
               <div
@@ -1354,14 +1352,14 @@ export default function GrandmaChatter({
                     aria-label={`質問例: ${activeConsultExample}`}
                   >
                     <span className="flex items-center gap-2">
-                      <span className={`text-[10px] font-semibold ${isConsultVariant ? "text-slate-600" : "text-amber-600"}`}>質問例</span>
+                      <Badge variant="outline" className={`text-[10px] font-semibold ${isConsultVariant ? "text-slate-600" : "text-amber-600"}`}>質問例</Badge>
                       <span className="text-slate-600">{activeConsultExample}</span>
                     </span>
-                    <span className={`text-[11px] ${isConsultVariant ? "text-slate-500" : "text-amber-500"}`}>送信</span>
+                    <Badge variant="secondary" className={`text-[11px] ${isConsultVariant ? "text-slate-500" : "text-amber-500"}`}>送信</Badge>
                   </button>
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-end gap-2">
                 <input
                   ref={imageInputRef}
                   type="file"
@@ -1369,17 +1367,18 @@ export default function GrandmaChatter({
                   onChange={handleImagePick}
                   className="hidden"
                 />
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="icon"
                   onClick={() => imageInputRef.current?.click()}
-                  className="flex h-10 w-10 items-center justify-center rounded-xl border border-amber-200 bg-white text-lg font-semibold text-amber-700 shadow-sm transition hover:bg-amber-50"
+                  className="border-amber-200 bg-white text-lg font-semibold text-amber-700 hover:bg-amber-50"
                   aria-label="写真を選ぶ"
                 >
                   +
-                </button>
-                <input
+                </Button>
+                <Textarea
                   ref={inputRef}
-                  type="text"
                   value={askText}
                   onChange={(e) => {
                     const nextValue = e.target.value;
@@ -1395,22 +1394,31 @@ export default function GrandmaChatter({
                       setShouldShowValidation(true);
                     }
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      handleAskSubmit();
+                    }
+                  }}
                   disabled={aiStatus === "thinking"}
-                  className={`w-full rounded-xl border px-3 py-2 text-base shadow-sm focus:outline-none focus:ring-2 ${
+                  rows={2}
+                  className={`min-h-[44px] max-h-28 resize-none ${
                     aiStatus === "thinking"
                       ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
                       : isConsultVariant
-                        ? "border-[var(--consult-border)] bg-white text-gray-900 focus:ring-slate-400"
-                        : "border-amber-200 bg-white text-gray-900 focus:ring-amber-400"
+                        ? "border-[var(--consult-border)] bg-white text-gray-900 focus-visible:ring-slate-400"
+                        : "border-amber-200 bg-white text-gray-900 focus-visible:ring-amber-400"
                   }`}
                   placeholder={smartContext.placeholder}
                 />
                 {enableSpeechInput && (
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
+                    size="icon"
                     onClick={startSpeechRecognition}
                     disabled={!isSpeechSupported || aiStatus === "thinking"}
-                    className={`flex h-10 w-10 items-center justify-center rounded-xl border shadow-sm transition ${
+                    className={`${
                       !isSpeechSupported || aiStatus === "thinking"
                         ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
                         : isListening
@@ -1440,13 +1448,14 @@ export default function GrandmaChatter({
                         <line x1="8" y1="23" x2="16" y2="23" />
                       </svg>
                     )}
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
                   type="button"
+                  size="icon"
                   onClick={() => handleAskSubmit()}
                   disabled={aiStatus === "thinking"}
-                  className={`flex h-10 w-10 items-center justify-center rounded-xl border shadow-sm transition ${
+                  className={`${
                     aiStatus === "thinking"
                       ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
                       : isConsultVariant
@@ -1468,7 +1477,7 @@ export default function GrandmaChatter({
                     <path d="M22 2 11 13" />
                     <path d="M22 2 15 22 11 13 2 9 22 2" />
                   </svg>
-                </button>
+                </Button>
               </div>
               {enableSpeechInput && !isSpeechSupported && (
                 <div className="text-[11px] text-slate-500">
@@ -1476,10 +1485,10 @@ export default function GrandmaChatter({
                 </div>
               )}
               {enableSpeechInput && isListening && (
-                <div className="flex items-center gap-2 text-[11px] text-red-600">
-                  <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+                <Badge variant="destructive" className="w-fit gap-2 text-[11px]">
+                  <span className="h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
                   音声入力中
-                </div>
+                </Badge>
               )}
               {selectedImageName && (
                 <div className="text-[11px] text-slate-600">
@@ -1492,7 +1501,7 @@ export default function GrandmaChatter({
                 </div>
               )}
             </div>
-          </div>
+          </Card>
         </div>
       </div>
     </div>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type BadgeProps = React.HTMLAttributes<HTMLDivElement> & {
+  variant?: "default" | "secondary" | "outline" | "destructive";
+};
+
+const badgeVariantClassMap: Record<NonNullable<BadgeProps["variant"]>, string> = {
+  default: "border-transparent bg-slate-700 text-white",
+  secondary: "border-transparent bg-slate-100 text-slate-700",
+  outline: "border bg-white text-slate-700",
+  destructive: "border-transparent bg-rose-100 text-rose-700",
+};
+
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+        badgeVariantClassMap[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "default" | "outline" | "ghost";
+  size?: "default" | "icon";
+};
+
+const variantClassMap: Record<NonNullable<ButtonProps["variant"]>, string> = {
+  default: "bg-slate-700 text-white hover:bg-slate-600",
+  outline: "border bg-white hover:bg-slate-50",
+  ghost: "bg-transparent hover:bg-slate-100",
+};
+
+const sizeClassMap: Record<NonNullable<ButtonProps["size"]>, string> = {
+  default: "h-10 px-4 py-2",
+  icon: "h-10 w-10",
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", type = "button", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          "inline-flex items-center justify-center rounded-xl border text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+          variantClassMap[variant],
+          sizeClassMap[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("rounded-2xl border bg-white text-slate-900 shadow-sm", className)} {...props} />
+  )
+);
+Card.displayName = "Card";

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const ScrollArea = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("relative overflow-y-auto", className)} {...props} />
+  )
+);
+ScrollArea.displayName = "ScrollArea";

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "min-h-[72px] w-full rounded-xl border px-3 py-2 text-base shadow-sm focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
### Motivation
- consult（相談）画面の `GrandmaChatter` を段階的に置換し、既存の Tailwind 設定を活かした再利用可能な UI プリミティブを導入して保守性を高めるため。
- 吹き出しの幅・余白・改行ルールを相談専用に統一して可読性を向上させるため。
- consult モードでの過剰なホバー/アニメーションを抑え、読みやすさ優先のモーションに調整するため。

### Description
- `components/ui` にローカル UI プリミティブを追加：`Button`, `Badge`, `Card`, `ScrollArea`, `Textarea` を新規作成し、`cn` を使った最小の variant/size 管理を実装。
- `app/(public)/consult/components/MessageBubble.tsx` を新規追加して user／assistant の吹き出しの見た目（最大幅、padding、改行/折返し）を統一。
- `app/(public)/map/components/GrandmaChatter.tsx` を consult モード向けに段階置換：
  - メッセージ一覧を `ScrollArea` に差し替え。
  - 入力欄を `Textarea` に変更し、送信や補助操作を `Button` コンポーネント化（Enterで送信、Shift+Enterで改行）。
  - 提案チップやステータス表示を `Badge` へ置換。入力エリアを `Card` でラップしてスタイルを統一。 
- consult モードでは提案チップの `hover:scale` / 強いアニメーションを無効化し、入力カードは色変化中心のトランジションへ変更して過剰アニメーションを抑制。

### Testing
- `npm run build`: アプリはコンパイル成功（TypeScript / Next.js のビルドは通過）ですが、環境依存で `/signup` ページの prerender が `Supabase env vars are missing.` により失敗しました（環境変数不足による既知の制約）。
- `npm run dev` で開発サーバ起動および `http://localhost:3000/consult` にアクセスして UI 差し替えを目視確認（起動成功、該当画面の動作確認を実施）。
- consult ページのスクリーンショットを取得して表示確認を行いました（UI 表示の自動取得による目視検証）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c19a974c83258f757f3137c52482)