### PR TITLE
 マップ道路データ対応と操作系の整理、map-edit の道路編集機能を追加Feature/map

### DIFF
--- a/app/(public)/map-edit/MapEditClient.tsx
+++ b/app/(public)/map-edit/MapEditClient.tsx
@@ -4,6 +4,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { Trash2 } from "lucide-react";
 import type { Landmark as EditableLandmark } from "../map/types/landmark";
+import type { MapRoute, MapRouteConfig, MapRoutePoint } from "../map/types/mapRoute";
+import {
+  getDefaultMapRouteConfig,
+  getDefaultMapRoutePoints,
+  normalizeMapRoutePoints,
+} from "../map/utils/mapRouteGeometry";
 
 type EditableShop = {
   locationId: string;
@@ -57,6 +63,14 @@ function cloneLandmarks(landmarks: EditableLandmark[]) {
   return landmarks.map((landmark) => ({ ...landmark }));
 }
 
+function cloneRoutePoints(points: MapRoutePoint[]) {
+  return points.map((point) => ({ ...point }));
+}
+
+function cloneRouteConfig(config: MapRouteConfig) {
+  return { ...config };
+}
+
 function getUnassignedPriority(shop: EditableShop) {
   if (shop.vendorId) return Number.NEGATIVE_INFINITY;
   if (shop.locationId.startsWith("new-")) {
@@ -93,6 +107,7 @@ async function fetchMapLayout() {
   return response.json() as Promise<{
     shops?: EditableShop[];
     landmarks?: EditableLandmark[];
+    route?: MapRoute;
     vendors?: VendorOption[];
   }>;
 }
@@ -100,11 +115,15 @@ async function fetchMapLayout() {
 export default function MapEditClient() {
   const [shops, setShops] = useState<EditableShop[]>([]);
   const [landmarks, setLandmarks] = useState<EditableLandmark[]>([]);
+  const [routePoints, setRoutePoints] = useState<MapRoutePoint[]>([]);
+  const [routeConfig, setRouteConfig] = useState<MapRouteConfig>(getDefaultMapRouteConfig());
   const [initialShops, setInitialShops] = useState<EditableShop[]>([]);
   const [initialLandmarks, setInitialLandmarks] = useState<EditableLandmark[]>([]);
+  const [initialRoutePoints, setInitialRoutePoints] = useState<MapRoutePoint[]>([]);
+  const [initialRouteConfig, setInitialRouteConfig] = useState<MapRouteConfig>(getDefaultMapRouteConfig());
   const [vendorOptions, setVendorOptions] = useState<VendorOption[]>([]);
   const [mode, setMode] = useState<"edit" | "preview">("edit");
-  const [selectedKind, setSelectedKind] = useState<"shop" | "landmark">("shop");
+  const [selectedKind, setSelectedKind] = useState<"shop" | "landmark" | "route">("shop");
   const [selectedId, setSelectedId] = useState<string>("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -118,6 +137,7 @@ export default function MapEditClient() {
   const [isRestoring, setIsRestoring] = useState<string | null>(null);
   const shopItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const landmarkItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const routePointItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   useEffect(() => {
     let active = true;
@@ -136,14 +156,23 @@ export default function MapEditClient() {
         const nextLandmarks = Array.isArray(data.landmarks)
           ? (data.landmarks as EditableLandmark[])
           : [];
+        const nextRoutePoints = normalizeMapRoutePoints(data.route?.points ?? getDefaultMapRoutePoints());
+        const nextRouteConfig = {
+          ...getDefaultMapRouteConfig(),
+          ...(data.route?.config ?? {}),
+        };
         const nextVendors = Array.isArray(data.vendors) ? (data.vendors as VendorOption[]) : [];
         const nextMapSettings = { ...DEFAULT_MAP_SETTINGS, ...(settingsData.map ?? {}) };
         setShops(sortShops(nextShops));
         setLandmarks(nextLandmarks);
+        setRoutePoints(nextRoutePoints);
+        setRouteConfig(nextRouteConfig);
         setVendorOptions(nextVendors);
         setMapSettings(nextMapSettings);
         setInitialShops(cloneShops(nextShops));
         setInitialLandmarks(cloneLandmarks(nextLandmarks));
+        setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
+        setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
       })
       .catch(() => {
         if (!active) return;
@@ -164,6 +193,10 @@ export default function MapEditClient() {
   const selectedLandmark = useMemo(
     () => landmarks.find((landmark) => landmark.key === selectedId) ?? null,
     [landmarks, selectedId]
+  );
+  const selectedRoutePoint = useMemo(
+    () => routePoints.find((point) => point.id === selectedId) ?? null,
+    [routePoints, selectedId]
   );
   const normalizedShopQuery = shopQuery.trim().toLowerCase();
   const normalizedLandmarkQuery = landmarkQuery.trim().toLowerCase();
@@ -190,6 +223,7 @@ export default function MapEditClient() {
       }),
     [landmarks, normalizedLandmarkQuery, selectedId, selectedKind]
   );
+  const filteredRoutePoints = useMemo(() => routePoints, [routePoints]);
   const hasUnsavedChanges = useMemo(() => {
     const initialShopMap = new Map(initialShops.map((shop) => [shop.locationId, shop]));
     const currentShopMap = new Map(shops.map((shop) => [shop.locationId, shop]));
@@ -223,9 +257,36 @@ export default function MapEditClient() {
     const deletedLandmarkExists = initialLandmarks.some(
       (landmark) => !currentLandmarkMap.has(landmark.key)
     );
+    const routePointsChanged =
+      initialRoutePoints.length !== routePoints.length ||
+      routePoints.some((point, index) => {
+        const initial = initialRoutePoints[index];
+        if (!initial) return true;
+        return initial.id !== point.id || initial.lat !== point.lat || initial.lng !== point.lng;
+      });
+    const routeConfigChanged =
+      initialRouteConfig.roadHalfWidthMeters !== routeConfig.roadHalfWidthMeters ||
+      initialRouteConfig.snapDistanceMeters !== routeConfig.snapDistanceMeters ||
+      initialRouteConfig.visibleDistanceMeters !== routeConfig.visibleDistanceMeters;
 
-    return updatedShopExists || deletedShopExists || updatedLandmarkExists || deletedLandmarkExists;
-  }, [initialLandmarks, initialShops, landmarks, shops]);
+    return (
+      updatedShopExists ||
+      deletedShopExists ||
+      updatedLandmarkExists ||
+      deletedLandmarkExists ||
+      routePointsChanged ||
+      routeConfigChanged
+    );
+  }, [
+    initialLandmarks,
+    initialRouteConfig,
+    initialRoutePoints,
+    initialShops,
+    landmarks,
+    routeConfig,
+    routePoints,
+    shops,
+  ]);
 
   const loadSnapshots = async () => {
     setIsLoadingSnapshots(true);
@@ -247,10 +308,12 @@ export default function MapEditClient() {
     const target =
       selectedKind === "shop"
         ? shopItemRefs.current[selectedId]
-        : landmarkItemRefs.current[selectedId];
+        : selectedKind === "landmark"
+          ? landmarkItemRefs.current[selectedId]
+          : routePointItemRefs.current[selectedId];
 
     target?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-  }, [filteredLandmarks, filteredShops, selectedId, selectedKind]);
+  }, [filteredLandmarks, filteredRoutePoints, filteredShops, selectedId, selectedKind]);
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -291,12 +354,25 @@ export default function MapEditClient() {
       const deletedLandmarkKeys = initialLandmarks
         .filter((landmark) => !currentLandmarkMap.has(landmark.key))
         .map((landmark) => landmark.key);
+      const routePointsChanged =
+        initialRoutePoints.length !== routePoints.length ||
+        routePoints.some((point, index) => {
+          const initial = initialRoutePoints[index];
+          if (!initial) return true;
+          return initial.id !== point.id || initial.lat !== point.lat || initial.lng !== point.lng;
+        });
+      const routeConfigChanged =
+        initialRouteConfig.roadHalfWidthMeters !== routeConfig.roadHalfWidthMeters ||
+        initialRouteConfig.snapDistanceMeters !== routeConfig.snapDistanceMeters ||
+        initialRouteConfig.visibleDistanceMeters !== routeConfig.visibleDistanceMeters;
 
       if (
         updatedShops.length === 0 &&
         deletedLocationIds.length === 0 &&
         upsertLandmarks.length === 0 &&
-        deletedLandmarkKeys.length === 0
+        deletedLandmarkKeys.length === 0 &&
+        !routePointsChanged &&
+        !routeConfigChanged
       ) {
         setMessage("変更はありません。");
         setIsSaving(false);
@@ -315,22 +391,35 @@ export default function MapEditClient() {
             upsert: upsertLandmarks,
             deletedKeys: deletedLandmarkKeys,
           },
+          route: {
+            points: routePoints,
+            config: routeConfig,
+          },
         }),
       });
       if (!response.ok) throw new Error("save failed");
       const nextData = await fetchMapLayout();
       const nextShops = Array.isArray(nextData.shops) ? nextData.shops : [];
       const nextLandmarks = Array.isArray(nextData.landmarks) ? nextData.landmarks : [];
+      const nextRoutePoints = normalizeMapRoutePoints(nextData.route?.points ?? getDefaultMapRoutePoints());
+      const nextRouteConfig = {
+        ...getDefaultMapRouteConfig(),
+        ...(nextData.route?.config ?? {}),
+      };
       const nextVendors = Array.isArray(nextData.vendors) ? nextData.vendors : [];
       setShops(sortShops(nextShops));
       setLandmarks(nextLandmarks);
+      setRoutePoints(nextRoutePoints);
+      setRouteConfig(nextRouteConfig);
       setVendorOptions(nextVendors);
       setInitialShops(cloneShops(nextShops));
       setInitialLandmarks(cloneLandmarks(nextLandmarks));
+      setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
+      setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
       if (isHistoryOpen) {
         await loadSnapshots();
       }
-      setMessage("保存しました。店舗マーカと建物オブジェクトをDBへ反映しました。");
+      setMessage("保存しました。店舗・建物・道路通路の編集をDBへ反映しました。");
     } catch {
       setMessage("保存に失敗しました。");
     } finally {
@@ -496,12 +585,21 @@ export default function MapEditClient() {
       const nextData = await fetchMapLayout();
       const nextShops = Array.isArray(nextData.shops) ? nextData.shops : [];
       const nextLandmarks = Array.isArray(nextData.landmarks) ? nextData.landmarks : [];
+      const nextRoutePoints = normalizeMapRoutePoints(nextData.route?.points ?? getDefaultMapRoutePoints());
+      const nextRouteConfig = {
+        ...getDefaultMapRouteConfig(),
+        ...(nextData.route?.config ?? {}),
+      };
       const nextVendors = Array.isArray(nextData.vendors) ? nextData.vendors : [];
       setShops(sortShops(nextShops));
       setLandmarks(nextLandmarks);
+      setRoutePoints(nextRoutePoints);
+      setRouteConfig(nextRouteConfig);
       setVendorOptions(nextVendors);
       setInitialShops(cloneShops(nextShops));
       setInitialLandmarks(cloneLandmarks(nextLandmarks));
+      setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
+      setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
       await loadSnapshots();
       setMessage("バックアップから復元しました。復元前の状態も自動保存しています。");
     } catch {
@@ -509,6 +607,57 @@ export default function MapEditClient() {
     } finally {
       setIsRestoring(null);
     }
+  };
+
+  const handleAddRoutePoint = () => {
+    const base =
+      selectedRoutePoint ??
+      routePoints[routePoints.length - 1] ?? {
+        id: "route-point-seed",
+        lat: 33.56145,
+        lng: 133.5383,
+        order: 0,
+      };
+    const nextPoint: MapRoutePoint = {
+      id: `route-point-${Date.now()}`,
+      lat: base.lat,
+      lng: base.lng,
+      order: routePoints.length,
+    };
+    const next = normalizeMapRoutePoints([...routePoints, nextPoint]);
+    setRoutePoints(next);
+    setSelectedKind("route");
+    setSelectedId(nextPoint.id);
+  };
+
+  const handleDeleteRoutePoint = (pointId: string) => {
+    setRoutePoints((prev) => normalizeMapRoutePoints(prev.filter((point) => point.id !== pointId)));
+    if (selectedKind === "route" && selectedId === pointId) {
+      setSelectedId("");
+    }
+  };
+
+  const handleCancelRoute = () => {
+    setRoutePoints(cloneRoutePoints(initialRoutePoints));
+    setRouteConfig(cloneRouteConfig(initialRouteConfig));
+    if (selectedKind === "route") {
+      setSelectedId("");
+    }
+  };
+
+  const handleConfirmRoute = () => {
+    setSelectedKind("route");
+    setSelectedId("");
+    setMessage("道路と通路設定の編集を確定しました。保存するとDBへ反映されます。");
+  };
+
+  const toggleRouteSelection = (pointId: string) => {
+    if (selectedKind === "route" && selectedId === pointId) {
+      setSelectedId("");
+      return;
+    }
+    setSelectedKind("route");
+    setSelectedId(pointId);
   };
 
   const formatSnapshotDate = (value: string) => {
@@ -658,6 +807,13 @@ export default function MapEditClient() {
               className={`rounded-full px-4 py-2 text-sm font-semibold ${selectedKind === "landmark" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
             >
               建物オブジェクト
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedKind("route")}
+              className={`rounded-full px-4 py-2 text-sm font-semibold ${selectedKind === "route" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
+            >
+              道路・通路
             </button>
           </div>
 
@@ -823,7 +979,7 @@ export default function MapEditClient() {
                 )}
               </div>
             </div>
-          ) : (
+          ) : selectedKind === "landmark" ? (
             <div className="mt-4 flex min-h-0 flex-1 flex-col">
               <button
                 type="button"
@@ -882,6 +1038,117 @@ export default function MapEditClient() {
                   該当する建物オブジェクトはありません。
                 </div>
               )}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-4 flex min-h-0 flex-1 flex-col">
+              <button
+                type="button"
+                onClick={handleAddRoutePoint}
+                className="w-full rounded-2xl border border-dashed border-sky-300 bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700"
+              >
+                ＋道路ポイントを追加
+              </button>
+              <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Corridor Settings
+                </p>
+                <div className="mt-3 grid grid-cols-1 gap-3">
+                  <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    道幅の半径(m)
+                    <input
+                      type="number"
+                      min="1"
+                      step="0.1"
+                      value={routeConfig.roadHalfWidthMeters}
+                      onChange={(event) =>
+                        setRouteConfig((prev) => ({
+                          ...prev,
+                          roadHalfWidthMeters: Number(event.target.value),
+                        }))
+                      }
+                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    />
+                  </label>
+                  <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    スナップ開始距離(m)
+                    <input
+                      type="number"
+                      min="1"
+                      step="0.5"
+                      value={routeConfig.snapDistanceMeters}
+                      onChange={(event) =>
+                        setRouteConfig((prev) => ({
+                          ...prev,
+                          snapDistanceMeters: Number(event.target.value),
+                        }))
+                      }
+                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    />
+                  </label>
+                  <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    最大表示距離(m)
+                    <input
+                      type="number"
+                      min="1"
+                      step="0.5"
+                      value={routeConfig.visibleDistanceMeters}
+                      onChange={(event) =>
+                        setRouteConfig((prev) => ({
+                          ...prev,
+                          visibleDistanceMeters: Number(event.target.value),
+                        }))
+                      }
+                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    />
+                  </label>
+                </div>
+              </div>
+              <div className="mt-3 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
+                {filteredRoutePoints.map((point, index) => (
+                  <div
+                    key={point.id}
+                    ref={(node) => {
+                      routePointItemRefs.current[point.id] = node;
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => toggleRouteSelection(point.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        toggleRouteSelection(point.id);
+                      }
+                    }}
+                    className={`rounded-2xl border px-4 py-3 transition ${
+                      selectedId === point.id
+                        ? "border-sky-400 bg-sky-50 shadow-sm ring-2 ring-sky-200"
+                        : "border-slate-200 bg-white"
+                    } cursor-pointer`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0 flex-1 text-left">
+                        <span className="block text-sm font-semibold text-slate-900">
+                          ポイント {index + 1}
+                        </span>
+                        <span className="block text-xs text-slate-500">
+                          {point.lat.toFixed(6)}, {point.lng.toFixed(6)}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          handleDeleteRoutePoint(point.id);
+                        }}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
+                        aria-label={`道路ポイント ${index + 1} を削除`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}
@@ -943,6 +1210,83 @@ export default function MapEditClient() {
             </div>
           )}
 
+          {selectedKind === "route" && (
+            <div className="mt-6 space-y-3 rounded-2xl bg-slate-50 p-4">
+              {selectedRoutePoint ? (
+                <>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Selected Route Point
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      緯度
+                      <input
+                        type="number"
+                        step="0.000001"
+                        value={selectedRoutePoint.lat}
+                        onChange={(event) =>
+                          setRoutePoints((prev) =>
+                            normalizeMapRoutePoints(
+                              prev.map((point) =>
+                                point.id === selectedRoutePoint.id
+                                  ? { ...point, lat: Number(event.target.value) }
+                                  : point
+                              )
+                            )
+                          )
+                        }
+                        className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+                      />
+                    </label>
+                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      経度
+                      <input
+                        type="number"
+                        step="0.000001"
+                        value={selectedRoutePoint.lng}
+                        onChange={(event) =>
+                          setRoutePoints((prev) =>
+                            normalizeMapRoutePoints(
+                              prev.map((point) =>
+                                point.id === selectedRoutePoint.id
+                                  ? { ...point, lng: Number(event.target.value) }
+                                  : point
+                              )
+                            )
+                          )
+                        }
+                        className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+                      />
+                    </label>
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-slate-600">
+                  道路ポイントを選ぶと座標を直接編集できます。地図上ではドラッグでも動かせます。
+                </p>
+              )}
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleCancelRoute}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmRoute}
+                  className="rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
+                >
+                  確定
+                </button>
+              </div>
+              <p className="text-xs text-slate-500">
+                この道路中心線が公開マップの道路形状と現在地の通路判定に使われます。
+              </p>
+            </div>
+          )}
+
           {message && (
             <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50 px-4 py-3 text-sm text-sky-800">
               {message}
@@ -955,6 +1299,8 @@ export default function MapEditClient() {
             mode={mode}
             shops={shops}
             landmarks={landmarks}
+            routePoints={routePoints}
+            routeConfig={routeConfig}
             maxZoom={mapSettings.maxEditZoom}
             selectedKind={selectedKind}
             selectedId={selectedId}
@@ -973,8 +1319,16 @@ export default function MapEditClient() {
             onMoveLandmark={(key, lat, lng) =>
               setLandmarks((prev) => prev.map((item) => (item.key === key ? { ...item, lat, lng } : item)))
             }
+            onMoveRoutePoint={(id, lat, lng) =>
+              setRoutePoints((prev) =>
+                normalizeMapRoutePoints(
+                  prev.map((point) => (point.id === id ? { ...point, lat, lng } : point))
+                )
+              )
+            }
             onDeleteShop={handleDeleteShop}
             onDeleteLandmark={handleDeleteLandmark}
+            onDeleteRoutePoint={handleDeleteRoutePoint}
           />
         </div>
       </div>

--- a/app/(public)/map-edit/MapEditClient.tsx
+++ b/app/(public)/map-edit/MapEditClient.tsx
@@ -8,6 +8,7 @@ import type { MapRoute, MapRouteConfig, MapRoutePoint } from "../map/types/mapRo
 import {
   getDefaultMapRouteConfig,
   getDefaultMapRoutePoints,
+  getRouteLengthKm,
   normalizeMapRoutePoints,
 } from "../map/utils/mapRouteGeometry";
 
@@ -224,6 +225,11 @@ export default function MapEditClient() {
     [landmarks, normalizedLandmarkQuery, selectedId, selectedKind]
   );
   const filteredRoutePoints = useMemo(() => routePoints, [routePoints]);
+  const routeLengthKm = useMemo(() => getRouteLengthKm(routePoints), [routePoints]);
+  const mainRoutePoints = useMemo(
+    () => routePoints.filter((point) => !point.branchFromId),
+    [routePoints]
+  );
   const hasUnsavedChanges = useMemo(() => {
     const initialShopMap = new Map(initialShops.map((shop) => [shop.locationId, shop]));
     const currentShopMap = new Map(shops.map((shop) => [shop.locationId, shop]));
@@ -623,6 +629,7 @@ export default function MapEditClient() {
       lat: base.lat,
       lng: base.lng,
       order: routePoints.length,
+      branchFromId: null,
     };
     const next = normalizeMapRoutePoints([...routePoints, nextPoint]);
     setRoutePoints(next);
@@ -658,6 +665,132 @@ export default function MapEditClient() {
     }
     setSelectedKind("route");
     setSelectedId(pointId);
+  };
+
+  const handleMoveRoutePointOrder = (pointId: string, direction: -1 | 1) => {
+    setRoutePoints((prev) => {
+      const current = normalizeMapRoutePoints(prev);
+      const index = current.findIndex((point) => point.id === pointId);
+      const targetIndex = index + direction;
+      if (index < 0 || targetIndex < 0 || targetIndex >= current.length) {
+        return current;
+      }
+      const next = [...current];
+      const [moved] = next.splice(index, 1);
+      next.splice(targetIndex, 0, moved);
+      return normalizeMapRoutePoints(next);
+    });
+  };
+
+  const handleInsertRoutePointAtSegment = (
+    segmentStartId: string,
+    lat: number,
+    lng: number,
+    segmentEndId?: string
+  ) => {
+    setRoutePoints((prev) => {
+      const current = normalizeMapRoutePoints(prev);
+      const index = current.findIndex((point) => point.id === segmentStartId);
+      if (index < 0) return current;
+      const segmentStart = current[index];
+      const segmentEnd = segmentEndId ? current.find((point) => point.id === segmentEndId) : null;
+      const nextPoint: MapRoutePoint = {
+        id: `route-point-${Date.now()}`,
+        lat,
+        lng,
+        order: index + 1,
+        branchFromId: segmentEnd?.branchFromId === segmentStart.id ? segmentStart.id : segmentStart.branchFromId ?? null,
+      };
+      const next = [...current];
+      if (segmentEnd && segmentEnd.branchFromId === segmentStart.id) {
+        next.splice(index + 1, 0, nextPoint);
+        const endIndex = next.findIndex((point) => point.id === segmentEnd.id);
+        if (endIndex >= 0) {
+          next[endIndex] = { ...next[endIndex], branchFromId: nextPoint.id };
+        }
+      } else {
+        next.splice(index + 1, 0, nextPoint);
+      }
+      const normalized = normalizeMapRoutePoints(next);
+      setSelectedKind("route");
+      setSelectedId(nextPoint.id);
+      return normalized;
+    });
+  };
+
+  const handleAddConnectedRoutePoint = (pointId: string) => {
+    setRoutePoints((prev) => {
+      const current = normalizeMapRoutePoints(prev);
+      const index = current.findIndex((point) => point.id === pointId);
+      if (index < 0) return current;
+      const anchor = current[index];
+      const nextReference = current[index + 1];
+      const prevReference = current[index - 1];
+      let baseLatOffset = 0;
+      let baseLngOffset = 0;
+
+      const isBranchPoint = Boolean(anchor.branchFromId);
+      const isLeftEnd = !isBranchPoint && !prevReference && Boolean(nextReference);
+      const isRightEnd = !isBranchPoint && Boolean(prevReference) && !nextReference;
+      const isMiddle = !isBranchPoint && Boolean(prevReference && nextReference);
+
+      if (isLeftEnd && nextReference) {
+        // 左端: 左側へ延長
+        baseLatOffset = anchor.lat - nextReference.lat;
+        baseLngOffset = anchor.lng - nextReference.lng;
+      } else if (isRightEnd && prevReference) {
+        // 右端: 右側へ延長
+        baseLatOffset = anchor.lat - prevReference.lat;
+        baseLngOffset = anchor.lng - prevReference.lng;
+      } else if (isMiddle && prevReference && nextReference) {
+        // 中間点: 上か下へ分岐
+        const tangentLat = nextReference.lat - prevReference.lat;
+        const tangentLng = nextReference.lng - prevReference.lng;
+        let upLat = tangentLng;
+        let upLng = -tangentLat;
+        const normalLength = Math.hypot(upLat, upLng);
+        if (normalLength > 0) {
+          upLat /= normalLength;
+          upLng /= normalLength;
+        }
+        if (upLat < 0) {
+          upLat *= -1;
+          upLng *= -1;
+        }
+
+        const prevDistance = Math.hypot(anchor.lat - prevReference.lat, anchor.lng - prevReference.lng);
+        const nextDistance = Math.hypot(nextReference.lat - anchor.lat, nextReference.lng - anchor.lng);
+        const baseDistance = Math.max(0.00012, (prevDistance + nextDistance) / 2);
+        const placeUp = window.confirm(
+          "この中間ポイントから上側へ新しい道路ポイントを追加しますか？\nキャンセルで下側に追加します。"
+        );
+        const direction = placeUp ? 1 : -1;
+        baseLatOffset = upLat * baseDistance * direction;
+        baseLngOffset = upLng * baseDistance * direction;
+      } else {
+        baseLngOffset = 0.00018;
+      }
+
+      const nextPoint: MapRoutePoint = {
+        id: `route-point-${Date.now()}`,
+        lat: anchor.lat + (Math.abs(baseLatOffset) > 0 ? baseLatOffset : 0),
+        lng: anchor.lng + (Math.abs(baseLngOffset) > 0 ? baseLngOffset : 0.00018),
+        order: index + 1,
+        branchFromId: isMiddle || isBranchPoint ? anchor.id : null,
+      };
+
+      const next = [...current];
+      if (isMiddle || isBranchPoint) {
+        next.push(nextPoint);
+      } else {
+        next.splice(index + 1, 0, nextPoint);
+      }
+
+      const normalized = normalizeMapRoutePoints(next);
+      setSelectedKind("route");
+      setSelectedId(nextPoint.id);
+      return normalized;
+    });
   };
 
   const formatSnapshotDate = (value: string) => {
@@ -792,7 +925,7 @@ export default function MapEditClient() {
             </div>
           </aside>
         )}
-        <aside className="flex min-h-0 flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+        <aside className="flex min-h-0 flex-col overflow-y-auto rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex gap-2">
             <button
               type="button"
@@ -1042,17 +1175,51 @@ export default function MapEditClient() {
             </div>
           ) : (
             <div className="mt-4 flex min-h-0 flex-1 flex-col">
-              <button
-                type="button"
-                onClick={handleAddRoutePoint}
-                className="w-full rounded-2xl border border-dashed border-sky-300 bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700"
-              >
-                ＋道路ポイントを追加
-              </button>
-              <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Corridor Settings
-                </p>
+              <div className="rounded-[28px] border border-slate-200 bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_100%)] p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-700">
+                      Route Editor
+                    </p>
+                    <h3 className="mt-1 text-lg font-bold text-slate-900">道路と通路の編集</h3>
+                    <p className="mt-1 text-xs leading-5 text-slate-500">
+                      道路の形、現在地の吸着距離、表示許容距離をここで調整します。
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleAddRoutePoint}
+                    className="shrink-0 rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
+                  >
+                    ＋ポイント追加
+                  </button>
+                </div>
+
+                <div className="mt-4 grid grid-cols-3 gap-2">
+                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Points</p>
+                    <p className="mt-1 text-lg font-bold text-slate-900">{routePoints.length}</p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Length</p>
+                    <p className="mt-1 text-lg font-bold text-slate-900">{routeLengthKm.toFixed(2)}km</p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Selected</p>
+                    <p className="mt-1 text-lg font-bold text-slate-900">
+                      {selectedRoutePoint ? routePoints.findIndex((point) => point.id === selectedRoutePoint.id) + 1 : "-"}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Corridor Settings
+                  </p>
+                  <p className="text-[11px] text-slate-400">数値は公開マップへそのまま反映されます</p>
+                </div>
                 <div className="mt-3 grid grid-cols-1 gap-3">
                   <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
                     道幅の半径(m)
@@ -1104,51 +1271,102 @@ export default function MapEditClient() {
                   </label>
                 </div>
               </div>
-              <div className="mt-3 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
-                {filteredRoutePoints.map((point, index) => (
-                  <div
-                    key={point.id}
-                    ref={(node) => {
-                      routePointItemRefs.current[point.id] = node;
-                    }}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => toggleRouteSelection(point.id)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        toggleRouteSelection(point.id);
-                      }
-                    }}
-                    className={`rounded-2xl border px-4 py-3 transition ${
-                      selectedId === point.id
-                        ? "border-sky-400 bg-sky-50 shadow-sm ring-2 ring-sky-200"
-                        : "border-slate-200 bg-white"
-                    } cursor-pointer`}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="min-w-0 flex-1 text-left">
-                        <span className="block text-sm font-semibold text-slate-900">
-                          ポイント {index + 1}
-                        </span>
-                        <span className="block text-xs text-slate-500">
-                          {point.lat.toFixed(6)}, {point.lng.toFixed(6)}
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          handleDeleteRoutePoint(point.id);
-                        }}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
-                        aria-label={`道路ポイント ${index + 1} を削除`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
+
+              <div className="mt-3 flex min-h-0 flex-1 flex-col overflow-hidden rounded-[28px] border border-slate-200 bg-white">
+                <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Route Points
+                    </p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      地図上ドラッグ、または一覧選択後の座標入力で編集
+                    </p>
                   </div>
-                ))}
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+                  <div className="space-y-2">
+                    {filteredRoutePoints.map((point, index) => (
+                      <div
+                        key={point.id}
+                        ref={(node) => {
+                          routePointItemRefs.current[point.id] = node;
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => toggleRouteSelection(point.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            toggleRouteSelection(point.id);
+                          }
+                        }}
+                        className={`rounded-2xl border px-4 py-3 transition ${
+                          selectedId === point.id
+                            ? "border-sky-400 bg-sky-50 shadow-sm ring-2 ring-sky-200"
+                            : "border-slate-200 bg-white hover:border-slate-300"
+                        } cursor-pointer`}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1 text-left">
+                            <div className="flex items-center gap-2">
+                              <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-slate-900 px-2 text-[11px] font-bold text-white">
+                                {index + 1}
+                              </span>
+                              <span className="text-sm font-semibold text-slate-900">道路ポイント</span>
+                            </div>
+                            <p className="mt-2 text-xs leading-5 text-slate-500">
+                              緯度 {point.lat.toFixed(6)}
+                              <br />
+                              経度 {point.lng.toFixed(6)}
+                            </p>
+                          </div>
+                          <div className="flex shrink-0 items-center gap-1">
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                handleMoveRoutePointOrder(point.id, -1);
+                              }}
+                              disabled={index === 0}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                              aria-label={`道路ポイント ${index + 1} を前へ移動`}
+                            >
+                              ↑
+                            </button>
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                handleMoveRoutePointOrder(point.id, 1);
+                              }}
+                              disabled={index === filteredRoutePoints.length - 1}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                              aria-label={`道路ポイント ${index + 1} を後ろへ移動`}
+                            >
+                              ↓
+                            </button>
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                handleDeleteRoutePoint(point.id);
+                              }}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
+                              aria-label={`道路ポイント ${index + 1} を削除`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                    {filteredRoutePoints.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-500">
+                        道路ポイントがまだありません。
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
           )}
@@ -1211,12 +1429,22 @@ export default function MapEditClient() {
           )}
 
           {selectedKind === "route" && (
-            <div className="mt-6 space-y-3 rounded-2xl bg-slate-50 p-4">
+            <div className="mt-6 space-y-3 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
               {selectedRoutePoint ? (
                 <>
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    Selected Route Point
-                  </p>
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        Selected Route Point
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-slate-900">
+                        ポイント {routePoints.findIndex((point) => point.id === selectedRoutePoint.id) + 1}
+                      </p>
+                    </div>
+                    <div className="rounded-full bg-white px-3 py-1 text-[11px] font-semibold text-slate-500">
+                      ID: {selectedRoutePoint.id}
+                    </div>
+                  </div>
                   <div className="grid grid-cols-2 gap-3">
                     <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
                       緯度
@@ -1259,10 +1487,28 @@ export default function MapEditClient() {
                       />
                     </label>
                   </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleMoveRoutePointOrder(selectedRoutePoint.id, -1)}
+                      disabled={routePoints.findIndex((point) => point.id === selectedRoutePoint.id) === 0}
+                      className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      一つ前へ移動
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleMoveRoutePointOrder(selectedRoutePoint.id, 1)}
+                      disabled={routePoints.findIndex((point) => point.id === selectedRoutePoint.id) === routePoints.length - 1}
+                      className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      一つ後ろへ移動
+                    </button>
+                  </div>
                 </>
               ) : (
                 <p className="text-sm text-slate-600">
-                  道路ポイントを選ぶと座標を直接編集できます。地図上ではドラッグでも動かせます。
+                  左の一覧から道路ポイントを選ぶと、ここで座標編集と順序変更ができます。地図上ではドラッグでも動かせます。
                 </p>
               )}
               <div className="flex items-center justify-end gap-2">
@@ -1326,6 +1572,8 @@ export default function MapEditClient() {
                 )
               )
             }
+            onInsertRoutePointAtSegment={handleInsertRoutePointAtSegment}
+            onAddConnectedRoutePoint={handleAddConnectedRoutePoint}
             onDeleteShop={handleDeleteShop}
             onDeleteLandmark={handleDeleteLandmark}
             onDeleteRoutePoint={handleDeleteRoutePoint}

--- a/app/(public)/map-edit/MapEditClient.tsx
+++ b/app/(public)/map-edit/MapEditClient.tsx
@@ -6,10 +6,15 @@ import { Trash2 } from "lucide-react";
 import type { Landmark as EditableLandmark } from "../map/types/landmark";
 import type { MapRoute, MapRouteConfig, MapRoutePoint } from "../map/types/mapRoute";
 import {
+  getBranchParent,
   getDefaultMapRouteConfig,
   getDefaultMapRoutePoints,
+  getMainRouteNeighbors,
+  getRoutePointStatus,
+  getRoutePointRole,
   getRouteLengthKm,
   normalizeMapRoutePoints,
+  stabilizeRoutePointMove,
 } from "../map/utils/mapRouteGeometry";
 
 type EditableShop = {
@@ -72,6 +77,25 @@ function cloneRouteConfig(config: MapRouteConfig) {
   return { ...config };
 }
 
+function areRoutePointsEqual(a: MapRoutePoint[], b: MapRoutePoint[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((point, index) => {
+    const target = b[index];
+    if (!target) {
+      return false;
+    }
+    return (
+      point.id === target.id &&
+      point.lat === target.lat &&
+      point.lng === target.lng &&
+      point.order === target.order &&
+      (point.branchFromId ?? null) === (target.branchFromId ?? null)
+    );
+  });
+}
+
 function getUnassignedPriority(shop: EditableShop) {
   if (shop.vendorId) return Number.NEGATIVE_INFINITY;
   if (shop.locationId.startsWith("new-")) {
@@ -131,6 +155,7 @@ export default function MapEditClient() {
   const [message, setMessage] = useState<string | null>(null);
   const [shopQuery, setShopQuery] = useState("");
   const [landmarkQuery, setLandmarkQuery] = useState("");
+  const [routeQuery, setRouteQuery] = useState("");
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [snapshots, setSnapshots] = useState<SnapshotItem[]>([]);
   const [mapSettings, setMapSettings] = useState<MapSettings>(DEFAULT_MAP_SETTINGS);
@@ -201,6 +226,7 @@ export default function MapEditClient() {
   );
   const normalizedShopQuery = shopQuery.trim().toLowerCase();
   const normalizedLandmarkQuery = landmarkQuery.trim().toLowerCase();
+  const normalizedRouteQuery = routeQuery.trim().toLowerCase();
   const filteredShops = useMemo(
     () =>
       sortShops(
@@ -224,12 +250,26 @@ export default function MapEditClient() {
       }),
     [landmarks, normalizedLandmarkQuery, selectedId, selectedKind]
   );
-  const filteredRoutePoints = useMemo(() => routePoints, [routePoints]);
-  const routeLengthKm = useMemo(() => getRouteLengthKm(routePoints), [routePoints]);
-  const mainRoutePoints = useMemo(
-    () => routePoints.filter((point) => !point.branchFromId),
-    [routePoints]
+  const filteredRoutePoints = useMemo(
+    () =>
+      routePoints.filter((point, index) => {
+        if (selectedKind === "route" && selectedId === point.id) return true;
+        if (!normalizedRouteQuery) return true;
+        const status = getRoutePointStatus(routePoints, point.id);
+        return (
+          point.id.toLowerCase().includes(normalizedRouteQuery) ||
+          String(index + 1).includes(normalizedRouteQuery) ||
+          `ポイント ${index + 1}`.toLowerCase().includes(normalizedRouteQuery) ||
+          (status?.label ?? "").toLowerCase().includes(normalizedRouteQuery)
+        );
+      }),
+    [normalizedRouteQuery, routePoints, selectedId, selectedKind]
   );
+  const routeLengthKm = useMemo(() => getRouteLengthKm(routePoints), [routePoints]);
+  const selectedRouteStatus = useMemo(() => {
+    if (!selectedRoutePoint) return null;
+    return getRoutePointStatus(routePoints, selectedRoutePoint.id);
+  }, [routePoints, selectedRoutePoint]);
   const hasUnsavedChanges = useMemo(() => {
     const initialShopMap = new Map(initialShops.map((shop) => [shop.locationId, shop]));
     const currentShopMap = new Map(shops.map((shop) => [shop.locationId, shop]));
@@ -263,13 +303,7 @@ export default function MapEditClient() {
     const deletedLandmarkExists = initialLandmarks.some(
       (landmark) => !currentLandmarkMap.has(landmark.key)
     );
-    const routePointsChanged =
-      initialRoutePoints.length !== routePoints.length ||
-      routePoints.some((point, index) => {
-        const initial = initialRoutePoints[index];
-        if (!initial) return true;
-        return initial.id !== point.id || initial.lat !== point.lat || initial.lng !== point.lng;
-      });
+    const routePointsChanged = !areRoutePointsEqual(initialRoutePoints, routePoints);
     const routeConfigChanged =
       initialRouteConfig.roadHalfWidthMeters !== routeConfig.roadHalfWidthMeters ||
       initialRouteConfig.snapDistanceMeters !== routeConfig.snapDistanceMeters ||
@@ -360,13 +394,7 @@ export default function MapEditClient() {
       const deletedLandmarkKeys = initialLandmarks
         .filter((landmark) => !currentLandmarkMap.has(landmark.key))
         .map((landmark) => landmark.key);
-      const routePointsChanged =
-        initialRoutePoints.length !== routePoints.length ||
-        routePoints.some((point, index) => {
-          const initial = initialRoutePoints[index];
-          if (!initial) return true;
-          return initial.id !== point.id || initial.lat !== point.lat || initial.lng !== point.lng;
-        });
+      const routePointsChanged = !areRoutePointsEqual(initialRoutePoints, routePoints);
       const routeConfigChanged =
         initialRouteConfig.roadHalfWidthMeters !== routeConfig.roadHalfWidthMeters ||
         initialRouteConfig.snapDistanceMeters !== routeConfig.snapDistanceMeters ||
@@ -644,20 +672,6 @@ export default function MapEditClient() {
     }
   };
 
-  const handleCancelRoute = () => {
-    setRoutePoints(cloneRoutePoints(initialRoutePoints));
-    setRouteConfig(cloneRouteConfig(initialRouteConfig));
-    if (selectedKind === "route") {
-      setSelectedId("");
-    }
-  };
-
-  const handleConfirmRoute = () => {
-    setSelectedKind("route");
-    setSelectedId("");
-    setMessage("道路と通路設定の編集を確定しました。保存するとDBへ反映されます。");
-  };
-
   const toggleRouteSelection = (pointId: string) => {
     if (selectedKind === "route" && selectedId === pointId) {
       setSelectedId("");
@@ -665,21 +679,6 @@ export default function MapEditClient() {
     }
     setSelectedKind("route");
     setSelectedId(pointId);
-  };
-
-  const handleMoveRoutePointOrder = (pointId: string, direction: -1 | 1) => {
-    setRoutePoints((prev) => {
-      const current = normalizeMapRoutePoints(prev);
-      const index = current.findIndex((point) => point.id === pointId);
-      const targetIndex = index + direction;
-      if (index < 0 || targetIndex < 0 || targetIndex >= current.length) {
-        return current;
-      }
-      const next = [...current];
-      const [moved] = next.splice(index, 1);
-      next.splice(targetIndex, 0, moved);
-      return normalizeMapRoutePoints(next);
-    });
   };
 
   const handleInsertRoutePointAtSegment = (
@@ -718,34 +717,29 @@ export default function MapEditClient() {
     });
   };
 
-  const handleAddConnectedRoutePoint = (pointId: string) => {
+  const handleAddConnectedRoutePoint = (pointId: string, branchDirection: "up" | "down" | "auto" = "auto") => {
     setRoutePoints((prev) => {
       const current = normalizeMapRoutePoints(prev);
-      const index = current.findIndex((point) => point.id === pointId);
-      if (index < 0) return current;
-      const anchor = current[index];
-      const nextReference = current[index + 1];
-      const prevReference = current[index - 1];
+      const anchor = current.find((point) => point.id === pointId);
+      if (!anchor) return current;
+      const role = getRoutePointRole(current, pointId);
       let baseLatOffset = 0;
       let baseLngOffset = 0;
+      const mainNeighbors = getMainRouteNeighbors(current, pointId);
+      const branchParent = getBranchParent(current, pointId);
 
-      const isBranchPoint = Boolean(anchor.branchFromId);
-      const isLeftEnd = !isBranchPoint && !prevReference && Boolean(nextReference);
-      const isRightEnd = !isBranchPoint && Boolean(prevReference) && !nextReference;
-      const isMiddle = !isBranchPoint && Boolean(prevReference && nextReference);
-
-      if (isLeftEnd && nextReference) {
+      if (role === "main-start" && mainNeighbors.next) {
         // 左端: 左側へ延長
-        baseLatOffset = anchor.lat - nextReference.lat;
-        baseLngOffset = anchor.lng - nextReference.lng;
-      } else if (isRightEnd && prevReference) {
+        baseLatOffset = anchor.lat - mainNeighbors.next.lat;
+        baseLngOffset = anchor.lng - mainNeighbors.next.lng;
+      } else if (role === "main-end" && mainNeighbors.previous) {
         // 右端: 右側へ延長
-        baseLatOffset = anchor.lat - prevReference.lat;
-        baseLngOffset = anchor.lng - prevReference.lng;
-      } else if (isMiddle && prevReference && nextReference) {
+        baseLatOffset = anchor.lat - mainNeighbors.previous.lat;
+        baseLngOffset = anchor.lng - mainNeighbors.previous.lng;
+      } else if (role === "main-middle" && mainNeighbors.previous && mainNeighbors.next) {
         // 中間点: 上か下へ分岐
-        const tangentLat = nextReference.lat - prevReference.lat;
-        const tangentLng = nextReference.lng - prevReference.lng;
+        const tangentLat = mainNeighbors.next.lat - mainNeighbors.previous.lat;
+        const tangentLng = mainNeighbors.next.lng - mainNeighbors.previous.lng;
         let upLat = tangentLng;
         let upLng = -tangentLat;
         const normalLength = Math.hypot(upLat, upLng);
@@ -758,15 +752,22 @@ export default function MapEditClient() {
           upLng *= -1;
         }
 
-        const prevDistance = Math.hypot(anchor.lat - prevReference.lat, anchor.lng - prevReference.lng);
-        const nextDistance = Math.hypot(nextReference.lat - anchor.lat, nextReference.lng - anchor.lng);
-        const baseDistance = Math.max(0.00012, (prevDistance + nextDistance) / 2);
-        const placeUp = window.confirm(
-          "この中間ポイントから上側へ新しい道路ポイントを追加しますか？\nキャンセルで下側に追加します。"
+        const prevDistance = Math.hypot(
+          anchor.lat - mainNeighbors.previous.lat,
+          anchor.lng - mainNeighbors.previous.lng
         );
-        const direction = placeUp ? 1 : -1;
+        const nextDistance = Math.hypot(
+          mainNeighbors.next.lat - anchor.lat,
+          mainNeighbors.next.lng - anchor.lng
+        );
+        const baseDistance = Math.max(0.00012, (prevDistance + nextDistance) / 2);
+        const direction = branchDirection === "down" ? -1 : 1;
         baseLatOffset = upLat * baseDistance * direction;
         baseLngOffset = upLng * baseDistance * direction;
+      } else if (role === "branch" && branchParent) {
+        // 枝点: 親からのベクトルを延長
+        baseLatOffset = anchor.lat - branchParent.lat;
+        baseLngOffset = anchor.lng - branchParent.lng;
       } else {
         baseLngOffset = 0.00018;
       }
@@ -775,14 +776,15 @@ export default function MapEditClient() {
         id: `route-point-${Date.now()}`,
         lat: anchor.lat + (Math.abs(baseLatOffset) > 0 ? baseLatOffset : 0),
         lng: anchor.lng + (Math.abs(baseLngOffset) > 0 ? baseLngOffset : 0.00018),
-        order: index + 1,
-        branchFromId: isMiddle || isBranchPoint ? anchor.id : null,
+        order: current.length,
+        branchFromId: role === "main-middle" || role === "branch" ? anchor.id : null,
       };
 
       const next = [...current];
-      if (isMiddle || isBranchPoint) {
+      if (role === "main-middle" || role === "branch") {
         next.push(nextPoint);
       } else {
+        const index = current.findIndex((point) => point.id === pointId);
         next.splice(index + 1, 0, nextPoint);
       }
 
@@ -930,21 +932,21 @@ export default function MapEditClient() {
             <button
               type="button"
               onClick={() => setSelectedKind("shop")}
-              className={`rounded-full px-4 py-2 text-sm font-semibold ${selectedKind === "shop" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
+              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "shop" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
             >
               店舗マーカ
             </button>
             <button
               type="button"
               onClick={() => setSelectedKind("landmark")}
-              className={`rounded-full px-4 py-2 text-sm font-semibold ${selectedKind === "landmark" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
+              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "landmark" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
             >
               建物オブジェクト
             </button>
             <button
               type="button"
               onClick={() => setSelectedKind("route")}
-              className={`rounded-full px-4 py-2 text-sm font-semibold ${selectedKind === "route" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
+              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "route" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
             >
               道路・通路
             </button>
@@ -1174,51 +1176,44 @@ export default function MapEditClient() {
               </div>
             </div>
           ) : (
-            <div className="mt-4 flex min-h-0 flex-1 flex-col">
-              <div className="rounded-[28px] border border-slate-200 bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_100%)] p-4 shadow-sm">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-700">
-                      Route Editor
-                    </p>
-                    <h3 className="mt-1 text-lg font-bold text-slate-900">道路と通路の編集</h3>
-                    <p className="mt-1 text-xs leading-5 text-slate-500">
-                      道路の形、現在地の吸着距離、表示許容距離をここで調整します。
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={handleAddRoutePoint}
-                    className="shrink-0 rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
-                  >
-                    ＋ポイント追加
-                  </button>
+            <div className="mt-4 space-y-3">
+              <button
+                type="button"
+                onClick={handleAddRoutePoint}
+                className="w-full rounded-2xl border border-dashed border-sky-300 bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700"
+              >
+                ＋道路ポイントを追加
+              </button>
+              <input
+                type="search"
+                value={routeQuery}
+                onChange={(event) => setRouteQuery(event.target.value)}
+                placeholder="ポイント番号や状態で検索"
+                className="mt-3 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
+              />
+              <div className="mt-3 grid grid-cols-3 gap-2 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Points</p>
+                  <p className="mt-1 text-lg font-bold text-slate-900">{routePoints.length}</p>
                 </div>
-
-                <div className="mt-4 grid grid-cols-3 gap-2">
-                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Points</p>
-                    <p className="mt-1 text-lg font-bold text-slate-900">{routePoints.length}</p>
-                  </div>
-                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Length</p>
-                    <p className="mt-1 text-lg font-bold text-slate-900">{routeLengthKm.toFixed(2)}km</p>
-                  </div>
-                  <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Selected</p>
-                    <p className="mt-1 text-lg font-bold text-slate-900">
-                      {selectedRoutePoint ? routePoints.findIndex((point) => point.id === selectedRoutePoint.id) + 1 : "-"}
-                    </p>
-                  </div>
+                <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Length</p>
+                  <p className="mt-1 text-lg font-bold text-slate-900">{routeLengthKm.toFixed(2)}km</p>
+                </div>
+                <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Selected</p>
+                  <p className="mt-1 text-lg font-bold text-slate-900">
+                    {selectedRoutePoint ? routePoints.findIndex((point) => point.id === selectedRoutePoint.id) + 1 : "-"}
+                  </p>
                 </div>
               </div>
 
               <div className="mt-3 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
                 <div className="flex items-center justify-between gap-3">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    Corridor Settings
+                    Road Settings
                   </p>
-                  <p className="text-[11px] text-slate-400">数値は公開マップへそのまま反映されます</p>
+                  <p className="text-[11px] text-slate-400">数値は公開マップの道路表示と現在地補正に使われます</p>
                 </div>
                 <div className="mt-3 grid grid-cols-1 gap-3">
                   <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
@@ -1272,100 +1267,140 @@ export default function MapEditClient() {
                 </div>
               </div>
 
-              <div className="mt-3 flex min-h-0 flex-1 flex-col overflow-hidden rounded-[28px] border border-slate-200 bg-white">
-                <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      Route Points
-                    </p>
-                    <p className="mt-1 text-xs text-slate-400">
-                      地図上ドラッグ、または一覧選択後の座標入力で編集
-                    </p>
-                  </div>
+              <div className="rounded-2xl border border-slate-200 bg-white">
+                <div className="border-b border-slate-200 px-4 py-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Road Points
+                  </p>
+                  <p className="mt-1 text-xs text-slate-400">
+                    ポイントを選ぶと、その場で座標を編集できます。
+                  </p>
                 </div>
-                <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-                  <div className="space-y-2">
-                    {filteredRoutePoints.map((point, index) => (
+                <div className="space-y-2 px-3 py-3">
+                  {filteredRoutePoints.map((point, index) => {
+                    const pointStatus = getRoutePointStatus(routePoints, point.id);
+                    return (
                       <div
                         key={point.id}
                         ref={(node) => {
                           routePointItemRefs.current[point.id] = node;
                         }}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => toggleRouteSelection(point.id)}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            toggleRouteSelection(point.id);
-                          }
-                        }}
-                        className={`rounded-2xl border px-4 py-3 transition ${
-                          selectedId === point.id
-                            ? "border-sky-400 bg-sky-50 shadow-sm ring-2 ring-sky-200"
-                            : "border-slate-200 bg-white hover:border-slate-300"
-                        } cursor-pointer`}
                       >
-                        <div className="flex items-start justify-between gap-3">
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => toggleRouteSelection(point.id)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              toggleRouteSelection(point.id);
+                            }
+                          }}
+                          className={`flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left transition ${
+                            selectedId === point.id
+                              ? "border-sky-400 bg-sky-50 shadow-sm ring-2 ring-sky-200"
+                              : "border-slate-200 bg-white"
+                          } cursor-pointer`}
+                        >
                           <div className="min-w-0 flex-1 text-left">
-                            <div className="flex items-center gap-2">
+                            <span className="flex items-center gap-2">
                               <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-slate-900 px-2 text-[11px] font-bold text-white">
                                 {index + 1}
                               </span>
-                              <span className="text-sm font-semibold text-slate-900">道路ポイント</span>
-                            </div>
-                            <p className="mt-2 text-xs leading-5 text-slate-500">
-                              緯度 {point.lat.toFixed(6)}
-                              <br />
-                              経度 {point.lng.toFixed(6)}
-                            </p>
+                              <span className="block text-sm font-semibold text-slate-900">
+                                ポイント {index + 1}
+                              </span>
+                              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-600">
+                                {pointStatus?.label ?? "未判定"}
+                              </span>
+                            </span>
+                            <span className="mt-2 block text-xs text-slate-500">
+                              緯度 {point.lat.toFixed(6)} / 経度 {point.lng.toFixed(6)}
+                            </span>
                           </div>
-                          <div className="flex shrink-0 items-center gap-1">
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                handleMoveRoutePointOrder(point.id, -1);
-                              }}
-                              disabled={index === 0}
-                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
-                              aria-label={`道路ポイント ${index + 1} を前へ移動`}
-                            >
-                              ↑
-                            </button>
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                handleMoveRoutePointOrder(point.id, 1);
-                              }}
-                              disabled={index === filteredRoutePoints.length - 1}
-                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
-                              aria-label={`道路ポイント ${index + 1} を後ろへ移動`}
-                            >
-                              ↓
-                            </button>
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                handleDeleteRoutePoint(point.id);
-                              }}
-                              className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
-                              aria-label={`道路ポイント ${index + 1} を削除`}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </div>
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleDeleteRoutePoint(point.id);
+                            }}
+                            className="ml-3 inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
+                            aria-label={`道路ポイント ${index + 1} を削除`}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
                         </div>
+                        {selectedId === point.id && (
+                          <div
+                            className="mt-2 rounded-2xl bg-slate-50 p-4"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                                Status
+                              </p>
+                              <p className="mt-1 text-sm font-semibold text-slate-900">
+                                {pointStatus?.label ?? "未判定"}
+                              </p>
+                              <p className="mt-1 text-xs leading-5 text-slate-500">
+                                {pointStatus?.description ?? "このポイントの状態を確認できます。"}
+                              </p>
+                              {point.branchFromId && (
+                                <p className="mt-2 text-[11px] text-slate-400">分岐元 ID: {point.branchFromId}</p>
+                              )}
+                            </div>
+                            <div className="mt-4 grid grid-cols-2 gap-3">
+                              <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                緯度
+                                <input
+                                  type="number"
+                                  step="0.000001"
+                                  value={point.lat}
+                                  onChange={(event) =>
+                                    setRoutePoints((prev) =>
+                                      normalizeMapRoutePoints(
+                                        prev.map((item) =>
+                                          item.id === point.id
+                                            ? { ...item, lat: Number(event.target.value) }
+                                            : item
+                                        )
+                                      )
+                                    )
+                                  }
+                                  className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                                />
+                              </label>
+                              <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                経度
+                                <input
+                                  type="number"
+                                  step="0.000001"
+                                  value={point.lng}
+                                  onChange={(event) =>
+                                    setRoutePoints((prev) =>
+                                      normalizeMapRoutePoints(
+                                        prev.map((item) =>
+                                          item.id === point.id
+                                            ? { ...item, lng: Number(event.target.value) }
+                                            : item
+                                        )
+                                      )
+                                    )
+                                  }
+                                  className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                                />
+                              </label>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    ))}
-                    {filteredRoutePoints.length === 0 && (
-                      <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-500">
-                        道路ポイントがまだありません。
-                      </div>
-                    )}
-                  </div>
+                    );
+                  })}
+                  {filteredRoutePoints.length === 0 && (
+                    <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-500">
+                      道路ポイントがまだありません。
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -1428,111 +1463,6 @@ export default function MapEditClient() {
             </div>
           )}
 
-          {selectedKind === "route" && (
-            <div className="mt-6 space-y-3 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
-              {selectedRoutePoint ? (
-                <>
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                        Selected Route Point
-                      </p>
-                      <p className="mt-1 text-sm font-semibold text-slate-900">
-                        ポイント {routePoints.findIndex((point) => point.id === selectedRoutePoint.id) + 1}
-                      </p>
-                    </div>
-                    <div className="rounded-full bg-white px-3 py-1 text-[11px] font-semibold text-slate-500">
-                      ID: {selectedRoutePoint.id}
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      緯度
-                      <input
-                        type="number"
-                        step="0.000001"
-                        value={selectedRoutePoint.lat}
-                        onChange={(event) =>
-                          setRoutePoints((prev) =>
-                            normalizeMapRoutePoints(
-                              prev.map((point) =>
-                                point.id === selectedRoutePoint.id
-                                  ? { ...point, lat: Number(event.target.value) }
-                                  : point
-                              )
-                            )
-                          )
-                        }
-                        className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
-                      />
-                    </label>
-                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      経度
-                      <input
-                        type="number"
-                        step="0.000001"
-                        value={selectedRoutePoint.lng}
-                        onChange={(event) =>
-                          setRoutePoints((prev) =>
-                            normalizeMapRoutePoints(
-                              prev.map((point) =>
-                                point.id === selectedRoutePoint.id
-                                  ? { ...point, lng: Number(event.target.value) }
-                                  : point
-                              )
-                            )
-                          )
-                        }
-                        className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
-                      />
-                    </label>
-                  </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleMoveRoutePointOrder(selectedRoutePoint.id, -1)}
-                      disabled={routePoints.findIndex((point) => point.id === selectedRoutePoint.id) === 0}
-                      className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      一つ前へ移動
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleMoveRoutePointOrder(selectedRoutePoint.id, 1)}
-                      disabled={routePoints.findIndex((point) => point.id === selectedRoutePoint.id) === routePoints.length - 1}
-                      className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      一つ後ろへ移動
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <p className="text-sm text-slate-600">
-                  左の一覧から道路ポイントを選ぶと、ここで座標編集と順序変更ができます。地図上ではドラッグでも動かせます。
-                </p>
-              )}
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={handleCancelRoute}
-                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
-                >
-                  キャンセル
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmRoute}
-                  className="rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
-                >
-                  確定
-                </button>
-              </div>
-              <p className="text-xs text-slate-500">
-                この道路中心線が公開マップの道路形状と現在地の通路判定に使われます。
-              </p>
-            </div>
-          )}
-
           {message && (
             <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50 px-4 py-3 text-sm text-sky-800">
               {message}
@@ -1566,11 +1496,7 @@ export default function MapEditClient() {
               setLandmarks((prev) => prev.map((item) => (item.key === key ? { ...item, lat, lng } : item)))
             }
             onMoveRoutePoint={(id, lat, lng) =>
-              setRoutePoints((prev) =>
-                normalizeMapRoutePoints(
-                  prev.map((point) => (point.id === id ? { ...point, lat, lng } : point))
-                )
-              )
+              setRoutePoints((prev) => stabilizeRoutePointMove(prev, id, lat, lng))
             }
             onInsertRoutePointAtSegment={handleInsertRoutePointAtSegment}
             onAddConnectedRoutePoint={handleAddConnectedRoutePoint}

--- a/app/(public)/map-edit/MapEditClient.tsx
+++ b/app/(public)/map-edit/MapEditClient.tsx
@@ -161,6 +161,7 @@ export default function MapEditClient() {
   const [mapSettings, setMapSettings] = useState<MapSettings>(DEFAULT_MAP_SETTINGS);
   const [isLoadingSnapshots, setIsLoadingSnapshots] = useState(false);
   const [isRestoring, setIsRestoring] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
   const shopItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const landmarkItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const routePointItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -199,6 +200,7 @@ export default function MapEditClient() {
         setInitialLandmarks(cloneLandmarks(nextLandmarks));
         setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
         setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
+        setLastSavedAt(new Date().toISOString());
       })
       .catch(() => {
         if (!active) return;
@@ -450,6 +452,7 @@ export default function MapEditClient() {
       setInitialLandmarks(cloneLandmarks(nextLandmarks));
       setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
       setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
+      setLastSavedAt(new Date().toISOString());
       if (isHistoryOpen) {
         await loadSnapshots();
       }
@@ -600,6 +603,15 @@ export default function MapEditClient() {
     setIsHistoryOpen(false);
   };
 
+  const handleResetToLastSaved = () => {
+    setShops(sortShops(cloneShops(initialShops)));
+    setLandmarks(cloneLandmarks(initialLandmarks));
+    setRoutePoints(cloneRoutePoints(initialRoutePoints));
+    setRouteConfig(cloneRouteConfig(initialRouteConfig));
+    setSelectedId("");
+    setMessage("保存済みの状態に戻しました。");
+  };
+
   const handleRestoreSnapshot = async (snapshotId: string) => {
     if (hasUnsavedChanges) {
       setMessage("現在の変更を保存してからでないと復元できません。");
@@ -634,6 +646,7 @@ export default function MapEditClient() {
       setInitialLandmarks(cloneLandmarks(nextLandmarks));
       setInitialRoutePoints(cloneRoutePoints(nextRoutePoints));
       setInitialRouteConfig(cloneRouteConfig(nextRouteConfig));
+      setLastSavedAt(new Date().toISOString());
       await loadSnapshots();
       setMessage("バックアップから復元しました。復元前の状態も自動保存しています。");
     } catch {
@@ -807,15 +820,58 @@ export default function MapEditClient() {
     }).format(date);
   };
 
+  const formatSavedTime = (value: string | null) => {
+    if (!value) return "未保存";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "未保存";
+    return new Intl.DateTimeFormat("ja-JP", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  };
+
+  const taskTabs = [
+    { key: "shop" as const, label: "店舗マーカ", count: shops.length },
+    { key: "landmark" as const, label: "建物", count: landmarks.length },
+    { key: "route" as const, label: "道路", count: routePoints.length },
+  ];
+
+  const mapEditHint =
+    selectedKind === "shop"
+      ? "店舗マーカをクリックして選択。選択中のマーカはドラッグで移動できます。"
+      : selectedKind === "landmark"
+        ? "建物をクリックして選択。選択中の建物はドラッグで移動できます。"
+        : "道路ポイントをドラッグして移動。線上の + で追加、点を押すと道を追加できます。";
+
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col overflow-hidden bg-slate-100">
       <div className="border-b border-slate-200 bg-white/95 px-4 py-4 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-7xl items-center gap-3">
+        <div className="mx-auto flex max-w-7xl items-start gap-3">
           <div className="pl-14">
             <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-sky-700">Map Admin</p>
             <h1 className="text-2xl font-bold text-slate-900">マップ管理</h1>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                  hasUnsavedChanges ? "bg-amber-100 text-amber-800" : "bg-emerald-100 text-emerald-700"
+                }`}
+              >
+                {hasUnsavedChanges ? "未保存の変更あり" : "保存済み"}
+              </span>
+              <span className="text-xs text-slate-500">最後に反映: {formatSavedTime(lastSavedAt)}</span>
+            </div>
           </div>
-          <div className="ml-auto mr-16 flex items-center gap-3">
+          <div className="ml-auto mr-16 flex flex-wrap items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={handleResetToLastSaved}
+              disabled={!hasUnsavedChanges || isSaving || isLoading}
+              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+            >
+              保存済みに戻す
+            </button>
             <button
               type="button"
               onClick={handleOpenHistory}
@@ -928,28 +984,31 @@ export default function MapEditClient() {
           </aside>
         )}
         <aside className="flex min-h-0 flex-col overflow-y-auto rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setSelectedKind("shop")}
-              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "shop" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
-            >
-              店舗マーカ
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedKind("landmark")}
-              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "landmark" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
-            >
-              建物オブジェクト
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedKind("route")}
-              className={`inline-flex h-10 items-center justify-center whitespace-nowrap rounded-full px-4 text-sm font-semibold ${selectedKind === "route" ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600"}`}
-            >
-              道路・通路
-            </button>
+          <div className="grid grid-cols-3 gap-2">
+            {taskTabs.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setSelectedKind(tab.key)}
+                className={`rounded-2xl border px-3 py-3 text-left transition ${
+                  selectedKind === tab.key
+                    ? "border-sky-200 bg-sky-50 shadow-sm"
+                    : "border-slate-200 bg-slate-50 text-slate-600"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className={`text-sm font-semibold ${selectedKind === tab.key ? "text-sky-900" : "text-slate-700"}`}>
+                    {tab.label}
+                  </span>
+                  <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-500">
+                    {tab.count}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-slate-400">
+                  {selectedKind === tab.key ? "編集中" : "切り替える"}
+                </p>
+              </button>
+            ))}
           </div>
 
           {selectedKind === "shop" ? (
@@ -1213,7 +1272,7 @@ export default function MapEditClient() {
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
                     Road Settings
                   </p>
-                  <p className="text-[11px] text-slate-400">数値は公開マップの道路表示と現在地補正に使われます</p>
+                  <p className="text-[11px] text-slate-400">よく使う設定だけ先に表示しています</p>
                 </div>
                 <div className="mt-3 grid grid-cols-1 gap-3">
                   <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
@@ -1232,39 +1291,46 @@ export default function MapEditClient() {
                       className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
                     />
                   </label>
-                  <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    スナップ開始距離(m)
-                    <input
-                      type="number"
-                      min="1"
-                      step="0.5"
-                      value={routeConfig.snapDistanceMeters}
-                      onChange={(event) =>
-                        setRouteConfig((prev) => ({
-                          ...prev,
-                          snapDistanceMeters: Number(event.target.value),
-                        }))
-                      }
-                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
-                    />
-                  </label>
-                  <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    最大表示距離(m)
-                    <input
-                      type="number"
-                      min="1"
-                      step="0.5"
-                      value={routeConfig.visibleDistanceMeters}
-                      onChange={(event) =>
-                        setRouteConfig((prev) => ({
-                          ...prev,
-                          visibleDistanceMeters: Number(event.target.value),
-                        }))
-                      }
-                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
-                    />
-                  </label>
                 </div>
+                <details className="mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                  <summary className="cursor-pointer text-sm font-semibold text-slate-700">
+                    詳細設定を開く
+                  </summary>
+                  <div className="mt-3 grid grid-cols-1 gap-3">
+                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      スナップ開始距離(m)
+                      <input
+                        type="number"
+                        min="1"
+                        step="0.5"
+                        value={routeConfig.snapDistanceMeters}
+                        onChange={(event) =>
+                          setRouteConfig((prev) => ({
+                            ...prev,
+                            snapDistanceMeters: Number(event.target.value),
+                          }))
+                        }
+                        className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                      />
+                    </label>
+                    <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      最大表示距離(m)
+                      <input
+                        type="number"
+                        min="1"
+                        step="0.5"
+                        value={routeConfig.visibleDistanceMeters}
+                        onChange={(event) =>
+                          setRouteConfig((prev) => ({
+                            ...prev,
+                            visibleDistanceMeters: Number(event.target.value),
+                          }))
+                        }
+                        className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                      />
+                    </label>
+                  </div>
+                </details>
               </div>
 
               <div className="rounded-2xl border border-slate-200 bg-white">
@@ -1477,6 +1543,7 @@ export default function MapEditClient() {
             landmarks={landmarks}
             routePoints={routePoints}
             routeConfig={routeConfig}
+            interactionHint={mapEditHint}
             maxZoom={mapSettings.maxEditZoom}
             selectedKind={selectedKind}
             selectedId={selectedId}

--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { MapContainer, Marker, Popup, TileLayer, useMapEvents } from "react-leaflet";
+import { MapContainer, Marker, Popup, Polyline, TileLayer, useMapEvents } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { Trash2 } from "lucide-react";
@@ -12,7 +12,7 @@ import RoadOverlay from "../map/components/RoadOverlay";
 import BackgroundOverlay from "../map/components/BackgroundOverlay";
 import OptimizedShopLayerWithClustering from "../map/components/OptimizedShopLayerWithClustering";
 import { normalizeRotationDeg } from "../map/utils/autoRotation";
-import { getRouteCenter, normalizeMapRoutePoints } from "../map/utils/mapRouteGeometry";
+import { getRouteCenter, getRouteSegments, normalizeMapRoutePoints } from "../map/utils/mapRouteGeometry";
 
 type EditableShop = {
   locationId: string;
@@ -37,6 +37,13 @@ type Props = {
   onMoveShop: (id: number, lat: number, lng: number) => void;
   onMoveLandmark: (key: string, lat: number, lng: number) => void;
   onMoveRoutePoint: (id: string, lat: number, lng: number) => void;
+  onInsertRoutePointAtSegment: (
+    segmentStartId: string,
+    lat: number,
+    lng: number,
+    segmentEndId?: string
+  ) => void;
+  onAddConnectedRoutePoint: (pointId: string) => void;
   onDeleteShop: (id: number) => void;
   onDeleteLandmark: (key: string) => void;
   onDeleteRoutePoint: (id: string) => void;
@@ -82,7 +89,7 @@ function isInteractiveMapElement(target: EventTarget | null): boolean {
 }
 
 function createMarkerIcon(
-  kind: "shop" | "landmark",
+  kind: "shop" | "landmark" | "route",
   isSelected: boolean,
   isUnassigned = false,
   isIncompleteLandmark = false
@@ -92,13 +99,17 @@ function createMarkerIcon(
   const background =
     kind === "shop"
       ? (isUnassigned ? "#94a3b8" : "#0284c7")
-      : (isIncompleteLandmark ? "#c7926a" : "#f97316");
+      : kind === "route"
+        ? "#111827"
+        : (isIncompleteLandmark ? "#c7926a" : "#f97316");
   const glow =
     kind === "shop"
       ? isUnassigned
         ? "rgba(148,163,184,.38)"
         : "rgba(2,132,199,.38)"
-      : (isIncompleteLandmark ? "rgba(199,146,106,.38)" : "rgba(249,115,22,.38)");
+      : kind === "route"
+        ? "rgba(15,23,42,.38)"
+        : (isIncompleteLandmark ? "rgba(199,146,106,.38)" : "rgba(249,115,22,.38)");
   const outline = isSelected ? "0 0 0 6px rgba(255,255,255,.95), 0 0 0 10px rgba(15,23,42,.14)" : "";
 
   return L.divIcon({
@@ -123,6 +134,8 @@ export default function MapLayoutEditor({
   onMoveShop,
   onMoveLandmark,
   onMoveRoutePoint,
+  onInsertRoutePointAtSegment,
+  onAddConnectedRoutePoint,
   onDeleteShop,
   onDeleteLandmark,
   onDeleteRoutePoint,
@@ -226,6 +239,10 @@ export default function MapLayoutEditor({
     }
     return icons;
   }, [landmarks]);
+  const routeSegments = useMemo(
+    () => getRouteSegments(routePoints),
+    [routePoints]
+  );
 
   const applyManualRotation = useCallback((nextRotation: number) => {
     setManualRotationOffset(normalizeRotationDeg(nextRotation));
@@ -452,6 +469,36 @@ export default function MapLayoutEditor({
           <>
             <BackgroundOverlay />
             <RoadOverlay routePoints={routePoints} routeConfig={routeConfig} />
+            {selectedKind === "route" &&
+              routeSegments.map((segment) => (
+                <Polyline
+                  key={`route-segment-${segment.start.id}-${segment.end.id}`}
+                  positions={[
+                    [segment.start.lat, segment.start.lng],
+                    [segment.end.lat, segment.end.lng],
+                  ]}
+                  pathOptions={{
+                    color: "#0f172a",
+                    weight: 14,
+                    opacity: 0.001,
+                  }}
+                  eventHandlers={{
+                    click: (event) => {
+                      L.DomEvent.stopPropagation(event);
+                      const shouldInsert = window.confirm(
+                        "この線分の途中に新しい道路ポイントを追加しますか？"
+                      );
+                      if (!shouldInsert) return;
+                      onInsertRoutePointAtSegment(
+                        segment.start.id,
+                        event.latlng.lat,
+                        event.latlng.lng,
+                        segment.end.id
+                      );
+                    },
+                  }}
+                />
+              ))}
             <ClickCapture
               onClick={() => {
                 onClearSelection();
@@ -544,10 +591,20 @@ export default function MapLayoutEditor({
               <Marker
                 key={point.id}
                 position={[point.lat, point.lng]}
-                icon={createMarkerIcon("landmark", selectedKind === "route" && selectedId === point.id)}
+                icon={createMarkerIcon("route", selectedKind === "route" && selectedId === point.id)}
                 draggable={selectedKind === "route" && selectedId === point.id}
                 eventHandlers={{
-                  click: () => onSelect("route", point.id),
+                  click: (event) => {
+                    L.DomEvent.stopPropagation(event);
+                    const shouldAdd = window.confirm(
+                      "このポイントから接続する新しい道路ポイントを追加しますか？"
+                    );
+                    if (!shouldAdd) {
+                      onSelect("route", point.id);
+                      return;
+                    }
+                    onAddConnectedRoutePoint(point.id);
+                  },
                   dragend: (event) => {
                     const marker = event.target;
                     const latlng = marker.getLatLng();

--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -34,6 +34,7 @@ type Props = {
   landmarks: EditableLandmark[];
   routePoints: MapRoutePoint[];
   routeConfig: MapRouteConfig;
+  interactionHint?: string;
   maxZoom?: number;
   selectedKind: "shop" | "landmark" | "route";
   selectedId: string;
@@ -147,6 +148,7 @@ export default function MapLayoutEditor({
   landmarks,
   routePoints,
   routeConfig,
+  interactionHint,
   maxZoom = 20,
   selectedKind,
   selectedId,
@@ -449,6 +451,11 @@ export default function MapLayoutEditor({
           transition: isTouchRotating ? "none" : "transform 1600ms ease-out",
         }}
       >
+        {mode === "edit" && interactionHint ? (
+          <div className="pointer-events-none absolute left-1/2 top-5 z-[500] w-[min(92%,560px)] -translate-x-1/2 rounded-2xl border border-white/70 bg-white/92 px-4 py-3 text-center text-sm text-slate-700 shadow-lg backdrop-blur">
+            {interactionHint}
+          </div>
+        ) : null}
         <MapContainer
           center={center}
           zoom={17}

--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -12,7 +12,12 @@ import RoadOverlay from "../map/components/RoadOverlay";
 import BackgroundOverlay from "../map/components/BackgroundOverlay";
 import OptimizedShopLayerWithClustering from "../map/components/OptimizedShopLayerWithClustering";
 import { normalizeRotationDeg } from "../map/utils/autoRotation";
-import { getRouteCenter, getRouteSegments, normalizeMapRoutePoints } from "../map/utils/mapRouteGeometry";
+import {
+  getRouteCenter,
+  getRoutePointRole,
+  getRouteSegments,
+  normalizeMapRoutePoints,
+} from "../map/utils/mapRouteGeometry";
 
 type EditableShop = {
   locationId: string;
@@ -43,7 +48,7 @@ type Props = {
     lng: number,
     segmentEndId?: string
   ) => void;
-  onAddConnectedRoutePoint: (pointId: string) => void;
+  onAddConnectedRoutePoint: (pointId: string, branchDirection?: "up" | "down" | "auto") => void;
   onDeleteShop: (id: number) => void;
   onDeleteLandmark: (key: string) => void;
   onDeleteRoutePoint: (id: string) => void;
@@ -117,6 +122,22 @@ function createMarkerIcon(
     html: `<div style="width:${size}px;height:${size}px;border-radius:${borderRadius};background:${background};border:3px solid white;box-shadow:${outline ? `${outline}, ` : ""}0 6px 16px ${glow};transform:${isSelected ? "scale(1.05)" : "scale(1)"};"></div>`,
     iconSize: [size, size],
     iconAnchor: [size / 2, size / 2],
+  });
+}
+
+function createMidpointHandleIcon() {
+  return L.divIcon({
+    className: "custom-route-midpoint-icon",
+    html: `
+      <div style="width:18px;height:18px;border-radius:9999px;background:#ffffff;border:2px solid #0f172a;box-shadow:0 4px 12px rgba(15,23,42,.18);display:flex;align-items:center;justify-content:center;">
+        <div style="position:relative;width:8px;height:8px;">
+          <span style="position:absolute;left:3px;top:0;width:2px;height:8px;background:#0f172a;border-radius:9999px;"></span>
+          <span style="position:absolute;left:0;top:3px;width:8px;height:2px;background:#0f172a;border-radius:9999px;"></span>
+        </div>
+      </div>
+    `,
+    iconSize: [18, 18],
+    iconAnchor: [9, 9],
   });
 }
 
@@ -243,6 +264,7 @@ export default function MapLayoutEditor({
     () => getRouteSegments(routePoints),
     [routePoints]
   );
+  const routeMidpointIcon = useMemo(() => createMidpointHandleIcon(), []);
 
   const applyManualRotation = useCallback((nextRotation: number) => {
     setManualRotationOffset(normalizeRotationDeg(nextRotation));
@@ -479,26 +501,37 @@ export default function MapLayoutEditor({
                   ]}
                   pathOptions={{
                     color: "#0f172a",
-                    weight: 14,
-                    opacity: 0.001,
-                  }}
-                  eventHandlers={{
-                    click: (event) => {
-                      L.DomEvent.stopPropagation(event);
-                      const shouldInsert = window.confirm(
-                        "この線分の途中に新しい道路ポイントを追加しますか？"
-                      );
-                      if (!shouldInsert) return;
-                      onInsertRoutePointAtSegment(
-                        segment.start.id,
-                        event.latlng.lat,
-                        event.latlng.lng,
-                        segment.end.id
-                      );
-                    },
+                    weight: 2,
+                    opacity: 0.28,
+                    dashArray: "8 10",
+                    lineCap: "round",
+                    lineJoin: "round",
                   }}
                 />
               ))}
+            {selectedKind === "route" &&
+              routeSegments.map((segment) => {
+                const midpointLat = (segment.start.lat + segment.end.lat) / 2;
+                const midpointLng = (segment.start.lng + segment.end.lng) / 2;
+                return (
+                  <Marker
+                    key={`route-midpoint-${segment.start.id}-${segment.end.id}`}
+                    position={[midpointLat, midpointLng]}
+                    icon={routeMidpointIcon}
+                    eventHandlers={{
+                      click: (event) => {
+                        L.DomEvent.stopPropagation(event);
+                        onInsertRoutePointAtSegment(
+                          segment.start.id,
+                          midpointLat,
+                          midpointLng,
+                          segment.end.id
+                        );
+                      },
+                    }}
+                  />
+                );
+              })}
             <ClickCapture
               onClick={() => {
                 onClearSelection();
@@ -588,23 +621,18 @@ export default function MapLayoutEditor({
               </Marker>
             ))}
             {routePoints.map((point, index) => (
+              (() => {
+                const pointRole = getRoutePointRole(routePoints, point.id);
+                const isMiddleMainPoint = pointRole === "main-middle";
+
+                return (
               <Marker
                 key={point.id}
                 position={[point.lat, point.lng]}
                 icon={createMarkerIcon("route", selectedKind === "route" && selectedId === point.id)}
                 draggable={selectedKind === "route" && selectedId === point.id}
                 eventHandlers={{
-                  click: (event) => {
-                    L.DomEvent.stopPropagation(event);
-                    const shouldAdd = window.confirm(
-                      "このポイントから接続する新しい道路ポイントを追加しますか？"
-                    );
-                    if (!shouldAdd) {
-                      onSelect("route", point.id);
-                      return;
-                    }
-                    onAddConnectedRoutePoint(point.id);
-                  },
+                  click: () => onSelect("route", point.id),
                   dragend: (event) => {
                     const marker = event.target;
                     const latlng = marker.getLatLng();
@@ -628,12 +656,40 @@ export default function MapLayoutEditor({
                         <Trash2 className="h-4 w-4" />
                       </button>
                     </div>
+                    {isMiddleMainPoint ? (
+                      <div className="mt-3 grid grid-cols-2 gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onAddConnectedRoutePoint(point.id, "up")}
+                          className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+                        >
+                          上に道を追加
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onAddConnectedRoutePoint(point.id, "down")}
+                          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+                        >
+                          下に道を追加
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => onAddConnectedRoutePoint(point.id, "auto")}
+                        className="mt-3 w-full rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+                      >
+                        ここから道を追加
+                      </button>
+                    )}
                     <p className="mt-3 text-xs leading-5 text-slate-500">
                       {point.lat.toFixed(6)}, {point.lng.toFixed(6)}
                     </p>
                   </div>
                 </Popup>
               </Marker>
+                );
+              })()
             ))}
           </>
         )}

--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -460,6 +460,12 @@ export default function MapLayoutEditor({
           center={center}
           zoom={17}
           maxZoom={maxZoom}
+          zoomSnap={0.2}
+          zoomDelta={0.35}
+          wheelPxPerZoomLevel={130}
+          zoomAnimation
+          markerZoomAnimation
+          fadeAnimation
           className="h-full w-full"
           scrollWheelZoom
           dragging={false}

--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -7,10 +7,12 @@ import "leaflet/dist/leaflet.css";
 import { Trash2 } from "lucide-react";
 import type { Landmark as EditableLandmark } from "../map/types/landmark";
 import type { Shop } from "../map/data/shops";
+import type { MapRouteConfig, MapRoutePoint } from "../map/types/mapRoute";
 import RoadOverlay from "../map/components/RoadOverlay";
 import BackgroundOverlay from "../map/components/BackgroundOverlay";
 import OptimizedShopLayerWithClustering from "../map/components/OptimizedShopLayerWithClustering";
 import { normalizeRotationDeg } from "../map/utils/autoRotation";
+import { getRouteCenter, normalizeMapRoutePoints } from "../map/utils/mapRouteGeometry";
 
 type EditableShop = {
   locationId: string;
@@ -25,15 +27,19 @@ type Props = {
   mode: "edit" | "preview";
   shops: EditableShop[];
   landmarks: EditableLandmark[];
+  routePoints: MapRoutePoint[];
+  routeConfig: MapRouteConfig;
   maxZoom?: number;
-  selectedKind: "shop" | "landmark";
+  selectedKind: "shop" | "landmark" | "route";
   selectedId: string;
-  onSelect: (kind: "shop" | "landmark", id: string) => void;
+  onSelect: (kind: "shop" | "landmark" | "route", id: string) => void;
   onClearSelection: () => void;
   onMoveShop: (id: number, lat: number, lng: number) => void;
   onMoveLandmark: (key: string, lat: number, lng: number) => void;
+  onMoveRoutePoint: (id: string, lat: number, lng: number) => void;
   onDeleteShop: (id: number) => void;
   onDeleteLandmark: (key: string) => void;
+  onDeleteRoutePoint: (id: string) => void;
 };
 
 function ClickCapture({ onClick }: { onClick: (lat: number, lng: number) => void }) {
@@ -107,6 +113,8 @@ export default function MapLayoutEditor({
   mode,
   shops,
   landmarks,
+  routePoints,
+  routeConfig,
   maxZoom = 20,
   selectedKind,
   selectedId,
@@ -114,8 +122,10 @@ export default function MapLayoutEditor({
   onClearSelection,
   onMoveShop,
   onMoveLandmark,
+  onMoveRoutePoint,
   onDeleteShop,
   onDeleteLandmark,
+  onDeleteRoutePoint,
 }: Props) {
   const mapRef = useRef<L.Map | null>(null);
   const [manualRotationOffset, setManualRotationOffset] = useState(0);
@@ -142,9 +152,13 @@ export default function MapLayoutEditor({
     isPanning: boolean;
   } | null>(null);
   const center = useMemo<[number, number]>(() => {
+    const normalizedRoutePoints = normalizeMapRoutePoints(routePoints);
+    if (normalizedRoutePoints.length >= 2) {
+      return getRouteCenter(normalizedRoutePoints);
+    }
     const first = shops[0] ?? landmarks[0];
     return first ? [first.lat, first.lng] : [33.56145, 133.5383];
-  }, [landmarks, shops]);
+  }, [landmarks, routePoints, shops]);
   const mapRotation = normalizeRotationDeg(manualRotationOffset);
   const shopIcons = useMemo(() => {
     const icons = new Map<number, L.DivIcon>();
@@ -421,7 +435,7 @@ export default function MapLayoutEditor({
         {mode === "preview" ? (
           <>
             <BackgroundOverlay />
-            <RoadOverlay />
+            <RoadOverlay routePoints={routePoints} routeConfig={routeConfig} />
             {landmarks.map((landmark) => (
               <Marker
                 key={landmark.key}
@@ -436,6 +450,8 @@ export default function MapLayoutEditor({
           </>
         ) : (
           <>
+            <BackgroundOverlay />
+            <RoadOverlay routePoints={routePoints} routeConfig={routeConfig} />
             <ClickCapture
               onClick={() => {
                 onClearSelection();
@@ -519,6 +535,44 @@ export default function MapLayoutEditor({
                     </div>
                     <p className="mt-3 text-xs leading-5 text-slate-500">
                       {landmark.lat.toFixed(6)}, {landmark.lng.toFixed(6)}
+                    </p>
+                  </div>
+                </Popup>
+              </Marker>
+            ))}
+            {routePoints.map((point, index) => (
+              <Marker
+                key={point.id}
+                position={[point.lat, point.lng]}
+                icon={createMarkerIcon("landmark", selectedKind === "route" && selectedId === point.id)}
+                draggable={selectedKind === "route" && selectedId === point.id}
+                eventHandlers={{
+                  click: () => onSelect("route", point.id),
+                  dragend: (event) => {
+                    const marker = event.target;
+                    const latlng = marker.getLatLng();
+                    onMoveRoutePoint(point.id, latlng.lat, latlng.lng);
+                  },
+                }}
+              >
+                <Popup className="map-edit-marker-popup" closeButton={false} offset={[0, -12]}>
+                  <div className="min-w-[180px]">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Route</p>
+                        <h3 className="mt-1 text-sm font-semibold text-slate-900">ポイント {index + 1}</h3>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => onDeleteRoutePoint(point.id)}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-rose-50 text-rose-600 transition hover:bg-rose-100"
+                        aria-label={`道路ポイント ${index + 1} を削除`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                    <p className="mt-3 text-xs leading-5 text-slate-500">
+                      {point.lat.toFixed(6)}, {point.lng.toFixed(6)}
                     </p>
                   </div>
                 </Popup>

--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -14,6 +14,7 @@ import { BadgeModal } from "./components/BadgeModal";
 import { useAuth } from "../../../lib/auth/AuthContext";
 import type { Shop } from "./data/shops";
 import type { Landmark } from "./types/landmark";
+import type { MapRoute } from "./types/mapRoute";
 import { grandmaComments } from "./data/grandmaComments";
 import { loadKotodute } from "../../../lib/kotoduteStorage";
 import { applyShopEdits } from "../../../lib/shopEdits";
@@ -28,6 +29,7 @@ const MapView = dynamic(() => import("./components/MapView"), {
 type MapPageClientProps = {
   shops: Shop[];
   landmarks: Landmark[];
+  mapRoute: MapRoute;
   showGrandma?: boolean;
   shopBannerVariant?: "default" | "kotodute";
   attendanceEstimates?: Record<
@@ -93,6 +95,7 @@ function shuffleArray<T>(items: T[]): T[] {
 export default function MapPageClient({
   shops,
   landmarks,
+  mapRoute,
   showGrandma = true,
   shopBannerVariant = "default",
   attendanceEstimates,
@@ -627,6 +630,7 @@ export default function MapPageClient({
             <MapView
               shops={shops}
               landmarks={landmarks}
+              mapRoute={mapRoute}
               initialShopId={initialShopId}
               openInitialShopBanner={!isAiFocusMode}
               selectedRecipe={recommendedRecipe ?? undefined}

--- a/app/(public)/map/components/MapOverlays.tsx
+++ b/app/(public)/map/components/MapOverlays.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { Fragment, memo, useEffect, useState } from "react";
+import type { ComponentType } from "react";
+import { CircleMarker, Marker, Pane, Popup, Rectangle, Tooltip, useMap } from "react-leaflet";
+import L from "leaflet";
+import type { LatLngBoundsExpression } from "leaflet";
+import type { Landmark } from "../types/landmark";
+import type { Shop } from "../data/shops";
+import type { ShopBannerOrigin } from "./MapView";
+import type { MapRouteConfig, MapRoutePoint } from "../types/mapRoute";
+import RoadOverlay from "./RoadOverlay";
+
+const MIN_ZOOM_LABEL_NAMES = new Set(["高知城", "高知駅", "チンチン電車"]);
+const MIN_ZOOM_ONLY_LABEL = { name: "日曜市", lat: 33.56145, lng: 133.5383 };
+
+export const MapOverlays = memo(function MapOverlays({
+  isLowZoomTintMode,
+  routePoints,
+  routeConfig,
+  mapBounds,
+  visibleMajorPlaceLabels,
+  shouldRenderEventGlow,
+  eventTargets,
+  highlightEventTargets,
+  visibleLandmarkSpecs,
+  landmarkIcons,
+  isMinimumZoomMode,
+  shops,
+  onShopClick,
+  onChunkProgress,
+  selectedShopId,
+  favoriteShopIds,
+  searchShopIds,
+  aiHighlightShopIds,
+  commentHighlightShopIds,
+  kotoduteShopIds,
+  recipeIngredientIconsByShop,
+  attendanceLabelsByShop,
+  bagShopIds,
+  shouldRenderRecipeOverlay,
+  shopsWithIngredients,
+  recipeIngredients,
+  onRecipeShopClick,
+  OptimizedShopLayerWithClustering,
+}: {
+  isLowZoomTintMode: boolean;
+  routePoints: MapRoutePoint[];
+  routeConfig: MapRouteConfig;
+  mapBounds: [[number, number], [number, number]];
+  visibleMajorPlaceLabels: Array<{ name: string; lat: number; lng: number }>;
+  shouldRenderEventGlow: boolean;
+  eventTargets?: Array<{ id: string | number; lat: number; lng: number }>;
+  highlightEventTargets: boolean;
+  visibleLandmarkSpecs: Landmark[];
+  landmarkIcons: Map<string, L.DivIcon>;
+  isMinimumZoomMode: boolean;
+  shops: Shop[];
+  onShopClick: (shop: Shop, origin?: ShopBannerOrigin) => void;
+  onChunkProgress: (processed: number, total: number, done: boolean) => void;
+  selectedShopId?: number;
+  favoriteShopIds: number[];
+  searchShopIds?: number[];
+  aiHighlightShopIds?: number[];
+  commentHighlightShopIds?: number[];
+  kotoduteShopIds?: number[];
+  recipeIngredientIconsByShop: Record<number, string[]>;
+  attendanceLabelsByShop: Record<number, string>;
+  bagShopIds: number[];
+  shouldRenderRecipeOverlay: boolean;
+  shopsWithIngredients: Shop[];
+  recipeIngredients: Array<{ name: string; icon: string }>;
+  onRecipeShopClick: (shop: Shop) => void;
+  OptimizedShopLayerWithClustering: ComponentType<any>;
+}) {
+  return (
+    <>
+      <RoadOverlay
+        overviewTint={isLowZoomTintMode}
+        routePoints={routePoints}
+        routeConfig={routeConfig}
+      />
+      <DynamicMaxBounds baseBounds={mapBounds} paddingPx={100} />
+
+      <Pane name="major-place-label" style={{ zIndex: 950 }}>
+        {visibleMajorPlaceLabels.map((place) => (
+          <Marker
+            key={`major-place-${place.name}`}
+            position={[place.lat, place.lng]}
+            icon={L.divIcon({
+              className: "major-place-label-icon",
+              html: `<span class="major-place-label-pill${
+                place.name === "日曜市" ? " is-sunday-market" : ""
+              }" style="display:inline-block;padding:2px 8px;border-radius:9999px;background:rgba(255,255,255,0.88);border:1px solid rgba(15,23,42,0.15);font-size:11px;font-weight:700;color:#0f172a;white-space:nowrap;">${place.name}</span>`,
+              iconSize: [0, 0],
+            })}
+            interactive={false}
+            keyboard={false}
+            zIndexOffset={1200}
+          />
+        ))}
+      </Pane>
+
+      <EventDimOverlay active={highlightEventTargets} />
+
+      {shouldRenderEventGlow && (
+        <Pane name="event-glow" style={{ zIndex: 2000 }}>
+          {eventTargets?.map((target) => (
+            <Fragment key={target.id}>
+              <CircleMarker
+                center={[target.lat, target.lng]}
+                radius={20}
+                pane="event-glow"
+                pathOptions={{
+                  fillColor: "transparent",
+                  fillOpacity: 0,
+                  color: "#ffffff",
+                  weight: 2,
+                  opacity: 0.9,
+                }}
+                className="map-event-ripple is-1"
+              />
+              <CircleMarker
+                center={[target.lat, target.lng]}
+                radius={30}
+                pane="event-glow"
+                pathOptions={{
+                  fillColor: "transparent",
+                  fillOpacity: 0,
+                  color: "#ffffff",
+                  weight: 2,
+                  opacity: 0.7,
+                }}
+                className="map-event-ripple is-2"
+              />
+            </Fragment>
+          ))}
+        </Pane>
+      )}
+
+      <Pane name="landmarks" style={{ zIndex: highlightEventTargets ? 3000 : 70 }}>
+        {visibleLandmarkSpecs.map((spec) => (
+          <Marker
+            key={`landmark-${spec.key}`}
+            position={[spec.lat, spec.lng]}
+            icon={landmarkIcons.get(spec.key) ?? L.divIcon({ className: "map-landmark-icon" })}
+            interactive
+            keyboard={false}
+            opacity={1}
+            zIndexOffset={highlightEventTargets ? 1800 : 0}
+          >
+            <Popup pane="landmark-popup" offset={[0, -18]} className="map-landmark-popup">
+              <div className="min-w-[180px] max-w-[220px]">
+                <p className="text-sm font-bold text-slate-900">{spec.name}</p>
+                <p className="mt-1 text-xs leading-relaxed text-slate-600">{spec.description}</p>
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+      </Pane>
+      <Pane name="landmark-popup" style={{ zIndex: 10000 }} />
+
+      {!isMinimumZoomMode && (
+        <OptimizedShopLayerWithClustering
+          shops={shops}
+          onShopClick={onShopClick}
+          onChunkProgress={onChunkProgress}
+          selectedShopId={selectedShopId}
+          favoriteShopIds={favoriteShopIds}
+          searchShopIds={searchShopIds}
+          aiHighlightShopIds={aiHighlightShopIds}
+          commentHighlightShopIds={commentHighlightShopIds}
+          kotoduteShopIds={kotoduteShopIds}
+          recipeIngredientIconsByShop={recipeIngredientIconsByShop}
+          attendanceLabelsByShop={attendanceLabelsByShop}
+          bagShopIds={bagShopIds}
+        />
+      )}
+
+      {!isMinimumZoomMode && shouldRenderRecipeOverlay && shopsWithIngredients.map((shop) => {
+        const matchingIngredients = recipeIngredients.filter((ing) =>
+          shop.products.some((product) =>
+            product.toLowerCase().includes(ing.name.toLowerCase()) ||
+            ing.name.toLowerCase().includes(product.toLowerCase())
+          )
+        );
+
+        return (
+          <CircleMarker
+            key={`recipe-${shop.id}`}
+            center={[shop.lat, shop.lng]}
+            radius={40}
+            pathOptions={{
+              fillColor: "#f59e0b",
+              fillOpacity: 0.2,
+              color: "#f59e0b",
+              weight: 3,
+              opacity: 0.8,
+            }}
+            eventHandlers={{
+              click: () => onRecipeShopClick(shop),
+            }}
+          >
+            <Tooltip direction="top" offset={[0, -10]} opacity={0.95}>
+              <div className="text-xs">
+                <div className="mb-1 font-bold">{shop.name}</div>
+                <div className="space-y-0.5 text-[10px]">
+                  {matchingIngredients.slice(0, 3).map((ing, i) => (
+                    <div key={i}>
+                      {ing.icon} {ing.name}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Tooltip>
+          </CircleMarker>
+        );
+      })}
+    </>
+  );
+});
+
+function DynamicMaxBounds({
+  baseBounds,
+  paddingPx,
+}: {
+  baseBounds: [[number, number], [number, number]];
+  paddingPx: number;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    const baseLatLngBounds = L.latLngBounds(baseBounds);
+
+    const updateBounds = () => {
+      const zoom = map.getZoom();
+      const size = map.getSize();
+      const viewportDiagonal = Math.sqrt(size.x * size.x + size.y * size.y);
+      const dynamicPaddingPx = Math.max(paddingPx, viewportDiagonal);
+      const sw = map.project(baseLatLngBounds.getSouthWest(), zoom);
+      const ne = map.project(baseLatLngBounds.getNorthEast(), zoom);
+      const paddedSw = L.point(sw.x - dynamicPaddingPx, sw.y + dynamicPaddingPx);
+      const paddedNe = L.point(ne.x + dynamicPaddingPx, ne.y - dynamicPaddingPx);
+      const paddedBounds = L.latLngBounds(
+        map.unproject(paddedSw, zoom),
+        map.unproject(paddedNe, zoom)
+      );
+      map.setMaxBounds(paddedBounds);
+    };
+
+    updateBounds();
+    map.on("zoom resize move", updateBounds);
+    return () => {
+      map.off("zoom resize move", updateBounds);
+    };
+  }, [map, baseBounds, paddingPx]);
+
+  return null;
+}
+
+function EventDimOverlay({ active }: { active: boolean }) {
+  const map = useMap();
+  const [bounds, setBounds] = useState<LatLngBoundsExpression | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const update = () => {
+      setBounds(map.getBounds());
+    };
+    update();
+    map.on("move zoom resize", update);
+    return () => {
+      map.off("move zoom resize", update);
+    };
+  }, [map, active]);
+
+  if (!active || !bounds) return null;
+
+  return (
+    <Pane name="event-dim" style={{ zIndex: 800 }}>
+      <Rectangle
+        bounds={bounds}
+        pathOptions={{
+          color: "transparent",
+          weight: 0,
+          fillColor: "#050505",
+          fillOpacity: 0.55,
+        }}
+        interactive={false}
+      />
+    </Pane>
+  );
+}
+
+export function getVisibleMajorPlaceLabels({
+  shouldRenderMajorLabels,
+  isMinimumZoomMode,
+  majorPlaceLabels,
+}: {
+  shouldRenderMajorLabels: boolean;
+  isMinimumZoomMode: boolean;
+  majorPlaceLabels: Array<{ name: string; lat: number; lng: number }>;
+}) {
+  if (!shouldRenderMajorLabels) {
+    return [];
+  }
+  if (!isMinimumZoomMode) {
+    return majorPlaceLabels;
+  }
+  return [
+    ...majorPlaceLabels.filter((place) => MIN_ZOOM_LABEL_NAMES.has(place.name)),
+    MIN_ZOOM_ONLY_LABEL,
+  ];
+}

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -15,19 +15,18 @@
 
 'use client';
 
-import { useEffect, useMemo, useRef, useState, useCallback, Fragment, memo } from "react";
-import { MapContainer, useMap, Tooltip, CircleMarker, Pane, Rectangle, Marker, Popup, TileLayer } from "react-leaflet";
+import { useEffect, useMemo, useRef, useState, useCallback, memo } from "react";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import L from "leaflet";
-import type { LatLngBoundsExpression } from "leaflet";
 import { Navigation, Plus, Minus } from "lucide-react";
 import "leaflet/dist/leaflet.css";
 import { shops as baseShops, Shop } from "../data/shops";
 import ShopDetailBanner from "./ShopDetailBanner";
-import RoadOverlay from "./RoadOverlay";
 import BackgroundOverlay from "./BackgroundOverlay";
 import UserLocationMarker from "./UserLocationMarker";
 import MapAgentAssistant from "./MapAgentAssistant";
 import OptimizedShopLayerWithClustering from "./OptimizedShopLayerWithClustering";
+import { MapOverlays, getVisibleMajorPlaceLabels } from "./MapOverlays";
 import { ingredientCatalog, ingredientIcons, type Recipe } from "../../../../lib/recipes";
 import {
   getRecommendedZoomBounds,
@@ -48,7 +47,6 @@ import type { Landmark } from "../types/landmark";
 import type { MapRoute } from "../types/mapRoute";
 import {
   getAutoRotationForVisibleRoad,
-  getNearestRoadAlignedRotation,
   normalizeRotationDeg,
 } from "../utils/autoRotation";
 import {
@@ -61,6 +59,7 @@ import {
   projectPointOntoRoute,
 } from "../utils/mapRouteGeometry";
 import { useMapGestures } from "../hooks/useMapGestures";
+import { useMapCameraController } from "../hooks/useMapCameraController";
 
 function findIngredientMatch(name: string) {
   const lower = name.trim().toLowerCase();
@@ -84,9 +83,6 @@ const ZOOM_BOUNDS = getRecommendedZoomBounds();
 const MIN_ZOOM = ZOOM_BOUNDS.min;
 const MAX_ZOOM = ZOOM_BOUNDS.max;
 const INITIAL_ZOOM = MAX_ZOOM;
-const MIN_ZOOM_LABEL_NAMES = new Set(["高知城", "高知駅", "チンチン電車"]);
-const MIN_ZOOM_ONLY_LABEL = { name: "日曜市", lat: 33.56145, lng: 133.5383 };
-
 const AGENT_STORAGE_KEY = "nicchyo-map-agent-plan";
 const BASEMAP_TILE_URL = "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png";
 const BASEMAP_ATTRIBUTION =
@@ -278,9 +274,8 @@ type MapViewProps = {
   onShopSelect?: (shop: Shop) => void;
 };
 
-type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
+export type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
 
-const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 15;
 const SKIPPED_ZOOM_LEVELS = [18];
 const SKIPPED_ZOOM_TOLERANCE = 0.01;
 
@@ -828,36 +823,6 @@ const MapView = memo(function MapView({
     handleShopClick(nextShop);
   }, [canNavigate, selectedShopIndex, handleShopClick, shops]);
 
-  const snapRotationToVisibleRoad = useCallback(
-    (center?: L.LatLng, forceNorthUp = false) => {
-      if (interactionDisabled || isTouchGestureActiveRef.current) return;
-      const map = mapRef.current;
-      if (!map) return;
-      if (forceNorthUp) {
-        setAutoRotation(0);
-        return;
-      }
-      const targetRotation = getAutoRotationForVisibleRoad({
-        center: center ?? map.getCenter(),
-        routePoints,
-      });
-      if (targetRotation === null) {
-        setAutoRotation(0);
-        return;
-      }
-      const currentRotation = normalizeRotationDeg(autoRotation);
-      const { rotation: snappedRotation, delta } = getNearestRoadAlignedRotation(
-        currentRotation,
-        targetRotation
-      );
-      if (Math.abs(delta) > AUTO_ROTATION_SNAP_THRESHOLD_DEG || Math.abs(delta) < 0.1) {
-        return;
-      }
-      setAutoRotation(snappedRotation);
-    },
-    [autoRotation, interactionDisabled, routePoints]
-  );
-
   const handleMapZoomChange = useCallback(
     (zoom: number) => {
       setMapUiZoom(zoom);
@@ -865,13 +830,6 @@ const MapView = memo(function MapView({
     },
     [onZoomChange]
   );
-
-  useEffect(() => {
-    if (!isTracking) return;
-    const map = mapRef.current;
-    if (!map) return;
-    snapRotationToVisibleRoad(map.getCenter());
-  }, [isTracking, snapRotationToVisibleRoad]);
 
   const landmarkScale = useMemo(() => {
     const factor = Math.pow(1.22, mapUiZoom - 18);
@@ -897,18 +855,15 @@ const MapView = memo(function MapView({
     return icons;
   }, [highlightEventTargets, landmarkScale, landmarkSpecs]);
 
-  const visibleMajorPlaceLabels = useMemo(() => {
-    if (!shouldRenderMajorLabels) {
-      return [];
-    }
-    if (!isMinimumZoomMode) {
-      return majorPlaceLabels;
-    }
-    return [
-      ...majorPlaceLabels.filter((place) => MIN_ZOOM_LABEL_NAMES.has(place.name)),
-      MIN_ZOOM_ONLY_LABEL,
-    ];
-  }, [isMinimumZoomMode, majorPlaceLabels, shouldRenderMajorLabels]);
+  const visibleMajorPlaceLabels = useMemo(
+    () =>
+      getVisibleMajorPlaceLabels({
+        shouldRenderMajorLabels,
+        isMinimumZoomMode,
+        majorPlaceLabels,
+      }),
+    [isMinimumZoomMode, majorPlaceLabels, shouldRenderMajorLabels]
+  );
 
   const visibleLandmarkSpecs = useMemo(() => {
     if (!shouldRenderLandmarks) {
@@ -927,48 +882,28 @@ const MapView = memo(function MapView({
     mapRotation,
     onPanStart: () => setIsTracking(false),
     onRotationChange: setAutoRotation,
-    onGestureEnd: () => {
+    onGestureEnd: () => {},
+  });
+
+  const { snapRotationToVisibleRoad } = useMapCameraController({
+    mapRef,
+    interactionDisabled,
+    isGestureActive: isTouchGestureActive,
+    autoRotation,
+    routePoints,
+    isTracking,
+    setIsTracking,
+    setAutoRotation,
+  });
+
+  useEffect(() => {
+    if (!isTouchGestureActive) {
       const map = mapRef.current;
       if (map) {
         snapRotationToVisibleRoad(map.getCenter());
       }
-    },
-  });
-
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
-    if (!interactionDisabled) {
-      map.dragging.disable();
-      map.touchZoom.disable();
     }
-  }, [interactionDisabled, mapInstance]);
-
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
-
-    const handleMoveEnd = () => {
-      if (isTouchGestureActive) {
-        return;
-      }
-      snapRotationToVisibleRoad(map.getCenter());
-    };
-
-    const handleDragStart = () => {
-      if (isTouchGestureActive) {
-        return;
-      }
-      setIsTracking(false);
-    };
-
-    map.on("dragstart", handleDragStart);
-    map.on("moveend", handleMoveEnd);
-    return () => {
-      map.off("dragstart", handleDragStart);
-      map.off("moveend", handleMoveEnd);
-    };
-  }, [isTouchGestureActive, mapInstance, snapRotationToVisibleRoad]);
+  }, [isTouchGestureActive, snapRotationToVisibleRoad]);
 
   return (
     <div
@@ -1041,109 +976,18 @@ const MapView = memo(function MapView({
           />
           {/* 背景 */}
           <BackgroundOverlay />
-
-        {/* 道路 */}
-        <RoadOverlay
-          overviewTint={isLowZoomTintMode}
-          routePoints={routePoints}
-          routeConfig={routeConfig}
-        />
-        <DynamicMaxBounds baseBounds={mapBounds} paddingPx={100} />
-          <Pane name="major-place-label" style={{ zIndex: 950 }}>
-          {visibleMajorPlaceLabels.map((place) => (
-            <Marker
-              key={`major-place-${place.name}`}
-              position={[place.lat, place.lng]}
-              icon={L.divIcon({
-                className: "major-place-label-icon",
-                html: `<span class="major-place-label-pill${
-                  place.name === "日曜市" ? " is-sunday-market" : ""
-                }" style="display:inline-block;padding:2px 8px;border-radius:9999px;background:rgba(255,255,255,0.88);border:1px solid rgba(15,23,42,0.15);font-size:11px;font-weight:700;color:#0f172a;white-space:nowrap;">${place.name}</span>`,
-                iconSize: [0, 0],
-              })}
-              interactive={false}
-              keyboard={false}
-              zIndexOffset={1200}
-            />
-          ))}
-        </Pane>
-
-        <EventDimOverlay active={highlightEventTargets} />
-
-        {shouldRenderEventGlow && (
-          <Pane name="event-glow" style={{ zIndex: 2000 }}>
-            {eventTargets?.map((target) => (
-              <Fragment key={target.id}>
-                <CircleMarker
-                  key={`${target.id}-r1`}
-                  center={[target.lat, target.lng]}
-                  radius={20}
-                  pane="event-glow"
-                  pathOptions={{
-                    fillColor: "transparent",
-                    fillOpacity: 0,
-                    color: "#ffffff",
-                    weight: 2,
-                    opacity: 0.9,
-                  }}
-                  className="map-event-ripple is-1"
-                />
-                <CircleMarker
-                  key={`${target.id}-r2`}
-                  center={[target.lat, target.lng]}
-                  radius={30}
-                  pane="event-glow"
-                  pathOptions={{
-                    fillColor: "transparent",
-                    fillOpacity: 0,
-                    color: "#ffffff",
-                    weight: 2,
-                    opacity: 0.7,
-                  }}
-                  className="map-event-ripple is-2"
-                />
-              </Fragment>
-            ))}
-          </Pane>
-        )}
-
-        <Pane
-          name="landmarks"
-          style={{ zIndex: highlightEventTargets ? 3000 : 70 }}
-        >
-          {visibleLandmarkSpecs.map((spec) => (
-            <Marker
-              key={`landmark-${spec.key}`}
-              position={[spec.lat, spec.lng]}
-              icon={landmarkIcons.get(spec.key) ?? L.divIcon({ className: "map-landmark-icon" })}
-              interactive
-              keyboard={false}
-              opacity={1}
-              zIndexOffset={highlightEventTargets ? 1800 : 0}
-            >
-              <Popup
-                pane="landmark-popup"
-                offset={[0, -18]}
-                className="map-landmark-popup"
-              >
-                <div className="min-w-[180px] max-w-[220px]">
-                  <p className="text-sm font-bold text-slate-900">{spec.name}</p>
-                  <p className="mt-1 text-xs leading-relaxed text-slate-600">{spec.description}</p>
-                </div>
-              </Popup>
-            </Marker>
-          ))}
-        </Pane>
-        <Pane name="landmark-popup" style={{ zIndex: 10000 }} />
-        {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            【ポイント8】最適化された店舗レイヤー
-            - 300個の ShopMarker コンポーネントではなく、
-              1つの OptimizedShopLayerWithClustering が Leaflet API で管理
-            - shops は初期ロード時のみ渡され、以降変更されない
-            - ズーム操作で再レンダリングされない
-            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
-        {!isMinimumZoomMode && (
-          <OptimizedShopLayerWithClustering
+          <MapOverlays
+            isLowZoomTintMode={isLowZoomTintMode}
+            routePoints={routePoints}
+            routeConfig={routeConfig}
+            mapBounds={mapBounds}
+            visibleMajorPlaceLabels={visibleMajorPlaceLabels}
+            shouldRenderEventGlow={shouldRenderEventGlow}
+            eventTargets={eventTargets}
+            highlightEventTargets={highlightEventTargets}
+            visibleLandmarkSpecs={visibleLandmarkSpecs}
+            landmarkIcons={landmarkIcons}
+            isMinimumZoomMode={isMinimumZoomMode}
             shops={shops}
             onShopClick={handleShopClick}
             onChunkProgress={handleShopChunkProgress}
@@ -1156,49 +1000,12 @@ const MapView = memo(function MapView({
             recipeIngredientIconsByShop={recipeIngredientIconsByShop}
             attendanceLabelsByShop={attendanceLabelsByShop}
             bagShopIds={bagShopIds}
+            shouldRenderRecipeOverlay={shouldRenderRecipeOverlay}
+            shopsWithIngredients={shopsWithIngredients}
+            recipeIngredients={recipeIngredients}
+            onRecipeShopClick={setSelectedShop}
+            OptimizedShopLayerWithClustering={OptimizedShopLayerWithClustering}
           />
-        )}
-
-        {/* レシピオーバーレイ */}
-        {!isMinimumZoomMode && shouldRenderRecipeOverlay && shopsWithIngredients.map((shop) => {
-          const matchingIngredients = recipeIngredients.filter((ing) =>
-            shop.products.some((product) =>
-              product.toLowerCase().includes(ing.name.toLowerCase()) ||
-              ing.name.toLowerCase().includes(product.toLowerCase())
-            )
-          );
-
-          return (
-            <CircleMarker
-              key={`recipe-${shop.id}`}
-              center={[shop.lat, shop.lng]}
-              radius={40}
-              pathOptions={{
-                fillColor: "#f59e0b",
-                fillOpacity: 0.2,
-                color: "#f59e0b",
-                weight: 3,
-                opacity: 0.8,
-              }}
-              eventHandlers={{
-                click: () => setSelectedShop(shop),
-              }}
-            >
-              <Tooltip direction="top" offset={[0, -10]} opacity={0.95}>
-                <div className="text-xs">
-                  <div className="font-bold mb-1">{shop.name}</div>
-                  <div className="text-[10px] space-y-0.5">
-                    {matchingIngredients.slice(0, 3).map((ing, i) => (
-                      <div key={i}>
-                        {ing.icon} {ing.name}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </Tooltip>
-            </CircleMarker>
-          );
-        })}
 
         {/* ユーザー位置 */}
         <UserLocationMarker
@@ -1271,75 +1078,3 @@ const MapView = memo(function MapView({
 });
 
 export default MapView;
-
-function DynamicMaxBounds({
-  baseBounds,
-  paddingPx,
-}: {
-  baseBounds: [[number, number], [number, number]];
-  paddingPx: number;
-}) {
-  const map = useMap();
-
-  useEffect(() => {
-    const baseLatLngBounds = L.latLngBounds(baseBounds);
-
-    const updateBounds = () => {
-      const zoom = map.getZoom();
-      const size = map.getSize();
-      const viewportDiagonal = Math.sqrt(size.x * size.x + size.y * size.y);
-      const dynamicPaddingPx = Math.max(paddingPx, viewportDiagonal);
-      const sw = map.project(baseLatLngBounds.getSouthWest(), zoom);
-      const ne = map.project(baseLatLngBounds.getNorthEast(), zoom);
-      const paddedSw = L.point(sw.x - dynamicPaddingPx, sw.y + dynamicPaddingPx);
-      const paddedNe = L.point(ne.x + dynamicPaddingPx, ne.y - dynamicPaddingPx);
-      const paddedBounds = L.latLngBounds(
-        map.unproject(paddedSw, zoom),
-        map.unproject(paddedNe, zoom)
-      );
-      map.setMaxBounds(paddedBounds);
-    };
-
-    updateBounds();
-    map.on("zoom resize move", updateBounds);
-    return () => {
-      map.off("zoom resize move", updateBounds);
-    };
-  }, [map, baseBounds, paddingPx]);
-
-  return null;
-}
-
-function EventDimOverlay({ active }: { active: boolean }) {
-  const map = useMap();
-  const [bounds, setBounds] = useState<LatLngBoundsExpression | null>(null);
-
-  useEffect(() => {
-    if (!active) return;
-    const update = () => {
-      setBounds(map.getBounds());
-    };
-    update();
-    map.on("move zoom resize", update);
-    return () => {
-      map.off("move zoom resize", update);
-    };
-  }, [map, active]);
-
-  if (!active || !bounds) return null;
-
-  return (
-    <Pane name="event-dim" style={{ zIndex: 800 }}>
-      <Rectangle
-        bounds={bounds}
-        pathOptions={{
-          color: "transparent",
-          weight: 0,
-          fillColor: "#050505",
-          fillOpacity: 0.55,
-        }}
-        interactive={false}
-      />
-    </Pane>
-  );
-}

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -875,25 +875,28 @@ const MapView = memo(function MapView({
     return landmarkSpecs.filter((spec) => minZoomLandmarkKeys.has(spec.key));
   }, [isMinimumZoomMode, landmarkSpecs, minZoomLandmarkKeys, shouldRenderLandmarks]);
 
+  const { markManualRotation, snapRotationToVisibleRoad } = useMapCameraController({
+    mapRef,
+    gestureActiveRef: isTouchGestureActiveRef,
+    interactionDisabled,
+    autoRotation,
+    routePoints,
+    isTracking,
+    setIsTracking,
+    setAutoRotation,
+  });
+
   const { isTouchGestureActive, gestureHandlers } = useMapGestures({
     mapRef,
     gestureActiveRef: isTouchGestureActiveRef,
     interactionDisabled,
     mapRotation,
     onPanStart: () => setIsTracking(false),
-    onRotationChange: setAutoRotation,
+    onRotationChange: (rotation) => {
+      markManualRotation();
+      setAutoRotation(rotation);
+    },
     onGestureEnd: () => {},
-  });
-
-  const { snapRotationToVisibleRoad } = useMapCameraController({
-    mapRef,
-    interactionDisabled,
-    isGestureActive: isTouchGestureActive,
-    autoRotation,
-    routePoints,
-    isTracking,
-    setIsTracking,
-    setAutoRotation,
   });
 
   useEffect(() => {

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -746,9 +746,9 @@ const MapView = memo(function MapView({
   }, [selectedShop, shops]);
 
   const canNavigate = selectedShopIndex >= 0 && shops.length > 1;
-  const isMinimumZoomMode = mapUiZoom <= MIN_ZOOM + 0.05;
-  const isLowZoomTintMode = mapUiZoom <= MIN_ZOOM + 1.05;
-  const isThirdZoomFromMinimum = Math.abs(mapUiZoom - (MIN_ZOOM + 2)) <= 0.05;
+  const isMinimumZoomMode = mapUiZoom < MIN_ZOOM + 0.5;
+  const isLowZoomTintMode = mapUiZoom < MIN_ZOOM + 1.5;
+  const isThirdZoomFromMinimum = Math.abs(mapUiZoom - (MIN_ZOOM + 2.5)) <= 0.15;
   const interactionDisabled = agentOpen;
   const mapRotation = normalizeRotationDeg(manualRotationOffset);
   const getSnappedCenter = useCallback(
@@ -1049,6 +1049,12 @@ const MapView = memo(function MapView({
           zoom={INITIAL_ZOOM}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
+          zoomSnap={0.2}
+          zoomDelta={0.35}
+          wheelPxPerZoomLevel={130}
+          zoomAnimation
+          markerZoomAnimation
+          fadeAnimation
           scrollWheelZoom={!agentOpen && !isMobile}
           dragging={false}
           touchZoom={agentOpen ? false : isMultiTouchGesture || isTouchRotating ? false : isMobile ? "center" : true}

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -193,6 +193,53 @@ function MapControls({
   );
 }
 
+function MapStatusHud({
+  isTracking,
+  isInMarket,
+  shopLoadProgress,
+}: {
+  isTracking: boolean;
+  isInMarket: boolean | null;
+  shopLoadProgress: { processed: number; total: number; done: boolean };
+}) {
+  const showShopProgress = shopLoadProgress.total > 0 && !shopLoadProgress.done;
+  const trackingLabel = isTracking ? "現在地を追従中" : "地図を閲覧中";
+  const marketLabel =
+    isInMarket === null
+      ? "位置を確認中"
+      : isInMarket
+        ? "通路上に現在地を表示中"
+        : "通路外のため現在地は非表示";
+
+  return (
+    <div className="pointer-events-none absolute right-4 top-4 z-[1000] flex max-w-[240px] flex-col gap-2">
+      <div className="rounded-2xl bg-white/92 px-3 py-2 shadow-lg ring-1 ring-slate-900/8 backdrop-blur">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Map Status</p>
+        <p className="mt-1 text-sm font-semibold text-slate-900">{trackingLabel}</p>
+        <p className="mt-1 text-xs leading-5 text-slate-600">{marketLabel}</p>
+      </div>
+      {showShopProgress && (
+        <div className="rounded-2xl bg-white/92 px-3 py-2 shadow-lg ring-1 ring-slate-900/8 backdrop-blur">
+          <div className="flex items-center justify-between gap-3 text-xs text-slate-600">
+            <span className="font-medium text-slate-800">店舗を読み込み中</span>
+            <span>{shopLoadProgress.processed}/{shopLoadProgress.total}</span>
+          </div>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200">
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-[width] duration-200"
+              style={{
+                width: `${shopLoadProgress.total > 0
+                  ? Math.min(100, (shopLoadProgress.processed / shopLoadProgress.total) * 100)
+                  : 0}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 type MapViewProps = {
   shops?: Shop[];
   landmarks?: Landmark[];
@@ -424,6 +471,7 @@ const MapView = memo(function MapView({
   const [selectedShop, setSelectedShop] = useState<Shop | null>(null);
   const [shopBannerOrigin, setShopBannerOrigin] = useState<ShopBannerOrigin | null>(null);
   const [isTracking, setIsTracking] = useState(true);
+  const [shopLoadProgress, setShopLoadProgress] = useState({ processed: 0, total: 0, done: false });
   const [manualRotationOffset, setManualRotationOffset] = useState(0);
   const [mapUiZoom, setMapUiZoom] = useState(INITIAL_ZOOM);
   const [isTouchRotating, setIsTouchRotating] = useState(false);
@@ -740,6 +788,19 @@ const MapView = memo(function MapView({
     addItem({ name: value, fromShopId, category });
   }, [addItem]);
 
+  const handleShopChunkProgress = useCallback((processed: number, total: number, done: boolean) => {
+    setShopLoadProgress((prev) => {
+      if (
+        prev.processed === processed &&
+        prev.total === total &&
+        prev.done === done
+      ) {
+        return prev;
+      }
+      return { processed, total, done };
+    });
+  }, []);
+
   const selectedShopIndex = useMemo(() => {
     if (!selectedShop) return -1;
     return shops.findIndex((shop) => shop.id === selectedShop.id);
@@ -749,10 +810,21 @@ const MapView = memo(function MapView({
   const isMinimumZoomMode = mapUiZoom < MIN_ZOOM + 0.5;
   const isLowZoomTintMode = mapUiZoom < MIN_ZOOM + 1.5;
   const isThirdZoomFromMinimum = Math.abs(mapUiZoom - (MIN_ZOOM + 2.5)) <= 0.15;
-  const shouldRenderEventGlow = highlightEventTargets && mapUiZoom >= MIN_ZOOM + 1;
+  const shouldRenderEventGlow = highlightEventTargets && mapUiZoom >= MIN_ZOOM + 1.5;
   const shouldRenderRecipeOverlay = showRecipeOverlay && mapUiZoom >= 19.0;
+  const shouldRenderMajorLabels = mapUiZoom <= MIN_ZOOM + 2.5;
+  const shouldRenderLandmarks = mapUiZoom >= MIN_ZOOM + 0.8 || highlightEventTargets;
   const interactionDisabled = agentOpen;
   const mapRotation = normalizeRotationDeg(manualRotationOffset);
+
+  useEffect(() => {
+    if (isMinimumZoomMode) {
+      setShopLoadProgress({ processed: 0, total: 0, done: true });
+      return;
+    }
+    setShopLoadProgress({ processed: 0, total: shops.length, done: shops.length === 0 });
+  }, [isMinimumZoomMode, shops.length]);
+
   const getSnappedCenter = useCallback(
     (center: L.LatLng) => {
       const projection = projectPointOntoRoute(center, routePoints);
@@ -844,6 +916,9 @@ const MapView = memo(function MapView({
   }, [highlightEventTargets, landmarkScale, landmarkSpecs]);
 
   const visibleMajorPlaceLabels = useMemo(() => {
+    if (!shouldRenderMajorLabels) {
+      return [];
+    }
     if (!isMinimumZoomMode) {
       return majorPlaceLabels;
     }
@@ -851,14 +926,17 @@ const MapView = memo(function MapView({
       ...majorPlaceLabels.filter((place) => MIN_ZOOM_LABEL_NAMES.has(place.name)),
       MIN_ZOOM_ONLY_LABEL,
     ];
-  }, [isMinimumZoomMode, majorPlaceLabels]);
+  }, [isMinimumZoomMode, majorPlaceLabels, shouldRenderMajorLabels]);
 
   const visibleLandmarkSpecs = useMemo(() => {
+    if (!shouldRenderLandmarks) {
+      return [];
+    }
     if (!isMinimumZoomMode) {
       return landmarkSpecs;
     }
     return landmarkSpecs.filter((spec) => minZoomLandmarkKeys.has(spec.key));
-  }, [isMinimumZoomMode, landmarkSpecs, minZoomLandmarkKeys]);
+  }, [isMinimumZoomMode, landmarkSpecs, minZoomLandmarkKeys, shouldRenderLandmarks]);
 
   const handleTouchStartRotate = useCallback(
     (e: React.TouchEvent<HTMLDivElement>) => {
@@ -1106,7 +1184,7 @@ const MapView = memo(function MapView({
           routeConfig={routeConfig}
         />
         <DynamicMaxBounds baseBounds={mapBounds} paddingPx={100} />
-        <Pane name="major-place-label" style={{ zIndex: 950 }}>
+          <Pane name="major-place-label" style={{ zIndex: 950 }}>
           {visibleMajorPlaceLabels.map((place) => (
             <Marker
               key={`major-place-${place.name}`}
@@ -1203,6 +1281,7 @@ const MapView = memo(function MapView({
           <OptimizedShopLayerWithClustering
             shops={shops}
             onShopClick={handleShopClick}
+            onChunkProgress={handleShopChunkProgress}
             selectedShopId={selectedShop?.id}
             favoriteShopIds={favoriteShopIds}
             searchShopIds={searchShopIds}
@@ -1286,6 +1365,11 @@ const MapView = memo(function MapView({
         isMobile={isMobile}
         isTracking={isTracking}
         onToggleTracking={() => setIsTracking((prev) => !prev)}
+      />
+      <MapStatusHud
+        isTracking={isTracking}
+        isInMarket={isInMarket}
+        shopLoadProgress={shopLoadProgress}
       />
 
       {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -60,6 +60,7 @@ import {
   normalizeMapRoutePoints,
   projectPointOntoRoute,
 } from "../utils/mapRouteGeometry";
+import { useMapGestures } from "../hooks/useMapGestures";
 
 function findIngredientMatch(name: string) {
   const lower = name.trim().toLowerCase();
@@ -279,29 +280,9 @@ type MapViewProps = {
 
 type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
 
-const TOUCH_ROTATION_ANGLE_THRESHOLD_DEG = 4;
-const TOUCH_ROTATION_DISTANCE_THRESHOLD_PX = 8;
-const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 20;
-const PAN_START_THRESHOLD_PX = 3;
+const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 15;
 const SKIPPED_ZOOM_LEVELS = [18];
 const SKIPPED_ZOOM_TOLERANCE = 0.01;
-
-function getTouchDistance(
-  t0: { clientX: number; clientY: number },
-  t1: { clientX: number; clientY: number }
-): number {
-  return Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY);
-}
-
-function rotateVector(x: number, y: number, degrees: number): { x: number; y: number } {
-  const radians = (degrees * Math.PI) / 180;
-  const cos = Math.cos(radians);
-  const sin = Math.sin(radians);
-  return {
-    x: x * cos - y * sin,
-    y: x * sin + y * cos,
-  };
-}
 
 function MapZoomListener({ onZoomChange }: { onZoomChange?: (zoom: number) => void }) {
   const map = useMap();
@@ -447,6 +428,24 @@ const MapView = memo(function MapView({
   );
   const routeBounds = useMemo(() => getRouteBounds(routePoints), [routePoints]);
   const routeCenter = useMemo(() => getRouteCenter(routePoints), [routePoints]);
+  const initialMapCenter = useMemo<[number, number]>(() => {
+    const projected = projectPointOntoRoute(
+      { lat: routeCenter[0], lng: routeCenter[1] },
+      routePoints
+    );
+    if (!projected) {
+      return routeCenter;
+    }
+    return [projected.point.lat, projected.point.lng];
+  }, [routeCenter, routePoints]);
+  const initialMapRotation = useMemo(() => {
+    const baseRotation =
+      getAutoRotationForVisibleRoad({
+        center: L.latLng(initialMapCenter[0], initialMapCenter[1]),
+        routePoints,
+      }) ?? 0;
+    return normalizeRotationDeg(baseRotation + 180);
+  }, [initialMapCenter, routePoints]);
   const mapBounds = useMemo(
     () => expandBoundsByMeters(routeBounds, Math.max(routeConfig.visibleDistanceMeters + 48, 120)),
     [routeBounds, routeConfig.visibleDistanceMeters]
@@ -472,37 +471,20 @@ const MapView = memo(function MapView({
   const [shopBannerOrigin, setShopBannerOrigin] = useState<ShopBannerOrigin | null>(null);
   const [isTracking, setIsTracking] = useState(true);
   const [shopLoadProgress, setShopLoadProgress] = useState({ processed: 0, total: 0, done: false });
-  const [manualRotationOffset, setManualRotationOffset] = useState(0);
+  const [autoRotation, setAutoRotation] = useState(initialMapRotation);
   const [mapUiZoom, setMapUiZoom] = useState(INITIAL_ZOOM);
-  const [isTouchRotating, setIsTouchRotating] = useState(false);
-  const [isMultiTouchGesture, setIsMultiTouchGesture] = useState(false);
   const [mapShellSize, setMapShellSize] = useState(() => {
     if (typeof window === "undefined") return 1600;
     const { innerWidth, innerHeight } = window;
     return Math.ceil(Math.hypot(innerWidth, innerHeight) + 120);
   });
-  const touchRotateRef = useRef<{
-    startAngle: number;
-    startDistance: number;
-    startRotation: number;
-    isRotating: boolean;
-  } | null>(null);
-  const touchPanRef = useRef<{
-    lastX: number;
-    lastY: number;
-    hasMoved: boolean;
-  } | null>(null);
-  const mousePanRef = useRef<{
-    lastX: number;
-    lastY: number;
-    isPanning: boolean;
-  } | null>(null);
 
   const [userLocation, setUserLocation] = useState<[number, number] | null>(null);
   const [favoriteShopIds, setFavoriteShopIds] = useState<number[]>([]);
   const [planOrder, setPlanOrder] = useState<number[]>([]);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
   const mapRef = useRef<L.Map | null>(null);
+  const isTouchGestureActiveRef = useRef(false);
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // 【削除】visibleShops の計算を削除
@@ -536,6 +518,10 @@ const MapView = memo(function MapView({
     if (!mapInstance) return;
     mapInstance.invalidateSize(false);
   }, [mapInstance, mapShellSize]);
+
+  useEffect(() => {
+    setAutoRotation(initialMapRotation);
+  }, [initialMapRotation]);
 
   useEffect(() => {
     if (initialShopId) {
@@ -815,7 +801,7 @@ const MapView = memo(function MapView({
   const shouldRenderMajorLabels = mapUiZoom <= MIN_ZOOM + 2.5;
   const shouldRenderLandmarks = mapUiZoom >= MIN_ZOOM + 0.8 || highlightEventTargets;
   const interactionDisabled = agentOpen;
-  const mapRotation = normalizeRotationDeg(manualRotationOffset);
+  const mapRotation = normalizeRotationDeg(autoRotation);
 
   useEffect(() => {
     if (isMinimumZoomMode) {
@@ -842,24 +828,24 @@ const MapView = memo(function MapView({
     handleShopClick(nextShop);
   }, [canNavigate, selectedShopIndex, handleShopClick, shops]);
 
-  const applyManualRotation = useCallback(
-    (nextRotation: number) => {
-      setManualRotationOffset(normalizeRotationDeg(nextRotation));
-    },
-    []
-  );
-
   const snapRotationToVisibleRoad = useCallback(
-    (center?: L.LatLng) => {
-      if (interactionDisabled || isTouchRotating) return;
+    (center?: L.LatLng, forceNorthUp = false) => {
+      if (interactionDisabled || isTouchGestureActiveRef.current) return;
       const map = mapRef.current;
       if (!map) return;
+      if (forceNorthUp) {
+        setAutoRotation(0);
+        return;
+      }
       const targetRotation = getAutoRotationForVisibleRoad({
         center: center ?? map.getCenter(),
         routePoints,
       });
-      if (targetRotation === null) return;
-      const currentRotation = normalizeRotationDeg(manualRotationOffset);
+      if (targetRotation === null) {
+        setAutoRotation(0);
+        return;
+      }
+      const currentRotation = normalizeRotationDeg(autoRotation);
       const { rotation: snappedRotation, delta } = getNearestRoadAlignedRotation(
         currentRotation,
         targetRotation
@@ -867,21 +853,10 @@ const MapView = memo(function MapView({
       if (Math.abs(delta) > AUTO_ROTATION_SNAP_THRESHOLD_DEG || Math.abs(delta) < 0.1) {
         return;
       }
-      setManualRotationOffset(snappedRotation);
+      setAutoRotation(snappedRotation);
     },
-    [interactionDisabled, isTouchRotating, manualRotationOffset, routePoints]
+    [autoRotation, interactionDisabled, routePoints]
   );
-
-  const panMapByScreenDelta = useCallback((dx: number, dy: number) => {
-    if (interactionDisabled) return;
-    const map = mapRef.current;
-    if (!map) return;
-    const adjusted = rotateVector(-dx, -dy, -mapRotation);
-    map.panBy([adjusted.x, adjusted.y], {
-      animate: false,
-      noMoveStart: true,
-    });
-  }, [interactionDisabled, mapRotation]);
 
   const handleMapZoomChange = useCallback(
     (zoom: number) => {
@@ -890,6 +865,13 @@ const MapView = memo(function MapView({
     },
     [onZoomChange]
   );
+
+  useEffect(() => {
+    if (!isTracking) return;
+    const map = mapRef.current;
+    if (!map) return;
+    snapRotationToVisibleRoad(map.getCenter());
+  }, [isTracking, snapRotationToVisibleRoad]);
 
   const landmarkScale = useMemo(() => {
     const factor = Math.pow(1.22, mapUiZoom - 18);
@@ -938,168 +920,55 @@ const MapView = memo(function MapView({
     return landmarkSpecs.filter((spec) => minZoomLandmarkKeys.has(spec.key));
   }, [isMinimumZoomMode, landmarkSpecs, minZoomLandmarkKeys, shouldRenderLandmarks]);
 
-  const handleTouchStartRotate = useCallback(
-    (e: React.TouchEvent<HTMLDivElement>) => {
-      if (interactionDisabled) return;
-      if (e.touches.length === 1) {
-        setIsMultiTouchGesture(false);
-        const touch = e.touches[0];
-        touchPanRef.current = {
-          lastX: touch.clientX,
-          lastY: touch.clientY,
-          hasMoved: false,
-        };
-        touchRotateRef.current = null;
-        setIsTouchRotating(false);
-        return;
-      }
-      if (e.touches.length !== 2) return;
-      setIsMultiTouchGesture(true);
-      touchPanRef.current = null;
-      const t0 = e.touches[0];
-      const t1 = e.touches[1];
-      const angle = Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX);
-      const distance = getTouchDistance(t0, t1);
-      touchRotateRef.current = {
-        startAngle: angle,
-        startDistance: distance,
-        startRotation: mapRotation,
-        isRotating: false,
-      };
-    },
-    [interactionDisabled, mapRotation]
-  );
-
-  const handleTouchMoveRotate = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
-    if (interactionDisabled) return;
-    if (e.touches.length === 1 && touchPanRef.current && !isTouchRotating) {
-      const touch = e.touches[0];
-      const dx = touch.clientX - touchPanRef.current.lastX;
-      const dy = touch.clientY - touchPanRef.current.lastY;
-      if (
-        !touchPanRef.current.hasMoved &&
-        Math.hypot(dx, dy) < PAN_START_THRESHOLD_PX
-      ) {
-        return;
-      }
-      touchPanRef.current.hasMoved = true;
-      touchPanRef.current.lastX = touch.clientX;
-      touchPanRef.current.lastY = touch.clientY;
-      setIsTracking(false);
-      e.preventDefault();
-      panMapByScreenDelta(dx, dy);
-      return;
-    }
-
-    if (e.touches.length !== 2 || !touchRotateRef.current) return;
-    const t0 = e.touches[0];
-    const t1 = e.touches[1];
-    const angle = Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX);
-    const deltaDeg = ((angle - touchRotateRef.current.startAngle) * 180) / Math.PI;
-    const distance = getTouchDistance(t0, t1);
-    const distanceDelta = distance - touchRotateRef.current.startDistance;
-
-    if (!touchRotateRef.current.isRotating) {
-      if (
-        Math.abs(deltaDeg) < TOUCH_ROTATION_ANGLE_THRESHOLD_DEG &&
-        Math.abs(distanceDelta) < TOUCH_ROTATION_DISTANCE_THRESHOLD_PX
-      ) {
-        return;
-      }
-
-      if (
-        Math.abs(deltaDeg) <= TOUCH_ROTATION_ANGLE_THRESHOLD_DEG ||
-        Math.abs(deltaDeg) * 2 < Math.abs(distanceDelta)
-      ) {
-        return;
-      }
-
-      touchRotateRef.current.isRotating = true;
-      setIsTouchRotating(true);
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-    const next = touchRotateRef.current.startRotation + deltaDeg;
-    applyManualRotation(next);
-  }, [applyManualRotation, interactionDisabled, isTouchRotating, panMapByScreenDelta]);
-
-  const handleTouchEndRotate = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
-    if (interactionDisabled) return;
-    setIsMultiTouchGesture(e.touches.length >= 2);
-    if (e.touches.length < 2) {
-      touchRotateRef.current = null;
-      setIsTouchRotating(false);
-    }
-    if (e.touches.length === 0) {
-      touchPanRef.current = null;
-    } else if (e.touches.length === 1) {
-      const touch = e.touches[0];
-      touchPanRef.current = {
-        lastX: touch.clientX,
-        lastY: touch.clientY,
-        hasMoved: false,
-      };
-    }
-    if (e.touches.length < 2) {
+  const { isTouchGestureActive, gestureHandlers } = useMapGestures({
+    mapRef,
+    gestureActiveRef: isTouchGestureActiveRef,
+    interactionDisabled,
+    mapRotation,
+    onPanStart: () => setIsTracking(false),
+    onRotationChange: setAutoRotation,
+    onGestureEnd: () => {
       const map = mapRef.current;
       if (map) {
         snapRotationToVisibleRoad(map.getCenter());
       }
-    }
-  }, [interactionDisabled, snapRotationToVisibleRoad]);
-
-  const handleMouseDownPan = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    if (interactionDisabled) return;
-    if (e.button !== 0) return;
-    mousePanRef.current = {
-      lastX: e.clientX,
-      lastY: e.clientY,
-      isPanning: false,
-    };
-  }, [interactionDisabled]);
+    },
+  });
 
   useEffect(() => {
-    const handleMove = (e: MouseEvent) => {
-      if (!mousePanRef.current || isTouchRotating || interactionDisabled) return;
-      const dx = e.clientX - mousePanRef.current.lastX;
-      const dy = e.clientY - mousePanRef.current.lastY;
-      if (
-        !mousePanRef.current.isPanning &&
-        Math.hypot(dx, dy) < PAN_START_THRESHOLD_PX
-      ) {
-        return;
-      }
-      mousePanRef.current.isPanning = true;
-      mousePanRef.current.lastX = e.clientX;
-      mousePanRef.current.lastY = e.clientY;
-      setIsTracking(false);
-      panMapByScreenDelta(dx, dy);
-    };
-    const handleUp = () => {
-      mousePanRef.current = null;
-    };
-    window.addEventListener("mousemove", handleMove);
-    window.addEventListener("mouseup", handleUp);
-    return () => {
-      window.removeEventListener("mousemove", handleMove);
-      window.removeEventListener("mouseup", handleUp);
-    };
-  }, [interactionDisabled, isTouchRotating, panMapByScreenDelta]);
+    const map = mapRef.current;
+    if (!map) return;
+    if (!interactionDisabled) {
+      map.dragging.disable();
+      map.touchZoom.disable();
+    }
+  }, [interactionDisabled, mapInstance]);
 
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
 
     const handleMoveEnd = () => {
+      if (isTouchGestureActive) {
+        return;
+      }
       snapRotationToVisibleRoad(map.getCenter());
     };
 
+    const handleDragStart = () => {
+      if (isTouchGestureActive) {
+        return;
+      }
+      setIsTracking(false);
+    };
+
+    map.on("dragstart", handleDragStart);
     map.on("moveend", handleMoveEnd);
     return () => {
+      map.off("dragstart", handleDragStart);
       map.off("moveend", handleMoveEnd);
     };
-  }, [mapInstance, snapRotationToVisibleRoad]);
+  }, [isTouchGestureActive, mapInstance, snapRotationToVisibleRoad]);
 
   return (
     <div
@@ -1110,22 +979,18 @@ const MapView = memo(function MapView({
     >
       <div
         className="absolute left-1/2 top-1/2 z-0"
-        onTouchStart={handleTouchStartRotate}
-        onTouchMove={handleTouchMoveRotate}
-        onTouchEnd={handleTouchEndRotate}
-        onTouchCancel={handleTouchEndRotate}
-        onMouseDown={handleMouseDownPan}
+        {...gestureHandlers}
         style={{
           width: `${mapShellSize}px`,
           height: `${mapShellSize}px`,
           touchAction: "none",
           transform: `translate(-50%, -50%) rotate(${mapRotation}deg)`,
           transformOrigin: "center center",
-          transition: isTouchRotating ? "none" : "transform 1600ms ease-out",
+          transition: "transform 1500ms ease-out",
         }}
       >
         <MapContainer
-          center={routeCenter}
+          center={initialMapCenter}
           zoom={INITIAL_ZOOM}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
@@ -1138,7 +1003,7 @@ const MapView = memo(function MapView({
           fadeAnimation
           scrollWheelZoom={!agentOpen && !isMobile}
           dragging={false}
-          touchZoom={agentOpen ? false : isMultiTouchGesture || isTouchRotating ? false : isMobile ? "center" : true}
+          touchZoom={false}
           doubleClickZoom={!agentOpen && !isMobile}
           className={`h-full w-full ${agentOpen ? "pointer-events-none" : ""}`}
           style={{

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -30,12 +30,8 @@ import MapAgentAssistant from "./MapAgentAssistant";
 import OptimizedShopLayerWithClustering from "./OptimizedShopLayerWithClustering";
 import { ingredientCatalog, ingredientIcons, type Recipe } from "../../../../lib/recipes";
 import {
-  getRoadBounds,
-  getNearestPointOnRoad,
-  getSundayMarketBounds,
   getRecommendedZoomBounds,
 } from '../config/roadConfig';
-import { getZoomConfig } from '../utils/zoomCalculator';
 import { FAVORITE_SHOPS_KEY, FAVORITE_SHOPS_UPDATED_EVENT, loadFavoriteShopIds } from "../../../../lib/favoriteShops";
 import {
   applyShopEdits,
@@ -49,17 +45,21 @@ import {
 } from '../config/displayConfig';
 import { useBag } from "../../../../lib/storage/BagContext";
 import type { Landmark } from "../types/landmark";
-import { normalizeRotationDeg } from "../utils/autoRotation";
-
-// Map bounds (Sunday market)
-const ROAD_BOUNDS = getRoadBounds();
-const KOCHI_SUNDAY_MARKET: [number, number] = [
-  (ROAD_BOUNDS[0][0] + ROAD_BOUNDS[1][0]) / 2, // latitude center
-  (ROAD_BOUNDS[0][1] + ROAD_BOUNDS[1][1]) / 2, // longitude center
-];
-
-// Sunday Market area boundaries (restrict pan operations to this area)
-const SUNDAY_MARKET_BOUNDS = getSundayMarketBounds();
+import type { MapRoute } from "../types/mapRoute";
+import {
+  getAutoRotationForVisibleRoad,
+  getNearestRoadAlignedRotation,
+  normalizeRotationDeg,
+} from "../utils/autoRotation";
+import {
+  expandBoundsByMeters,
+  getDefaultMapRouteConfig,
+  getDefaultMapRoutePoints,
+  getRouteBounds,
+  getRouteCenter,
+  normalizeMapRoutePoints,
+  projectPointOntoRoute,
+} from "../utils/mapRouteGeometry";
 
 function findIngredientMatch(name: string) {
   const lower = name.trim().toLowerCase();
@@ -80,15 +80,9 @@ function findIngredientMatch(name: string) {
 // Recommended zoom bounds (optimal range for Sunday Market)
 const ZOOM_BOUNDS = getRecommendedZoomBounds();
 
-// Zoom config by shop count
-const BASE_SHOP_COUNT = baseShops.length || 300;
-const ZOOM_CONFIG = getZoomConfig(BASE_SHOP_COUNT);
 const MIN_ZOOM = ZOOM_BOUNDS.min;
 const MAX_ZOOM = ZOOM_BOUNDS.max;
 const INITIAL_ZOOM = MAX_ZOOM;
-
-// Allow a slight pan margin outside road bounds
-const MAX_BOUNDS: [[number, number], [number, number]] = SUNDAY_MARKET_BOUNDS;
 const MIN_ZOOM_LABEL_NAMES = new Set(["高知城", "高知駅", "チンチン電車"]);
 const MIN_ZOOM_ONLY_LABEL = { name: "日曜市", lat: 33.56145, lng: 133.5383 };
 
@@ -202,6 +196,7 @@ function MapControls({
 type MapViewProps = {
   shops?: Shop[];
   landmarks?: Landmark[];
+  mapRoute?: MapRoute;
   initialShopId?: number;
   openInitialShopBanner?: boolean;
   selectedRecipe?: Recipe;
@@ -239,6 +234,7 @@ type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
 
 const TOUCH_ROTATION_ANGLE_THRESHOLD_DEG = 4;
 const TOUCH_ROTATION_DISTANCE_THRESHOLD_PX = 8;
+const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 20;
 const PAN_START_THRESHOLD_PX = 3;
 const SKIPPED_ZOOM_LEVELS = [18];
 const SKIPPED_ZOOM_TOLERANCE = 0.01;
@@ -307,7 +303,11 @@ function MapZoomConstraint() {
   return null;
 }
 
-function MapZoomRoadSnapController() {
+function MapZoomRoadSnapController({
+  onSnapCenter,
+}: {
+  onSnapCenter: (center: L.LatLng) => [number, number] | null;
+}) {
   const map = useMap();
 
   useEffect(() => {
@@ -323,8 +323,11 @@ function MapZoomRoadSnapController() {
       }
 
       const center = map.getCenter();
-      const nearestRoadPoint = getNearestPointOnRoad(center.lat, center.lng);
-      map.panTo([nearestRoadPoint.lat, nearestRoadPoint.lng], {
+      const snappedPoint = onSnapCenter(center);
+      if (!snappedPoint) {
+        return;
+      }
+      map.panTo(snappedPoint, {
         animate: true,
         duration: 0.7,
         easeLinearity: 0.25,
@@ -335,7 +338,7 @@ function MapZoomRoadSnapController() {
     return () => {
       map.off("zoomend", handleZoomEnd);
     };
-  }, [map]);
+  }, [map, onSnapCenter]);
 
   return null;
 }
@@ -343,6 +346,7 @@ function MapZoomRoadSnapController() {
 const MapView = memo(function MapView({
   shops: initialShops,
   landmarks = [],
+  mapRoute,
   initialShopId,
   openInitialShopBanner = true,
   selectedRecipe,
@@ -379,6 +383,26 @@ const MapView = memo(function MapView({
   const sourceShops = useMemo(
     () => (initialShops && initialShops.length > 0 ? initialShops : baseShops),
     [initialShops]
+  );
+  const routePoints = useMemo(
+    () => {
+      const normalized = normalizeMapRoutePoints(mapRoute?.points ?? []);
+      return normalized.length >= 2 ? normalized : getDefaultMapRoutePoints();
+    },
+    [mapRoute]
+  );
+  const routeConfig = useMemo(
+    () => ({
+      ...getDefaultMapRouteConfig(),
+      ...(mapRoute?.config ?? {}),
+    }),
+    [mapRoute]
+  );
+  const routeBounds = useMemo(() => getRouteBounds(routePoints), [routePoints]);
+  const routeCenter = useMemo(() => getRouteCenter(routePoints), [routePoints]);
+  const mapBounds = useMemo(
+    () => expandBoundsByMeters(routeBounds, Math.max(routeConfig.visibleDistanceMeters + 48, 120)),
+    [routeBounds, routeConfig.visibleDistanceMeters]
   );
   const landmarkSpecs = useMemo(() => landmarks ?? [], [landmarks]);
   const majorPlaceLabels = useMemo(
@@ -727,6 +751,14 @@ const MapView = memo(function MapView({
   const isThirdZoomFromMinimum = Math.abs(mapUiZoom - (MIN_ZOOM + 2)) <= 0.05;
   const interactionDisabled = agentOpen;
   const mapRotation = normalizeRotationDeg(manualRotationOffset);
+  const getSnappedCenter = useCallback(
+    (center: L.LatLng) => {
+      const projection = projectPointOntoRoute(center, routePoints);
+      if (!projection) return null;
+      return [projection.point.lat, projection.point.lng] as [number, number];
+    },
+    [routePoints]
+  );
 
   const handleSelectByOffset = useCallback((offset: number) => {
     if (!canNavigate) return;
@@ -741,6 +773,29 @@ const MapView = memo(function MapView({
       setManualRotationOffset(normalizeRotationDeg(nextRotation));
     },
     []
+  );
+
+  const snapRotationToVisibleRoad = useCallback(
+    (center?: L.LatLng) => {
+      if (interactionDisabled || isTouchRotating) return;
+      const map = mapRef.current;
+      if (!map) return;
+      const targetRotation = getAutoRotationForVisibleRoad({
+        center: center ?? map.getCenter(),
+        routePoints,
+      });
+      if (targetRotation === null) return;
+      const currentRotation = normalizeRotationDeg(manualRotationOffset);
+      const { rotation: snappedRotation, delta } = getNearestRoadAlignedRotation(
+        currentRotation,
+        targetRotation
+      );
+      if (Math.abs(delta) > AUTO_ROTATION_SNAP_THRESHOLD_DEG || Math.abs(delta) < 0.1) {
+        return;
+      }
+      setManualRotationOffset(snappedRotation);
+    },
+    [interactionDisabled, isTouchRotating, manualRotationOffset, routePoints]
   );
 
   const panMapByScreenDelta = useCallback((dx: number, dy: number) => {
@@ -906,7 +961,13 @@ const MapView = memo(function MapView({
         hasMoved: false,
       };
     }
-  }, [interactionDisabled]);
+    if (e.touches.length < 2) {
+      const map = mapRef.current;
+      if (map) {
+        snapRotationToVisibleRoad(map.getCenter());
+      }
+    }
+  }, [interactionDisabled, snapRotationToVisibleRoad]);
 
   const handleMouseDownPan = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (interactionDisabled) return;
@@ -946,6 +1007,20 @@ const MapView = memo(function MapView({
     };
   }, [interactionDisabled, isTouchRotating, panMapByScreenDelta]);
 
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const handleMoveEnd = () => {
+      snapRotationToVisibleRoad(map.getCenter());
+    };
+
+    map.on("moveend", handleMoveEnd);
+    return () => {
+      map.off("moveend", handleMoveEnd);
+    };
+  }, [mapInstance, snapRotationToVisibleRoad]);
+
   return (
     <div
       className="relative h-full w-full overflow-hidden"
@@ -970,7 +1045,7 @@ const MapView = memo(function MapView({
         }}
       >
         <MapContainer
-          center={KOCHI_SUNDAY_MARKET}
+          center={routeCenter}
           zoom={INITIAL_ZOOM}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
@@ -986,7 +1061,7 @@ const MapView = memo(function MapView({
           }}
           zoomControl={false}
           attributionControl={false}
-          maxBounds={MAX_BOUNDS}
+          maxBounds={mapBounds}
           maxBoundsViscosity={1.0}
           whenReady={() => {
             onMapReady?.();
@@ -1003,7 +1078,7 @@ const MapView = memo(function MapView({
           }}
         >
           <MapZoomConstraint />
-          <MapZoomRoadSnapController />
+          <MapZoomRoadSnapController onSnapCenter={getSnappedCenter} />
           <MapZoomListener onZoomChange={handleMapZoomChange} />
           <TileLayer
             url={BASEMAP_TILE_URL}
@@ -1016,8 +1091,12 @@ const MapView = memo(function MapView({
           <BackgroundOverlay />
 
         {/* 道路 */}
-        <RoadOverlay overviewTint={isLowZoomTintMode} />
-        <DynamicMaxBounds baseBounds={MAX_BOUNDS} paddingPx={100} />
+        <RoadOverlay
+          overviewTint={isLowZoomTintMode}
+          routePoints={routePoints}
+          routeConfig={routeConfig}
+        />
+        <DynamicMaxBounds baseBounds={mapBounds} paddingPx={100} />
         <Pane name="major-place-label" style={{ zIndex: 950 }}>
           {visibleMajorPlaceLabels.map((place) => (
             <Marker
@@ -1195,6 +1274,8 @@ const MapView = memo(function MapView({
           }}
           isTracking={isTracking}
           suppressInitialFocus={suppressInitialLocationFocus}
+          routePoints={routePoints}
+          routeConfig={routeConfig}
         />
 
           {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -749,6 +749,8 @@ const MapView = memo(function MapView({
   const isMinimumZoomMode = mapUiZoom < MIN_ZOOM + 0.5;
   const isLowZoomTintMode = mapUiZoom < MIN_ZOOM + 1.5;
   const isThirdZoomFromMinimum = Math.abs(mapUiZoom - (MIN_ZOOM + 2.5)) <= 0.15;
+  const shouldRenderEventGlow = highlightEventTargets && mapUiZoom >= MIN_ZOOM + 1;
+  const shouldRenderRecipeOverlay = showRecipeOverlay && mapUiZoom >= 19.0;
   const interactionDisabled = agentOpen;
   const mapRotation = normalizeRotationDeg(manualRotationOffset);
   const getSnappedCenter = useCallback(
@@ -1049,6 +1051,7 @@ const MapView = memo(function MapView({
           zoom={INITIAL_ZOOM}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
+          preferCanvas
           zoomSnap={0.2}
           zoomDelta={0.35}
           wheelPxPerZoomLevel={130}
@@ -1124,7 +1127,7 @@ const MapView = memo(function MapView({
 
         <EventDimOverlay active={highlightEventTargets} />
 
-        {highlightEventTargets && (
+        {shouldRenderEventGlow && (
           <Pane name="event-glow" style={{ zIndex: 2000 }}>
             {eventTargets?.map((target) => (
               <Fragment key={target.id}>
@@ -1155,20 +1158,6 @@ const MapView = memo(function MapView({
                     opacity: 0.7,
                   }}
                   className="map-event-ripple is-2"
-                />
-                <CircleMarker
-                  key={`${target.id}-r3`}
-                  center={[target.lat, target.lng]}
-                  radius={40}
-                  pane="event-glow"
-                  pathOptions={{
-                    fillColor: "transparent",
-                    fillOpacity: 0,
-                    color: "#ffffff",
-                    weight: 2,
-                    opacity: 0.5,
-                  }}
-                  className="map-event-ripple is-3"
                 />
               </Fragment>
             ))}
@@ -1227,7 +1216,7 @@ const MapView = memo(function MapView({
         )}
 
         {/* レシピオーバーレイ */}
-        {!isMinimumZoomMode && showRecipeOverlay && shopsWithIngredients.map((shop) => {
+        {!isMinimumZoomMode && shouldRenderRecipeOverlay && shopsWithIngredients.map((shop) => {
           const matchingIngredients = recipeIngredients.filter((ing) =>
             shop.products.some((product) =>
               product.toLowerCase().includes(ing.name.toLowerCase()) ||

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -20,6 +20,7 @@ type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
 interface OptimizedShopLayerWithClusteringProps {
   shops: Shop[];
   onShopClick: (shop: Shop, origin?: ShopBannerOrigin) => void;
+  onChunkProgress?: (processed: number, total: number, done: boolean) => void;
   selectedShopId?: number;
   favoriteShopIds?: number[];
   searchShopIds?: number[];
@@ -78,6 +79,7 @@ const getOriginRect = (marker: L.Marker): ShopBannerOrigin | undefined => {
 function OptimizedShopLayerWithClustering({
   shops,
   onShopClick,
+  onChunkProgress,
   selectedShopId,
   favoriteShopIds,
   searchShopIds,
@@ -111,6 +113,8 @@ function OptimizedShopLayerWithClustering({
   const lastIconModeRef = useRef<'compact' | 'mid' | 'full' | null>(null);
   const lastProductIconVisibleRef = useRef<boolean | null>(null);
   const lastSimpleBannerVisibleRef = useRef<boolean | null>(null);
+  const lastSimpleBannerNameVisibleRef = useRef<boolean | null>(null);
+  const lastMarkerZoomScaleRef = useRef<number | null>(null);
   const selectedShopIdRef = useRef<number | undefined>(undefined);
 
   const setMarkerFavorite = (marker: L.Marker, isFavorite: boolean) => {
@@ -282,6 +286,9 @@ function OptimizedShopLayerWithClustering({
         });
       },
       maxClusterRadius: 80,
+      chunkProgress: (processed, total) => {
+        onChunkProgress?.(processed, total, processed >= total);
+      },
     });
 
     clusterGroupRef.current = markers;
@@ -427,97 +434,103 @@ function OptimizedShopLayerWithClustering({
       if (
         lastIconModeRef.current === nextMode &&
         lastProductIconVisibleRef.current === showProductIcon &&
-        lastSimpleBannerVisibleRef.current === showSimpleBanner
+        lastSimpleBannerVisibleRef.current === showSimpleBanner &&
+        lastSimpleBannerNameVisibleRef.current === showSimpleBannerName &&
+        lastMarkerZoomScaleRef.current === markerZoomScale
       ) {
         return;
       }
+      const modeChanged = lastIconModeRef.current !== nextMode;
       lastIconModeRef.current = nextMode;
       lastProductIconVisibleRef.current = showProductIcon;
       lastSimpleBannerVisibleRef.current = showSimpleBanner;
+      lastSimpleBannerNameVisibleRef.current = showSimpleBannerName;
+      lastMarkerZoomScaleRef.current = markerZoomScale;
 
       markersRef.current.forEach((marker, shopId) => {
         let icon: L.DivIcon | undefined;
 
-        // Retrieve or generate the required icon
-        if (useCompact) {
-          icon = compactIconsRef.current.get(shopId);
-          if (!icon) {
-            const shop = shopsMap.get(shopId);
-            if (shop) {
-              icon = createCompactIcon(shop);
-              compactIconsRef.current.set(shopId, icon);
+        if (modeChanged) {
+          if (useCompact) {
+            icon = compactIconsRef.current.get(shopId);
+            if (!icon) {
+              const shop = shopsMap.get(shopId);
+              if (shop) {
+                icon = createCompactIcon(shop);
+                compactIconsRef.current.set(shopId, icon);
+              }
             }
-          }
-        } else if (useMid) {
-          icon = midIconsRef.current.get(shopId);
-          if (!icon) {
-            const shop = shopsMap.get(shopId);
-            if (shop) {
-              icon = createMidIcon(shop);
-              midIconsRef.current.set(shopId, icon);
+          } else if (useMid) {
+            icon = midIconsRef.current.get(shopId);
+            if (!icon) {
+              const shop = shopsMap.get(shopId);
+              if (shop) {
+                icon = createMidIcon(shop);
+                midIconsRef.current.set(shopId, icon);
+              }
             }
-          }
-        } else {
-          // Full
-          icon = fullIconsRef.current.get(shopId);
-          if (!icon) {
-            const shop = shopsMap.get(shopId);
-            if (shop) {
-              icon = createFullIcon(shop);
-              fullIconsRef.current.set(shopId, icon);
+          } else {
+            icon = fullIconsRef.current.get(shopId);
+            if (!icon) {
+              const shop = shopsMap.get(shopId);
+              if (shop) {
+                icon = createFullIcon(shop);
+                fullIconsRef.current.set(shopId, icon);
+              }
             }
           }
         }
 
         if (icon) {
           marker.setIcon(icon);
-          setMarkerFavorite(marker, favoriteSetRef.current.has(shopId));
-          setMarkerRecipeIcons(marker, recipeIconsRef.current[shopId]);
-          setMarkerProductIconVisibility(marker, showProductIcon);
-          setMarkerSimpleBannerVisibility(marker, showSimpleBanner);
-          setMarkerSimpleBannerNameVisibility(marker, showSimpleBannerName);
-          setMarkerZoomScale(marker, markerZoomScale);
-          setMarkerAttendanceLabel(
-            marker,
-            attendanceLabelsRef.current[shopId] ?? 'わからない'
-          );
-          const markerElement = marker.getElement();
-          if (markerElement) {
-            if (shopId === selectedShopIdRef.current) {
-              markerElement.classList.add('shop-marker-selected');
-              marker.setZIndexOffset(1000);
-            } else {
-              markerElement.classList.remove('shop-marker-selected');
-              marker.setZIndexOffset(0);
+        }
+
+        setMarkerFavorite(marker, favoriteSetRef.current.has(shopId));
+        setMarkerRecipeIcons(marker, recipeIconsRef.current[shopId]);
+        setMarkerProductIconVisibility(marker, showProductIcon);
+        setMarkerSimpleBannerVisibility(marker, showSimpleBanner);
+        setMarkerSimpleBannerNameVisibility(marker, showSimpleBannerName);
+        setMarkerZoomScale(marker, markerZoomScale);
+        setMarkerAttendanceLabel(
+          marker,
+          attendanceLabelsRef.current[shopId] ?? 'わからない'
+        );
+        const markerElement = marker.getElement();
+        if (markerElement) {
+          if (shopId === selectedShopIdRef.current) {
+            markerElement.classList.add('shop-marker-selected');
+            marker.setZIndexOffset(1000);
+          } else {
+            markerElement.classList.remove('shop-marker-selected');
+            marker.setZIndexOffset(0);
+          }
+          if (aiHighlightSetRef.current.has(shopId)) {
+            markerElement.classList.add('shop-marker-ai');
+            if (shopId !== selectedShopIdRef.current) {
+              marker.setZIndexOffset(900);
             }
-            if (aiHighlightSetRef.current.has(shopId)) {
-              markerElement.classList.add('shop-marker-ai');
-              if (shopId !== selectedShopIdRef.current) {
-                marker.setZIndexOffset(900);
-              }
-            } else {
-              markerElement.classList.remove('shop-marker-ai');
-            }
-            if (searchHighlightSetRef.current.has(shopId)) {
-              markerElement.classList.add('shop-marker-search');
-            } else {
-              markerElement.classList.remove('shop-marker-search');
-            }
-            if (commentHighlightSetRef.current.has(shopId)) {
-              markerElement.classList.add('shop-marker-comment');
-            } else {
-              markerElement.classList.remove('shop-marker-comment');
-            }
-            if (kotoduteSetRef.current.has(shopId)) {
-              markerElement.classList.add('shop-marker-kotodute');
-            } else {
-              markerElement.classList.remove('shop-marker-kotodute');
-            }
-            if (bagShopSetRef.current.has(shopId)) {
-              markerElement.classList.add('shop-marker-bag');
-            } else {
-              markerElement.classList.remove('shop-marker-bag');
-            }
+          } else {
+            markerElement.classList.remove('shop-marker-ai');
+          }
+          if (searchHighlightSetRef.current.has(shopId)) {
+            markerElement.classList.add('shop-marker-search');
+          } else {
+            markerElement.classList.remove('shop-marker-search');
+          }
+          if (commentHighlightSetRef.current.has(shopId)) {
+            markerElement.classList.add('shop-marker-comment');
+          } else {
+            markerElement.classList.remove('shop-marker-comment');
+          }
+          if (kotoduteSetRef.current.has(shopId)) {
+            markerElement.classList.add('shop-marker-kotodute');
+          } else {
+            markerElement.classList.remove('shop-marker-kotodute');
+          }
+          if (bagShopSetRef.current.has(shopId)) {
+            markerElement.classList.add('shop-marker-bag');
+          } else {
+            markerElement.classList.remove('shop-marker-bag');
           }
         }
       });
@@ -537,7 +550,7 @@ function OptimizedShopLayerWithClustering({
       midIconsRef.current.clear();
       compactIconsRef.current.clear();
     };
-  }, [shops, map, onShopClick]);
+  }, [map, onChunkProgress, onShopClick, shops]);
 
   useEffect(() => {
     favoriteSetRef.current = new Set(favoriteShopIds ?? []);

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -4,7 +4,7 @@
 
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet.markercluster';
@@ -36,6 +36,7 @@ const COMPACT_ICON_ANCHOR: [number, number] = [12, 18];
 const COMPACT_ICON_MAX_ZOOM = 19.0;
 const MID_ICON_MAX_ZOOM = 19.4;
 const FULL_ICON_MIN_ZOOM = 19.5;
+const FULL_ICON_NAME_MIN_ZOOM = 20.5;
 
 function getMarkerZoomScale(currentZoom: number, maxZoom: number): number {
   if (currentZoom >= maxZoom - 0.001) {
@@ -48,6 +49,14 @@ function getMarkerZoomScale(currentZoom: number, maxZoom: number): number {
     return 0.6;
   }
   return 1;
+}
+
+function getShopMarkerDisplayScale(currentZoom: number, maxZoom: number): number {
+  const baseScale = getMarkerZoomScale(currentZoom, maxZoom);
+  if (currentZoom >= 19.7 && currentZoom < 19.8) {
+    return baseScale * 1.1;
+  }
+  return baseScale;
 }
 
 // Helper to get origin rect for animation
@@ -66,7 +75,7 @@ const getOriginRect = (marker: L.Marker): ShopBannerOrigin | undefined => {
   };
 };
 
-export default function OptimizedShopLayerWithClustering({
+function OptimizedShopLayerWithClustering({
   shops,
   onShopClick,
   selectedShopId,
@@ -384,12 +393,12 @@ export default function OptimizedShopLayerWithClustering({
         setMarkerBag(marker, bagShopSetRef.current.has(shop.id));
         setMarkerRecipeIcons(marker, recipeIconsRef.current[shop.id]);
         const maxZoom = map.getMaxZoom() ?? map.getZoom();
-        const isMaxZoom = map.getZoom() >= maxZoom - 0.001;
         const showSimpleBanner = map.getZoom() >= FULL_ICON_MIN_ZOOM;
-        const markerZoomScale = getMarkerZoomScale(map.getZoom(), maxZoom);
-        setMarkerProductIconVisibility(marker, map.getZoom() >= FULL_ICON_MIN_ZOOM && !isMaxZoom);
+        const showSimpleBannerName = map.getZoom() >= FULL_ICON_NAME_MIN_ZOOM;
+        const markerZoomScale = getShopMarkerDisplayScale(map.getZoom(), maxZoom);
+        setMarkerProductIconVisibility(marker, map.getZoom() >= FULL_ICON_MIN_ZOOM && map.getZoom() < FULL_ICON_NAME_MIN_ZOOM);
         setMarkerSimpleBannerVisibility(marker, showSimpleBanner);
-        setMarkerSimpleBannerNameVisibility(marker, isMaxZoom);
+        setMarkerSimpleBannerNameVisibility(marker, showSimpleBannerName);
         setMarkerZoomScale(marker, markerZoomScale);
         setMarkerAttendanceLabel(
           marker,
@@ -404,11 +413,10 @@ export default function OptimizedShopLayerWithClustering({
     const updateMarkerDensity = () => {
       const zoom = map.getZoom();
       const maxZoom = map.getMaxZoom() ?? zoom;
-      const isMaxZoom = zoom >= maxZoom - 0.001;
-      const showProductIcon = zoom >= FULL_ICON_MIN_ZOOM && !isMaxZoom;
+      const showProductIcon = zoom >= FULL_ICON_MIN_ZOOM && zoom < FULL_ICON_NAME_MIN_ZOOM;
       const showSimpleBanner = zoom >= FULL_ICON_MIN_ZOOM;
-      const showSimpleBannerName = isMaxZoom;
-      const markerZoomScale = getMarkerZoomScale(zoom, maxZoom);
+      const showSimpleBannerName = zoom >= FULL_ICON_NAME_MIN_ZOOM;
+      const markerZoomScale = getShopMarkerDisplayScale(zoom, maxZoom);
       const useCompact = zoom <= COMPACT_ICON_MAX_ZOOM;
       const useMid = zoom > COMPACT_ICON_MAX_ZOOM && zoom <= MID_ICON_MAX_ZOOM;
       const nextMode: 'compact' | 'mid' | 'full' = useCompact
@@ -704,3 +712,5 @@ export default function OptimizedShopLayerWithClustering({
 
   return null;
 }
+
+export default memo(OptimizedShopLayerWithClustering);

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -33,8 +33,9 @@ interface OptimizedShopLayerWithClusteringProps {
 
 const COMPACT_ICON_SIZE: [number, number] = [24, 36];
 const COMPACT_ICON_ANCHOR: [number, number] = [12, 18];
-const COMPACT_ICON_MAX_ZOOM = 17.5;
-const MID_ICON_MAX_ZOOM = 18.0;
+const COMPACT_ICON_MAX_ZOOM = 19.0;
+const MID_ICON_MAX_ZOOM = 19.4;
+const FULL_ICON_MIN_ZOOM = 19.5;
 
 function getMarkerZoomScale(currentZoom: number, maxZoom: number): number {
   if (currentZoom >= maxZoom - 0.001) {
@@ -384,9 +385,9 @@ export default function OptimizedShopLayerWithClustering({
         setMarkerRecipeIcons(marker, recipeIconsRef.current[shop.id]);
         const maxZoom = map.getMaxZoom() ?? map.getZoom();
         const isMaxZoom = map.getZoom() >= maxZoom - 0.001;
-        const showSimpleBanner = map.getZoom() >= maxZoom - 1;
+        const showSimpleBanner = map.getZoom() >= FULL_ICON_MIN_ZOOM;
         const markerZoomScale = getMarkerZoomScale(map.getZoom(), maxZoom);
-        setMarkerProductIconVisibility(marker, map.getZoom() >= maxZoom - 1 && !isMaxZoom);
+        setMarkerProductIconVisibility(marker, map.getZoom() >= FULL_ICON_MIN_ZOOM && !isMaxZoom);
         setMarkerSimpleBannerVisibility(marker, showSimpleBanner);
         setMarkerSimpleBannerNameVisibility(marker, isMaxZoom);
         setMarkerZoomScale(marker, markerZoomScale);
@@ -404,8 +405,8 @@ export default function OptimizedShopLayerWithClustering({
       const zoom = map.getZoom();
       const maxZoom = map.getMaxZoom() ?? zoom;
       const isMaxZoom = zoom >= maxZoom - 0.001;
-      const showProductIcon = zoom >= maxZoom - 1 && !isMaxZoom;
-      const showSimpleBanner = zoom >= maxZoom - 1;
+      const showProductIcon = zoom >= FULL_ICON_MIN_ZOOM && !isMaxZoom;
+      const showSimpleBanner = zoom >= FULL_ICON_MIN_ZOOM;
       const showSimpleBannerName = isMaxZoom;
       const markerZoomScale = getMarkerZoomScale(zoom, maxZoom);
       const useCompact = zoom <= COMPACT_ICON_MAX_ZOOM;

--- a/app/(public)/map/components/RoadOverlay.tsx
+++ b/app/(public)/map/components/RoadOverlay.tsx
@@ -4,6 +4,7 @@
 
 'use client';
 
+import { Fragment } from 'react';
 import { ImageOverlay, Polygon, Polyline, Rectangle } from 'react-leaflet';
 import { ROAD_CONFIG, RoadConfig } from '../config/roadConfig';
 import { LatLngBoundsExpression } from 'leaflet';
@@ -12,6 +13,11 @@ import {
   buildRoadPolygon,
   densifyPath,
   getEffectiveMapRouteConfig,
+  getRouteSegments,
+  latToMeters,
+  lngToMeters,
+  metersToLat,
+  metersToLng,
   normalizeMapRoutePoints,
   smoothPath,
 } from '../utils/mapRouteGeometry';
@@ -254,46 +260,96 @@ function DynamicRoad({
   routeConfig: MapRouteConfig;
   overviewTint?: boolean;
 }) {
-  const centerline = densifyPath(points, 8);
-  const smoothedCenterline = smoothPath(centerline, 2);
-  const roadPolygon = buildRoadPolygon(smoothedCenterline, routeConfig.roadHalfWidthMeters);
+  const segments = getRouteSegments(points);
 
-  if (roadPolygon.length < 3 || smoothedCenterline.length < 2) {
+  if (segments.length === 0) {
     return null;
   }
 
   return (
     <>
-      <Polygon
-        positions={roadPolygon}
-        pathOptions={{
-          color: '#8f7d67',
-          weight: 1,
-          opacity: 0.8,
-          fillColor: '#d4c5b0',
-          fillOpacity: ROAD_CONFIG.opacity ?? 0.9,
-        }}
-      />
-      {overviewTint && (
-        <Polygon
-          positions={roadPolygon}
-          pathOptions={{
-            stroke: false,
-            fillColor: '#22c55e',
-            fillOpacity: 0.36,
-          }}
-        />
-      )}
-      <Polyline
-        positions={smoothedCenterline}
-        pathOptions={{
-          color: '#a89070',
-          weight: 1,
-          opacity: 0.5,
-        }}
-      />
+      {segments.map((segment) => {
+        const centerline = densifyPath([segment.start, segment.end], 8);
+        const smoothedCenterline = smoothPath(centerline, 2);
+        const cappedCenterline = extendCenterlineForCaps(
+          smoothedCenterline,
+          routeConfig.roadHalfWidthMeters
+        );
+        const roadPolygon = buildRoadPolygon(cappedCenterline, routeConfig.roadHalfWidthMeters);
+
+        if (roadPolygon.length < 3 || smoothedCenterline.length < 2) {
+          return null;
+        }
+
+        return (
+          <Fragment key={segment.key}>
+            <Polygon
+              positions={roadPolygon}
+              pathOptions={{
+                stroke: false,
+                fillColor: '#d4c5b0',
+                fillOpacity: ROAD_CONFIG.opacity ?? 0.9,
+              }}
+            />
+            {overviewTint && (
+              <Polygon
+                positions={roadPolygon}
+                pathOptions={{
+                  stroke: false,
+                  fillColor: '#22c55e',
+                  fillOpacity: 0.36,
+                }}
+              />
+            )}
+            <Polyline
+              positions={smoothedCenterline}
+              pathOptions={{
+                color: '#a89070',
+                weight: 1,
+                opacity: 0.5,
+              }}
+            />
+          </Fragment>
+        );
+      })}
     </>
   );
+}
+
+function extendCenterlineForCaps(
+  centerline: Array<[number, number]>,
+  extensionMeters: number
+): Array<[number, number]> {
+  if (centerline.length < 2 || extensionMeters <= 0) {
+    return centerline;
+  }
+
+  const first = centerline[0];
+  const second = centerline[1];
+  const last = centerline[centerline.length - 1];
+  const beforeLast = centerline[centerline.length - 2];
+
+  const startExtended = extendPoint(first, second, -extensionMeters);
+  const endExtended = extendPoint(last, beforeLast, -extensionMeters);
+
+  return [startExtended, ...centerline.slice(1, -1), endExtended];
+}
+
+function extendPoint(
+  origin: [number, number],
+  toward: [number, number],
+  distanceMeters: number
+): [number, number] {
+  const dxMeters = lngToMeters(toward[1] - origin[1], origin[0]);
+  const dyMeters = latToMeters(toward[0] - origin[0]);
+  const length = Math.hypot(dxMeters, dyMeters) || 1;
+  const ux = dxMeters / length;
+  const uy = dyMeters / length;
+
+  return [
+    origin[0] + metersToLat(uy * distanceMeters),
+    origin[1] + metersToLng(ux * distanceMeters, origin[0]),
+  ];
 }
 
 function renderSeparatorBricks(

--- a/app/(public)/map/components/RoadOverlay.tsx
+++ b/app/(public)/map/components/RoadOverlay.tsx
@@ -7,10 +7,26 @@
 import { ImageOverlay, Polygon, Polyline, Rectangle } from 'react-leaflet';
 import { ROAD_CONFIG, RoadConfig } from '../config/roadConfig';
 import { LatLngBoundsExpression } from 'leaflet';
+import type { MapRouteConfig, MapRoutePoint } from '../types/mapRoute';
+import {
+  buildRoadPolygon,
+  densifyPath,
+  getEffectiveMapRouteConfig,
+  normalizeMapRoutePoints,
+  smoothPath,
+} from '../utils/mapRouteGeometry';
 
 const PALM_IMAGE = '/images/maps/elements/decoration/yasinoki.png';
 
-export default function RoadOverlay({ overviewTint = false }: { overviewTint?: boolean }) {
+export default function RoadOverlay({
+  overviewTint = false,
+  routePoints,
+  routeConfig,
+}: {
+  overviewTint?: boolean;
+  routePoints?: MapRoutePoint[];
+  routeConfig?: MapRouteConfig;
+}) {
   const config = ROAD_CONFIG;
   const latSpan = Math.abs(config.bounds[0][0] - config.bounds[1][0]);
   const lngSpan = Math.abs(config.bounds[0][1] - config.bounds[1][1]);
@@ -18,6 +34,18 @@ export default function RoadOverlay({ overviewTint = false }: { overviewTint?: b
   const roadThickness = isEastWest ? latSpan : lngSpan;
   const separatorThickness = 0.00004;
   const roadOffset = roadThickness + separatorThickness;
+  const normalizedRoutePoints = normalizeMapRoutePoints(routePoints ?? []);
+  const effectiveRouteConfig = getEffectiveMapRouteConfig(routeConfig);
+
+  if (normalizedRoutePoints.length >= 2) {
+    return (
+      <DynamicRoad
+        points={normalizedRoutePoints}
+        routeConfig={effectiveRouteConfig}
+        overviewTint={overviewTint}
+      />
+    );
+  }
 
   if (config.type === 'curved' && config.segments) {
     return (
@@ -217,111 +245,55 @@ function CurvedRoad({
   );
 }
 
-function densifyPath(
-  points: Array<{ lat: number; lng: number }>,
-  stepMeters: number
-): Array<[number, number]> {
-  if (points.length < 2) {
-    return points.map((p) => [p.lat, p.lng]);
+function DynamicRoad({
+  points,
+  routeConfig,
+  overviewTint = false,
+}: {
+  points: MapRoutePoint[];
+  routeConfig: MapRouteConfig;
+  overviewTint?: boolean;
+}) {
+  const centerline = densifyPath(points, 8);
+  const smoothedCenterline = smoothPath(centerline, 2);
+  const roadPolygon = buildRoadPolygon(smoothedCenterline, routeConfig.roadHalfWidthMeters);
+
+  if (roadPolygon.length < 3 || smoothedCenterline.length < 2) {
+    return null;
   }
 
-  const dense: Array<[number, number]> = [];
-  for (let i = 0; i < points.length - 1; i += 1) {
-    const a = points[i];
-    const b = points[i + 1];
-    const dist = distanceMeters(a, b);
-    const steps = Math.max(1, Math.ceil(dist / stepMeters));
-    for (let k = 0; k < steps; k += 1) {
-      const t = k / steps;
-      dense.push([a.lat + (b.lat - a.lat) * t, a.lng + (b.lng - a.lng) * t]);
-    }
-  }
-  const last = points[points.length - 1];
-  dense.push([last.lat, last.lng]);
-  return dense;
-}
-
-function smoothPath(path: Array<[number, number]>, radius: number): Array<[number, number]> {
-  if (path.length < 3 || radius <= 0) return path;
-  return path.map((_, idx) => {
-    const start = Math.max(0, idx - radius);
-    const end = Math.min(path.length - 1, idx + radius);
-    let sumLat = 0;
-    let sumLng = 0;
-    let count = 0;
-    for (let i = start; i <= end; i += 1) {
-      sumLat += path[i][0];
-      sumLng += path[i][1];
-      count += 1;
-    }
-    return [sumLat / count, sumLng / count];
-  });
-}
-
-function buildRoadPolygon(
-  centerline: Array<[number, number]>,
-  halfWidthMeters: number
-): Array<[number, number]> {
-  if (centerline.length < 2) return [];
-
-  const left: Array<[number, number]> = [];
-  const right: Array<[number, number]> = [];
-  for (let i = 0; i < centerline.length; i += 1) {
-    const prev = centerline[Math.max(0, i - 1)];
-    const next = centerline[Math.min(centerline.length - 1, i + 1)];
-    const curr = centerline[i];
-    const tangent = tangentVectorMeters(prev, next, curr[0]);
-    const len = Math.hypot(tangent.x, tangent.y) || 1;
-    const nx = -tangent.y / len;
-    const ny = tangent.x / len;
-
-    const dLat = metersToLat(ny * halfWidthMeters);
-    const dLng = metersToLng(nx * halfWidthMeters, curr[0]);
-    left.push([curr[0] + dLat, curr[1] + dLng]);
-    right.push([curr[0] - dLat, curr[1] - dLng]);
-  }
-
-  return [...left, ...right.reverse()];
-}
-
-function tangentVectorMeters(
-  prev: [number, number],
-  next: [number, number],
-  latRef: number
-): { x: number; y: number } {
-  const dLng = next[1] - prev[1];
-  const dLat = next[0] - prev[0];
-  return {
-    x: lngToMeters(dLng, latRef),
-    y: latToMeters(dLat),
-  };
-}
-
-function latToMeters(latDiff: number): number {
-  return latDiff * 110540;
-}
-
-function lngToMeters(lngDiff: number, lat: number): number {
-  return lngDiff * (111320 * Math.cos((lat * Math.PI) / 180));
-}
-
-function metersToLat(meters: number): number {
-  return meters / 110540;
-}
-
-function metersToLng(meters: number, lat: number): number {
-  const unit = 111320 * Math.cos((lat * Math.PI) / 180);
-  if (Math.abs(unit) < 1e-6) return 0;
-  return meters / unit;
-}
-
-function distanceMeters(
-  a: { lat: number; lng: number },
-  b: { lat: number; lng: number }
-): number {
-  const dLat = latToMeters(b.lat - a.lat);
-  const dLng = lngToMeters(b.lng - a.lng, (a.lat + b.lat) / 2);
-  return Math.hypot(dLat, dLng);
+  return (
+    <>
+      <Polygon
+        positions={roadPolygon}
+        pathOptions={{
+          color: '#8f7d67',
+          weight: 1,
+          opacity: 0.8,
+          fillColor: '#d4c5b0',
+          fillOpacity: ROAD_CONFIG.opacity ?? 0.9,
+        }}
+      />
+      {overviewTint && (
+        <Polygon
+          positions={roadPolygon}
+          pathOptions={{
+            stroke: false,
+            fillColor: '#22c55e',
+            fillOpacity: 0.36,
+          }}
+        />
+      )}
+      <Polyline
+        positions={smoothedCenterline}
+        pathOptions={{
+          color: '#a89070',
+          weight: 1,
+          opacity: 0.5,
+        }}
+      />
+    </>
+  );
 }
 
 function renderSeparatorBricks(

--- a/app/(public)/map/components/RoadOverlay.tsx
+++ b/app/(public)/map/components/RoadOverlay.tsx
@@ -228,6 +228,7 @@ function CurvedRoad({
     <>
       <Polygon
         positions={roadPolygon}
+        interactive={false}
         pathOptions={{
           color: '#8f7d67',
           weight: 1,
@@ -239,6 +240,7 @@ function CurvedRoad({
       {overviewTint && (
         <Polygon
           positions={roadPolygon}
+          interactive={false}
           pathOptions={{
             stroke: false,
             fillColor: '#22c55e',
@@ -248,6 +250,7 @@ function CurvedRoad({
       )}
       <Polyline
         positions={smoothedCenterline}
+        interactive={false}
         pathOptions={{
           color: '#a89070',
           weight: 1,

--- a/app/(public)/map/components/RoadOverlay.tsx
+++ b/app/(public)/map/components/RoadOverlay.tsx
@@ -4,7 +4,7 @@
 
 'use client';
 
-import { Fragment } from 'react';
+import { Fragment, memo, useMemo } from 'react';
 import { ImageOverlay, Polygon, Polyline, Rectangle } from 'react-leaflet';
 import { ROAD_CONFIG, RoadConfig } from '../config/roadConfig';
 import { LatLngBoundsExpression } from 'leaflet';
@@ -25,7 +25,7 @@ import {
 
 const PALM_IMAGE = '/images/maps/elements/decoration/yasinoki.png';
 
-export default function RoadOverlay({
+function RoadOverlay({
   overviewTint = false,
   routePoints,
   routeConfig,
@@ -41,8 +41,14 @@ export default function RoadOverlay({
   const roadThickness = isEastWest ? latSpan : lngSpan;
   const separatorThickness = 0.00004;
   const roadOffset = roadThickness + separatorThickness;
-  const normalizedRoutePoints = normalizeMapRoutePoints(routePoints ?? []);
-  const effectiveRouteConfig = getEffectiveMapRouteConfig(routeConfig);
+  const normalizedRoutePoints = useMemo(
+    () => normalizeMapRoutePoints(routePoints ?? []),
+    [routePoints]
+  );
+  const effectiveRouteConfig = useMemo(
+    () => getEffectiveMapRouteConfig(routeConfig),
+    [routeConfig]
+  );
 
   if (normalizedRoutePoints.length >= 2) {
     return (
@@ -252,6 +258,8 @@ function CurvedRoad({
   );
 }
 
+export default memo(RoadOverlay);
+
 function DynamicRoad({
   points,
   routeConfig,
@@ -261,15 +269,10 @@ function DynamicRoad({
   routeConfig: MapRouteConfig;
   overviewTint?: boolean;
 }) {
-  const chains = getRouteChains(points);
-
-  if (chains.length === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      {chains.map((chain) => {
+  const chainGeometry = useMemo(() => {
+    const chains = getRouteChains(points);
+    return chains
+      .map((chain) => {
         const anchorPoints = chain.points.map((point) => ({
           lat: point.lat,
           lng: point.lng,
@@ -286,10 +289,26 @@ function DynamicRoad({
           return null;
         }
 
+        return {
+          key: chain.key,
+          roadPolygon,
+          smoothedCenterline,
+        };
+      })
+      .filter((item): item is { key: string; roadPolygon: Array<[number, number]>; smoothedCenterline: Array<[number, number]> } => Boolean(item));
+  }, [points, routeConfig.roadHalfWidthMeters]);
+
+  if (chainGeometry.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {chainGeometry.map((chain) => {
         return (
           <Fragment key={chain.key}>
             <Polygon
-              positions={roadPolygon}
+              positions={chain.roadPolygon}
               pathOptions={{
                 stroke: false,
                 fillColor: '#d4c5b0',
@@ -298,7 +317,7 @@ function DynamicRoad({
             />
             {overviewTint && (
               <Polygon
-                positions={roadPolygon}
+                positions={chain.roadPolygon}
                 pathOptions={{
                   stroke: false,
                   fillColor: '#22c55e',
@@ -307,7 +326,7 @@ function DynamicRoad({
               />
             )}
             <Polyline
-              positions={smoothedCenterline}
+              positions={chain.smoothedCenterline}
               pathOptions={{
                 color: '#a89070',
                 weight: 1,

--- a/app/(public)/map/components/RoadOverlay.tsx
+++ b/app/(public)/map/components/RoadOverlay.tsx
@@ -13,12 +13,13 @@ import {
   buildRoadPolygon,
   densifyPath,
   getEffectiveMapRouteConfig,
-  getRouteSegments,
+  getRouteChains,
   latToMeters,
   lngToMeters,
   metersToLat,
   metersToLng,
   normalizeMapRoutePoints,
+  smoothRoutePath,
   smoothPath,
 } from '../utils/mapRouteGeometry';
 
@@ -226,7 +227,7 @@ function CurvedRoad({
           weight: 1,
           opacity: 0.8,
           fillColor: '#d4c5b0',
-          fillOpacity: config.opacity ?? 0.9,
+          fillOpacity: 1,
         }}
       />
       {overviewTint && (
@@ -260,35 +261,39 @@ function DynamicRoad({
   routeConfig: MapRouteConfig;
   overviewTint?: boolean;
 }) {
-  const segments = getRouteSegments(points);
+  const chains = getRouteChains(points);
 
-  if (segments.length === 0) {
+  if (chains.length === 0) {
     return null;
   }
 
   return (
     <>
-      {segments.map((segment) => {
-        const centerline = densifyPath([segment.start, segment.end], 8);
-        const smoothedCenterline = smoothPath(centerline, 2);
-        const cappedCenterline = extendCenterlineForCaps(
+      {chains.map((chain) => {
+        const anchorPoints = chain.points.map((point) => ({
+          lat: point.lat,
+          lng: point.lng,
+        }));
+        const centerline = densifyPath(anchorPoints, 6);
+        const smoothedCenterline =
+          chain.points.length >= 3 ? smoothRoutePath(centerline, 2) : centerline;
+        const roadPolygon = buildRoadPolygon(
           smoothedCenterline,
           routeConfig.roadHalfWidthMeters
         );
-        const roadPolygon = buildRoadPolygon(cappedCenterline, routeConfig.roadHalfWidthMeters);
 
         if (roadPolygon.length < 3 || smoothedCenterline.length < 2) {
           return null;
         }
 
         return (
-          <Fragment key={segment.key}>
+          <Fragment key={chain.key}>
             <Polygon
               positions={roadPolygon}
               pathOptions={{
                 stroke: false,
                 fillColor: '#d4c5b0',
-                fillOpacity: ROAD_CONFIG.opacity ?? 0.9,
+                fillOpacity: 1,
               }}
             />
             {overviewTint && (
@@ -307,6 +312,8 @@ function DynamicRoad({
                 color: '#a89070',
                 weight: 1,
                 opacity: 0.5,
+                lineCap: 'round',
+                lineJoin: 'round',
               }}
             />
           </Fragment>
@@ -316,40 +323,17 @@ function DynamicRoad({
   );
 }
 
-function extendCenterlineForCaps(
-  centerline: Array<[number, number]>,
-  extensionMeters: number
-): Array<[number, number]> {
-  if (centerline.length < 2 || extensionMeters <= 0) {
-    return centerline;
-  }
-
-  const first = centerline[0];
-  const second = centerline[1];
-  const last = centerline[centerline.length - 1];
-  const beforeLast = centerline[centerline.length - 2];
-
-  const startExtended = extendPoint(first, second, -extensionMeters);
-  const endExtended = extendPoint(last, beforeLast, -extensionMeters);
-
-  return [startExtended, ...centerline.slice(1, -1), endExtended];
-}
-
-function extendPoint(
-  origin: [number, number],
-  toward: [number, number],
-  distanceMeters: number
-): [number, number] {
-  const dxMeters = lngToMeters(toward[1] - origin[1], origin[0]);
-  const dyMeters = latToMeters(toward[0] - origin[0]);
-  const length = Math.hypot(dxMeters, dyMeters) || 1;
-  const ux = dxMeters / length;
-  const uy = dyMeters / length;
-
-  return [
-    origin[0] + metersToLat(uy * distanceMeters),
-    origin[1] + metersToLng(ux * distanceMeters, origin[0]),
-  ];
+function tangentVectorMeters(
+  prev: [number, number],
+  next: [number, number],
+  latRef: number
+): { x: number; y: number } {
+  const dLng = next[1] - prev[1];
+  const dLat = next[0] - prev[0];
+  return {
+    x: lngToMeters(dLng, latRef),
+    y: latToMeters(dLat),
+  };
 }
 
 function renderSeparatorBricks(

--- a/app/(public)/map/components/UserLocationMarker.tsx
+++ b/app/(public)/map/components/UserLocationMarker.tsx
@@ -7,8 +7,9 @@ import type { MapRouteConfig, MapRoutePoint } from '../types/mapRoute';
 import {
   getDefaultMapRouteConfig,
   getDefaultMapRoutePoints,
+  getRouteSegments,
   normalizeMapRoutePoints,
-  projectPointOntoRoute,
+  projectPointOntoSegments,
 } from '../utils/mapRouteGeometry';
 
 const MARKET_CENTER: [number, number] = [33.5614118, 133.5379706];
@@ -68,6 +69,7 @@ export default function UserLocationMarker({
     }),
     [routeConfig]
   );
+  const routeSegments = useMemo(() => getRouteSegments(effectiveRoutePoints), [effectiveRoutePoints]);
 
   const applyHeading = (heading: number) => {
     lastHeadingRef.current = heading;
@@ -240,9 +242,10 @@ export default function UserLocationMarker({
       const watchId = navigator.geolocation.watchPosition(
         (position) => {
           const { latitude, longitude, accuracy } = position.coords;
-          const projected = projectPointOntoRoute(
+          const projected = projectPointOntoSegments(
             { lat: latitude, lng: longitude },
-            effectiveRoutePoints
+            effectiveRoutePoints,
+            routeSegments
           );
           const distanceFromRoute = projected?.distanceMeters ?? Number.POSITIVE_INFINITY;
           const canSnap = distanceFromRoute <= effectiveRouteConfig.snapDistanceMeters;
@@ -358,7 +361,7 @@ export default function UserLocationMarker({
     return () => {
       removeMarker();
     };
-  }, [effectiveRouteConfig, effectiveRoutePoints, map, suppressInitialFocus]);
+  }, [effectiveRouteConfig, effectiveRoutePoints, map, routeSegments, suppressInitialFocus]);
 
   return null;
 }

--- a/app/(public)/map/components/UserLocationMarker.tsx
+++ b/app/(public)/map/components/UserLocationMarker.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useMap } from 'react-leaflet';
 import L from 'leaflet';
-import { isInsideSundayMarket } from '../config/roadConfig';
+import type { MapRouteConfig, MapRoutePoint } from '../types/mapRoute';
+import {
+  getDefaultMapRouteConfig,
+  getDefaultMapRoutePoints,
+  normalizeMapRoutePoints,
+  projectPointOntoRoute,
+} from '../utils/mapRouteGeometry';
 
 const MARKET_CENTER: [number, number] = [33.5614118, 133.5379706];
 
@@ -22,12 +28,16 @@ interface UserLocationMarkerProps {
   onLocationUpdate?: (isInMarket: boolean, position: [number, number]) => void;
   isTracking?: boolean;
   suppressInitialFocus?: boolean;
+  routePoints?: MapRoutePoint[];
+  routeConfig?: MapRouteConfig;
 }
 
 export default function UserLocationMarker({
   onLocationUpdate,
   isTracking,
   suppressInitialFocus = false,
+  routePoints,
+  routeConfig,
 }: UserLocationMarkerProps) {
   const map = useMap();
   const markerRef = useRef<L.Marker | null>(null);
@@ -46,6 +56,18 @@ export default function UserLocationMarker({
   const lastAccuracyRef = useRef<number | null>(null);
   // 初回位置取得フラグ（マップを位置に移動させるため）
   const isFirstLocationRef = useRef(true);
+  const routeVisibleRef = useRef(false);
+  const effectiveRoutePoints = useMemo(() => {
+    const activeRoutePoints = normalizeMapRoutePoints(routePoints ?? []);
+    return activeRoutePoints.length >= 2 ? activeRoutePoints : getDefaultMapRoutePoints();
+  }, [routePoints]);
+  const effectiveRouteConfig = useMemo(
+    () => ({
+      ...getDefaultMapRouteConfig(),
+      ...(routeConfig ?? {}),
+    }),
+    [routeConfig]
+  );
 
   const applyHeading = (heading: number) => {
     lastHeadingRef.current = heading;
@@ -93,10 +115,6 @@ export default function UserLocationMarker({
     };
   }, []);
 
-  const checkIfInMarket = (lat: number, lng: number): boolean => {
-    return isInsideSundayMarket(lat, lng);
-  };
-
   useEffect(() => {
     if (!map) return;
 
@@ -139,6 +157,18 @@ export default function UserLocationMarker({
       iconSize: [40, 40],
       iconAnchor: [20, 20],
     });
+
+    const removeMarker = () => {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
+      }
+      if (markerRef.current) {
+        map.removeLayer(markerRef.current);
+        markerRef.current = null;
+      }
+      arrowRef.current = null;
+    };
 
     const animateMarkerTo = (target: [number, number]) => {
       if (!markerRef.current) return;
@@ -210,7 +240,15 @@ export default function UserLocationMarker({
       const watchId = navigator.geolocation.watchPosition(
         (position) => {
           const { latitude, longitude, accuracy } = position.coords;
-          const inMarket = checkIfInMarket(latitude, longitude);
+          const projected = projectPointOntoRoute(
+            { lat: latitude, lng: longitude },
+            effectiveRoutePoints
+          );
+          const distanceFromRoute = projected?.distanceMeters ?? Number.POSITIVE_INFINITY;
+          const canSnap = distanceFromRoute <= effectiveRouteConfig.snapDistanceMeters;
+          const canStayVisible = distanceFromRoute <= effectiveRouteConfig.visibleDistanceMeters;
+          const shouldShowOnRoute = canSnap || (routeVisibleRef.current && canStayVisible);
+          const inMarket = shouldShowOnRoute && projected !== null;
           const now = Date.now();
           const interval = inMarket ? UPDATE_INTERVAL_IN_MARKET_MS : UPDATE_INTERVAL_OUTSIDE_MS;
           if (markerRef.current && now - lastUpdateRef.current < interval) {
@@ -247,12 +285,15 @@ export default function UserLocationMarker({
           lastUpdateRef.current = now;
           lastAccuracyRef.current = accuracy;
 
-          // 実GPS座標をそのまま使用（DB座標系と一致させる）
           let displayPosition: [number, number];
-          if (inMarket) {
-            displayPosition = [latitude, longitude];
+          if (inMarket && projected) {
+            routeVisibleRef.current = true;
+            displayPosition = [projected.point.lat, projected.point.lng];
           } else {
-            displayPosition = MARKET_CENTER;
+            routeVisibleRef.current = false;
+            removeMarker();
+            onLocationUpdateRef.current?.(false, [latitude, longitude]);
+            return;
           }
 
           // 初回位置取得時はマップをその位置に移動
@@ -290,12 +331,8 @@ export default function UserLocationMarker({
         },
         (error) => {
           console.warn('Failed to get geolocation', error);
-          const defaultPosition = MARKET_CENTER;
-
-          if (!markerRef.current) {
-            markerRef.current = setupMarker(defaultPosition[0], defaultPosition[1]);
-          }
-          onLocationUpdateRef.current?.(false, defaultPosition);
+          removeMarker();
+          onLocationUpdateRef.current?.(false, MARKET_CENTER);
         },
         {
           enableHighAccuracy: true,
@@ -310,26 +347,18 @@ export default function UserLocationMarker({
           cancelAnimationFrame(animFrameRef.current);
           animFrameRef.current = null;
         }
-        if (markerRef.current) {
-          map.removeLayer(markerRef.current);
-          markerRef.current = null;
-        }
+        removeMarker();
       };
     }
 
     console.warn('Geolocation is not supported by this browser');
-    const defaultPosition = MARKET_CENTER;
-
-    markerRef.current = setupMarker(defaultPosition[0], defaultPosition[1]);
-    onLocationUpdateRef.current?.(false, defaultPosition);
+    removeMarker();
+    onLocationUpdateRef.current?.(false, MARKET_CENTER);
 
     return () => {
-      if (markerRef.current) {
-        map.removeLayer(markerRef.current);
-        markerRef.current = null;
-      }
+      removeMarker();
     };
-  }, [map, suppressInitialFocus]);
+  }, [effectiveRouteConfig, effectiveRoutePoints, map, suppressInitialFocus]);
 
   return null;
 }

--- a/app/(public)/map/config/displayConfig.ts
+++ b/app/(public)/map/config/displayConfig.ts
@@ -79,9 +79,9 @@ export const DEFAULT_ILLUSTRATION_SIZE: 'small' | 'medium' | 'large' =
  * - filterIntervalとの組み合わせで適切な間隔を確保
  *
  * 【設計根拠】
- * - ズーム19.0以上: medium (60px) - DETAIL モード（詳細閲覧、大きく見やすい）
- * - ズーム18.0-19.0: small (45px) - INTERMEDIATE モード（エリア探索、タップしやすい）
- * - ズーム18.0未満: small (45px) - OVERVIEW モード（全体俯瞰、見やすい）
+ * - ズーム19.5以上: medium (60px) - DETAIL モード（詳細閲覧、大きく見やすい）
+ * - ズーム17.5-19.5未満: small (45px) - 中間帯
+ * - ズーム17.5未満: small (45px) - OVERVIEW モード
  *
  * @param currentZoom 現在のズームレベル
  * @returns イラストサイズ ('small' | 'medium' | 'large')
@@ -89,10 +89,10 @@ export const DEFAULT_ILLUSTRATION_SIZE: 'small' | 'medium' | 'large' =
 export function getIllustrationSizeForZoom(
   currentZoom: number
 ): 'small' | 'medium' | 'large' {
-  if (currentZoom >= 19.0) {
+  if (currentZoom >= 19.5) {
     return 'medium'; // 【スマホUX】詳細閲覧: 60px（大きく見やすい）
   }
-  if (currentZoom >= 18.0) {
+  if (currentZoom >= 17.5) {
     return 'small'; // 【スマホUX】エリア探索: 45px（タップしやすい）
   }
   return 'small'; // 全体俯瞰: 45px（視認性確保）
@@ -160,7 +160,7 @@ export interface ZoomDisplayRule {
  */
 export const ZOOM_DISPLAY_RULES: ZoomDisplayRule[] = [
   {
-    minZoom: 18.0,
+    minZoom: 19.5,
     filterInterval: 1, // 拡大時: 全店舗表示（300店舗）
     allowShopDetails: true,
     allowShopInfo: true,
@@ -345,7 +345,7 @@ export interface ViewModeConfig {
  * 【シンプルな2段階表示】
  *
  * ┌─────────────────────────────────────┐
- * │ OVERVIEW（16.0-18.0未満）          │
+ * │ OVERVIEW（16.0-19.5未満）          │
  * │ 役割：縮小時、全体俯瞰              │
  * │ 体験：「日曜市の7丁目を把握」       │
  * │ 表示：14店舗（各丁目から左右1つずつ）│
@@ -353,7 +353,7 @@ export interface ViewModeConfig {
  * │ タップ：その丁目にズームイン        │
  * └─────────────────────────────────────┘
  * ┌─────────────────────────────────────┐
- * │ DETAIL（18.0以上）                 │
+ * │ DETAIL（19.5以上）                 │
  * │ 役割：拡大時、詳細閲覧              │
  * │ 体験：「全店舗を見渡せる」          │
  * │ 表示：300店舗すべて                 │
@@ -365,12 +365,12 @@ export interface ViewModeConfig {
  * - 2段階のシンプルな切り替え
  * - 縮小時は丁目別に代表店舗を表示（論理的な7分割）
  * - 拡大時は全店舗を表示
- * - デフォルトズーム18.0：拡大時（全店舗表示）
+ * - デフォルトズーム18.0：中間帯、19.5で全店舗表示へ
  */
 export const VIEW_MODE_CONFIGS: ViewModeConfig[] = [
   {
     mode: ViewMode.DETAIL,
-    minZoom: 18.0,  // 【2段階表示】拡大時（デフォルト）
+    minZoom: 19.5,  // 【2段階表示】19.5で詳細表示へ
     filterInterval: 1,  // 全店舗表示（300店舗すべて）
     mobileFilterInterval: 1,  // 全店舗表示
     allowShopDetails: true,

--- a/app/(public)/map/fetch-map-data.ts
+++ b/app/(public)/map/fetch-map-data.ts
@@ -1,5 +1,5 @@
 import { SupabaseClient } from '@supabase/supabase-js';
-import { fetchShopsFromDb } from './services/shopDb';
+import { fetchVendorShopsFromDb } from './services/shopDb';
 
 export type AttendanceEstimate = {
   label: string;
@@ -15,7 +15,7 @@ export async function fetchMapData(supabase: SupabaseClient) {
   try {
     const today = new Date().toISOString().slice(0, 10);
     const [shops, estimatesResult] = await Promise.all([
-      fetchShopsFromDb(supabase),
+      fetchVendorShopsFromDb(supabase),
       supabase.rpc('get_shop_attendance_estimates', {
         target_date: today,
       }),

--- a/app/(public)/map/hooks/useMapCameraController.ts
+++ b/app/(public)/map/hooks/useMapCameraController.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { MutableRefObject } from "react";
 import L from "leaflet";
 import {
@@ -11,11 +11,12 @@ import {
 import type { MapRoutePoint } from "../types/mapRoute";
 
 const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 15;
+const AUTO_ROTATION_COOLDOWN_MS = 3000;
 
 type UseMapCameraControllerArgs = {
   mapRef: MutableRefObject<L.Map | null>;
   interactionDisabled: boolean;
-  isGestureActive: boolean;
+  gestureActiveRef: MutableRefObject<boolean>;
   autoRotation: number;
   routePoints: MapRoutePoint[];
   isTracking: boolean;
@@ -26,16 +27,23 @@ type UseMapCameraControllerArgs = {
 export function useMapCameraController({
   mapRef,
   interactionDisabled,
-  isGestureActive,
+  gestureActiveRef,
   autoRotation,
   routePoints,
   isTracking,
   setIsTracking,
   setAutoRotation,
 }: UseMapCameraControllerArgs) {
+  const autoRotationCooldownUntilRef = useRef(0);
+
+  const markManualRotation = useCallback(() => {
+    autoRotationCooldownUntilRef.current = Date.now() + AUTO_ROTATION_COOLDOWN_MS;
+  }, []);
+
   const snapRotationToVisibleRoad = useCallback(
     (center?: L.LatLng, forceNorthUp = false) => {
-      if (interactionDisabled || isGestureActive) return;
+      if (interactionDisabled || gestureActiveRef.current) return;
+      if (Date.now() < autoRotationCooldownUntilRef.current) return;
       const map = mapRef.current;
       if (!map) return;
 
@@ -64,7 +72,7 @@ export function useMapCameraController({
 
       setAutoRotation(snappedRotation);
     },
-    [autoRotation, interactionDisabled, isGestureActive, mapRef, routePoints, setAutoRotation]
+    [autoRotation, gestureActiveRef, interactionDisabled, mapRef, routePoints, setAutoRotation]
   );
 
   useEffect(() => {
@@ -79,12 +87,12 @@ export function useMapCameraController({
     if (!map) return;
 
     const handleMoveEnd = () => {
-      if (isGestureActive) return;
+      if (gestureActiveRef.current) return;
       snapRotationToVisibleRoad(map.getCenter());
     };
 
     const handleDragStart = () => {
-      if (isGestureActive) return;
+      if (gestureActiveRef.current) return;
       setIsTracking(false);
     };
 
@@ -94,7 +102,7 @@ export function useMapCameraController({
       map.off("dragstart", handleDragStart);
       map.off("moveend", handleMoveEnd);
     };
-  }, [isGestureActive, mapRef, setIsTracking, snapRotationToVisibleRoad]);
+  }, [gestureActiveRef, mapRef, setIsTracking, snapRotationToVisibleRoad]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -106,6 +114,7 @@ export function useMapCameraController({
   }, [interactionDisabled, mapRef]);
 
   return {
+    markManualRotation,
     snapRotationToVisibleRoad,
   };
 }

--- a/app/(public)/map/hooks/useMapCameraController.ts
+++ b/app/(public)/map/hooks/useMapCameraController.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback, useEffect } from "react";
+import type { MutableRefObject } from "react";
+import L from "leaflet";
+import {
+  getAutoRotationForVisibleRoad,
+  getNearestRoadAlignedRotation,
+  normalizeRotationDeg,
+} from "../utils/autoRotation";
+import type { MapRoutePoint } from "../types/mapRoute";
+
+const AUTO_ROTATION_SNAP_THRESHOLD_DEG = 15;
+
+type UseMapCameraControllerArgs = {
+  mapRef: MutableRefObject<L.Map | null>;
+  interactionDisabled: boolean;
+  isGestureActive: boolean;
+  autoRotation: number;
+  routePoints: MapRoutePoint[];
+  isTracking: boolean;
+  setIsTracking: (value: boolean) => void;
+  setAutoRotation: (value: number) => void;
+};
+
+export function useMapCameraController({
+  mapRef,
+  interactionDisabled,
+  isGestureActive,
+  autoRotation,
+  routePoints,
+  isTracking,
+  setIsTracking,
+  setAutoRotation,
+}: UseMapCameraControllerArgs) {
+  const snapRotationToVisibleRoad = useCallback(
+    (center?: L.LatLng, forceNorthUp = false) => {
+      if (interactionDisabled || isGestureActive) return;
+      const map = mapRef.current;
+      if (!map) return;
+
+      if (forceNorthUp) {
+        setAutoRotation(0);
+        return;
+      }
+
+      const targetRotation = getAutoRotationForVisibleRoad({
+        center: center ?? map.getCenter(),
+        routePoints,
+      });
+      if (targetRotation === null) {
+        setAutoRotation(0);
+        return;
+      }
+
+      const currentRotation = normalizeRotationDeg(autoRotation);
+      const { rotation: snappedRotation, delta } = getNearestRoadAlignedRotation(
+        currentRotation,
+        targetRotation
+      );
+      if (Math.abs(delta) > AUTO_ROTATION_SNAP_THRESHOLD_DEG || Math.abs(delta) < 0.1) {
+        return;
+      }
+
+      setAutoRotation(snappedRotation);
+    },
+    [autoRotation, interactionDisabled, isGestureActive, mapRef, routePoints, setAutoRotation]
+  );
+
+  useEffect(() => {
+    if (!isTracking) return;
+    const map = mapRef.current;
+    if (!map) return;
+    snapRotationToVisibleRoad(map.getCenter());
+  }, [isTracking, mapRef, snapRotationToVisibleRoad]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const handleMoveEnd = () => {
+      if (isGestureActive) return;
+      snapRotationToVisibleRoad(map.getCenter());
+    };
+
+    const handleDragStart = () => {
+      if (isGestureActive) return;
+      setIsTracking(false);
+    };
+
+    map.on("dragstart", handleDragStart);
+    map.on("moveend", handleMoveEnd);
+    return () => {
+      map.off("dragstart", handleDragStart);
+      map.off("moveend", handleMoveEnd);
+    };
+  }, [isGestureActive, mapRef, setIsTracking, snapRotationToVisibleRoad]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!interactionDisabled) {
+      map.dragging.disable();
+      map.touchZoom.disable();
+    }
+  }, [interactionDisabled, mapRef]);
+
+  return {
+    snapRotationToVisibleRoad,
+  };
+}

--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -18,6 +18,7 @@ type TouchGestureState = {
   startDistance: number;
   startRotation: number;
   startZoom: number;
+  lastMidpoint: { x: number; y: number };
 };
 
 type PointerPanState = {
@@ -85,6 +86,8 @@ export function useMapGestures({
   const touchPanRef = useRef<PointerPanState | null>(null);
   const mousePanRef = useRef<PointerPanState | null>(null);
   const touchGestureRef = useRef<TouchGestureState | null>(null);
+  const zoomFrameRef = useRef<number | null>(null);
+  const pendingZoomRef = useRef<{ zoom: number; midpoint: { x: number; y: number } } | null>(null);
 
   useEffect(() => {
     gestureActiveRef.current = isTouchGestureActive;
@@ -113,6 +116,26 @@ export function useMapGestures({
       noMoveStart: true,
     });
   }, [interactionDisabled, mapRef, mapRotation]);
+
+  const flushPendingZoom = useCallback(() => {
+    const map = mapRef.current;
+    const pending = pendingZoomRef.current;
+    zoomFrameRef.current = null;
+    pendingZoomRef.current = null;
+    if (!map || !pending) return;
+    if (Math.abs(pending.zoom - map.getZoom()) <= 0.001) return;
+    map.setZoomAround(L.point(pending.midpoint.x, pending.midpoint.y), pending.zoom, { animate: false });
+  }, [mapRef]);
+
+  const scheduleZoom = useCallback((zoom: number, midpoint: { x: number; y: number }) => {
+    pendingZoomRef.current = { zoom, midpoint };
+    if (zoomFrameRef.current !== null) {
+      return;
+    }
+    zoomFrameRef.current = window.requestAnimationFrame(() => {
+      flushPendingZoom();
+    });
+  }, [flushPendingZoom]);
 
   const handleTouchStartCapture = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
     if (interactionDisabled) return;
@@ -145,6 +168,7 @@ export function useMapGestures({
       startDistance: getTouchDistance(t0, t1),
       startRotation: mapRotation,
       startZoom: map.getZoom(),
+      lastMidpoint: getTouchMidpoint(t0, t1),
     };
     setIsTouchGestureActive(true);
     debugLog("touch:start", { rotation: mapRotation, zoom: map.getZoom() });
@@ -178,6 +202,7 @@ export function useMapGestures({
     const t1 = e.touches[1];
     const angle = Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX);
     const distance = getTouchDistance(t0, t1);
+    const midpoint = getTouchMidpoint(t0, t1);
     const gesture = touchGestureRef.current;
     const deltaDeg = ((angle - gesture.startAngle) * 180) / Math.PI;
     const distanceDelta = distance - gesture.startDistance;
@@ -218,16 +243,15 @@ export function useMapGestures({
       return;
     }
 
-    const midpoint = getTouchMidpoint(t0, t1);
     const nextZoom = Math.max(
       map.getMinZoom(),
       Math.min(map.getMaxZoom(), gesture.startZoom + zoomDelta)
     );
-    if (Math.abs(nextZoom - map.getZoom()) <= 0.001) {
+    if (Math.abs(nextZoom - map.getZoom()) <= 0.001 && Math.abs(nextZoom - (pendingZoomRef.current?.zoom ?? nextZoom)) <= 0.001) {
       return;
     }
-
-    map.setZoomAround(L.point(midpoint.x, midpoint.y), nextZoom, { animate: false });
+    gesture.lastMidpoint = midpoint;
+    scheduleZoom(nextZoom, midpoint);
   }, [
     interactionDisabled,
     isTouchGestureActive,
@@ -236,6 +260,7 @@ export function useMapGestures({
     onRotationChange,
     panMapByScreenDelta,
     debugLog,
+    scheduleZoom,
   ]);
 
   const handleTouchEndCapture = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
@@ -259,6 +284,10 @@ export function useMapGestures({
     }
 
     touchGestureRef.current = null;
+    if (zoomFrameRef.current !== null) {
+      window.cancelAnimationFrame(zoomFrameRef.current);
+      flushPendingZoom();
+    }
     if (isTouchGestureActive) {
       debugLog("touch:end", { mode: activeGesture?.mode ?? "unknown" });
       onGestureEnd();
@@ -274,6 +303,14 @@ export function useMapGestures({
       hasMoved: false,
     };
   }, [interactionDisabled, isTouchGestureActive]);
+
+  useEffect(() => {
+    return () => {
+      if (zoomFrameRef.current !== null) {
+        window.cancelAnimationFrame(zoomFrameRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const handleMove = (e: MouseEvent) => {

--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -1,0 +1,317 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent, MutableRefObject, TouchEvent as ReactTouchEvent } from "react";
+import L from "leaflet";
+
+const TOUCH_ROTATION_ANGLE_THRESHOLD_DEG = 4;
+const TOUCH_ROTATION_DISTANCE_THRESHOLD_PX = 8;
+const POINTER_PAN_START_THRESHOLD_PX = 3;
+const DEBUG_STORAGE_KEY = "nicchyo-map-gesture-debug";
+
+type TouchPoint = { clientX: number; clientY: number };
+type GestureMode = "pending" | "rotate" | "zoom";
+
+type TouchGestureState = {
+  mode: GestureMode;
+  startAngle: number;
+  startDistance: number;
+  startRotation: number;
+  startZoom: number;
+};
+
+type PointerPanState = {
+  lastX: number;
+  lastY: number;
+  hasMoved: boolean;
+};
+
+function getTouchDistance(t0: TouchPoint, t1: TouchPoint): number {
+  return Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY);
+}
+
+function getTouchMidpoint(t0: TouchPoint, t1: TouchPoint): { x: number; y: number } {
+  return {
+    x: (t0.clientX + t1.clientX) / 2,
+    y: (t0.clientY + t1.clientY) / 2,
+  };
+}
+
+function rotateVector(x: number, y: number, degrees: number): { x: number; y: number } {
+  const radians = (degrees * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  return {
+    x: x * cos - y * sin,
+    y: x * sin + y * cos,
+  };
+}
+
+function normalizeRotationDeg(value: number): number {
+  return ((((value + 180) % 360) + 360) % 360) - 180;
+}
+
+function isDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const search = new URLSearchParams(window.location.search);
+    return search.get("mapGestureDebug") === "1" || window.localStorage.getItem(DEBUG_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+type UseMapGesturesArgs = {
+  mapRef: MutableRefObject<L.Map | null>;
+  gestureActiveRef: MutableRefObject<boolean>;
+  interactionDisabled: boolean;
+  mapRotation: number;
+  onPanStart: () => void;
+  onRotationChange: (rotation: number) => void;
+  onGestureEnd: () => void;
+};
+
+export function useMapGestures({
+  mapRef,
+  gestureActiveRef,
+  interactionDisabled,
+  mapRotation,
+  onPanStart,
+  onRotationChange,
+  onGestureEnd,
+}: UseMapGesturesArgs) {
+  const [isTouchGestureActive, setIsTouchGestureActive] = useState(false);
+  const debugEnabledRef = useRef(false);
+  const touchPanRef = useRef<PointerPanState | null>(null);
+  const mousePanRef = useRef<PointerPanState | null>(null);
+  const touchGestureRef = useRef<TouchGestureState | null>(null);
+
+  useEffect(() => {
+    gestureActiveRef.current = isTouchGestureActive;
+  }, [gestureActiveRef, isTouchGestureActive]);
+
+  useEffect(() => {
+    debugEnabledRef.current = isDebugEnabled();
+  }, []);
+
+  const debugLog = useCallback((event: string, data?: Record<string, unknown>) => {
+    if (!debugEnabledRef.current) return;
+    if (data) {
+      console.debug("[map-gesture]", event, data);
+      return;
+    }
+    console.debug("[map-gesture]", event);
+  }, []);
+
+  const panMapByScreenDelta = useCallback((dx: number, dy: number) => {
+    if (interactionDisabled) return;
+    const map = mapRef.current;
+    if (!map) return;
+    const adjusted = rotateVector(-dx, -dy, -mapRotation);
+    map.panBy([adjusted.x, adjusted.y], {
+      animate: false,
+      noMoveStart: true,
+    });
+  }, [interactionDisabled, mapRef, mapRotation]);
+
+  const handleTouchStartCapture = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
+    if (interactionDisabled) return;
+
+    if (e.touches.length === 1) {
+      const touch = e.touches[0];
+      touchPanRef.current = {
+        lastX: touch.clientX,
+        lastY: touch.clientY,
+        hasMoved: false,
+      };
+      touchGestureRef.current = null;
+      setIsTouchGestureActive(false);
+      return;
+    }
+
+    if (e.touches.length !== 2) {
+      return;
+    }
+
+    const map = mapRef.current;
+    if (!map) return;
+
+    touchPanRef.current = null;
+    const t0 = e.touches[0];
+    const t1 = e.touches[1];
+    touchGestureRef.current = {
+      mode: "pending",
+      startAngle: Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX),
+      startDistance: getTouchDistance(t0, t1),
+      startRotation: mapRotation,
+      startZoom: map.getZoom(),
+    };
+    setIsTouchGestureActive(true);
+    debugLog("touch:start", { rotation: mapRotation, zoom: map.getZoom() });
+  }, [debugLog, interactionDisabled, mapRef, mapRotation]);
+
+  const handleTouchMoveCapture = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
+    if (interactionDisabled) return;
+
+    if (e.touches.length === 1 && touchPanRef.current && !isTouchGestureActive) {
+      const touch = e.touches[0];
+      const dx = touch.clientX - touchPanRef.current.lastX;
+      const dy = touch.clientY - touchPanRef.current.lastY;
+      if (!touchPanRef.current.hasMoved && Math.hypot(dx, dy) < POINTER_PAN_START_THRESHOLD_PX) {
+        return;
+      }
+      touchPanRef.current.hasMoved = true;
+      touchPanRef.current.lastX = touch.clientX;
+      touchPanRef.current.lastY = touch.clientY;
+      onPanStart();
+      e.preventDefault();
+      panMapByScreenDelta(dx, dy);
+      return;
+    }
+
+    if (e.touches.length !== 2 || !touchGestureRef.current) return;
+
+    const map = mapRef.current;
+    if (!map) return;
+
+    const t0 = e.touches[0];
+    const t1 = e.touches[1];
+    const angle = Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX);
+    const distance = getTouchDistance(t0, t1);
+    const gesture = touchGestureRef.current;
+    const deltaDeg = ((angle - gesture.startAngle) * 180) / Math.PI;
+    const distanceDelta = distance - gesture.startDistance;
+
+    if (gesture.mode === "pending") {
+      if (
+        Math.abs(deltaDeg) < TOUCH_ROTATION_ANGLE_THRESHOLD_DEG &&
+        Math.abs(distanceDelta) < TOUCH_ROTATION_DISTANCE_THRESHOLD_PX
+      ) {
+        return;
+      }
+
+      gesture.mode =
+        Math.abs(distanceDelta) >= Math.abs(deltaDeg) * 2 ? "zoom" : "rotate";
+
+      debugLog("touch:mode", {
+        mode: gesture.mode,
+        deltaDeg: Number(deltaDeg.toFixed(2)),
+        distanceDelta: Number(distanceDelta.toFixed(2)),
+      });
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+    onPanStart();
+
+    if (gesture.mode === "rotate") {
+      onRotationChange(normalizeRotationDeg(gesture.startRotation + deltaDeg));
+      return;
+    }
+
+    const scale = distance / gesture.startDistance;
+    if (!Number.isFinite(scale) || scale <= 0) {
+      return;
+    }
+    const zoomDelta = Math.log2(scale);
+    if (Math.abs(zoomDelta) <= 0.001) {
+      return;
+    }
+
+    const midpoint = getTouchMidpoint(t0, t1);
+    const nextZoom = Math.max(
+      map.getMinZoom(),
+      Math.min(map.getMaxZoom(), gesture.startZoom + zoomDelta)
+    );
+    if (Math.abs(nextZoom - map.getZoom()) <= 0.001) {
+      return;
+    }
+
+    map.setZoomAround(L.point(midpoint.x, midpoint.y), nextZoom, { animate: false });
+  }, [
+    interactionDisabled,
+    isTouchGestureActive,
+    mapRef,
+    onPanStart,
+    onRotationChange,
+    panMapByScreenDelta,
+    debugLog,
+  ]);
+
+  const handleTouchEndCapture = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
+    if (interactionDisabled) return;
+
+    const activeGesture = touchGestureRef.current;
+
+    if (e.touches.length === 1) {
+      const touch = e.touches[0];
+      touchPanRef.current = {
+        lastX: touch.clientX,
+        lastY: touch.clientY,
+        hasMoved: false,
+      };
+    } else {
+      touchPanRef.current = null;
+    }
+
+    if (e.touches.length >= 2) {
+      return;
+    }
+
+    touchGestureRef.current = null;
+    if (isTouchGestureActive) {
+      debugLog("touch:end", { mode: activeGesture?.mode ?? "unknown" });
+      onGestureEnd();
+    }
+    setIsTouchGestureActive(false);
+  }, [debugLog, interactionDisabled, isTouchGestureActive, onGestureEnd]);
+
+  const handleMouseDownCapture = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
+    if (interactionDisabled || isTouchGestureActive || e.button !== 0) return;
+    mousePanRef.current = {
+      lastX: e.clientX,
+      lastY: e.clientY,
+      hasMoved: false,
+    };
+  }, [interactionDisabled, isTouchGestureActive]);
+
+  useEffect(() => {
+    const handleMove = (e: MouseEvent) => {
+      if (!mousePanRef.current || interactionDisabled || isTouchGestureActive) return;
+
+      const dx = e.clientX - mousePanRef.current.lastX;
+      const dy = e.clientY - mousePanRef.current.lastY;
+      if (!mousePanRef.current.hasMoved && Math.hypot(dx, dy) < POINTER_PAN_START_THRESHOLD_PX) {
+        return;
+      }
+
+      mousePanRef.current.hasMoved = true;
+      mousePanRef.current.lastX = e.clientX;
+      mousePanRef.current.lastY = e.clientY;
+      onPanStart();
+      panMapByScreenDelta(dx, dy);
+    };
+
+    const handleUp = () => {
+      mousePanRef.current = null;
+    };
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("mouseup", handleUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("mouseup", handleUp);
+    };
+  }, [interactionDisabled, isTouchGestureActive, onPanStart, panMapByScreenDelta]);
+
+  return {
+    isTouchGestureActive,
+    gestureHandlers: {
+      onTouchStartCapture: handleTouchStartCapture,
+      onTouchMoveCapture: handleTouchMoveCapture,
+      onTouchEndCapture: handleTouchEndCapture,
+      onTouchCancelCapture: handleTouchEndCapture,
+      onMouseDownCapture: handleMouseDownCapture,
+    },
+  };
+}

--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -5,9 +5,11 @@ import { createClient } from '@/utils/supabase/server';
 import MapPageClient from './MapPageClient';
 import type { Shop } from './data/shops';
 import { fetchMapData, type AttendanceEstimate } from './fetch-map-data';
-import { fetchShopsFromDb } from './services/shopDb';
+import { fetchVendorShopsFromDb } from './services/shopDb';
 import { fetchLandmarksFromDb } from './services/landmarksDb';
 import type { Landmark } from './types/landmark';
+import type { MapRoute } from './types/mapRoute';
+import { fetchMapRouteFromDb, getFallbackMapRoute } from './services/mapRouteDb';
 
 export const metadata: Metadata = {
   title: 'nicchyo | Sunday Market Map',
@@ -18,6 +20,7 @@ export default async function MapPage() {
   const cookieStore = await cookies();
   let shops: Shop[] = [];
   let landmarks: Landmark[] = [];
+  let mapRoute: MapRoute = getFallbackMapRoute();
   let attendanceEstimates: Record<number, AttendanceEstimate> = {};
 
   const hasSupabaseEnv =
@@ -27,17 +30,20 @@ export default async function MapPage() {
   if (hasSupabaseEnv) {
     try {
       const supabase = createClient(cookieStore);
-      const [fetchedShops, fetchedLandmarks, mapData] = await Promise.all([
-        fetchShopsFromDb(supabase),
+      const [fetchedShops, fetchedLandmarks, fetchedMapRoute, mapData] = await Promise.all([
+        fetchVendorShopsFromDb(supabase),
         fetchLandmarksFromDb(supabase),
+        fetchMapRouteFromDb(supabase),
         fetchMapData(supabase),
       ]);
       shops = fetchedShops;
       landmarks = fetchedLandmarks;
+      mapRoute = fetchedMapRoute;
       attendanceEstimates = mapData.attendanceEstimates;
     } catch {
       shops = [];
       landmarks = [];
+      mapRoute = getFallbackMapRoute();
     }
   }
 
@@ -50,6 +56,7 @@ export default async function MapPage() {
       <MapPageClient
         shops={shops}
         landmarks={landmarks}
+        mapRoute={mapRoute}
         attendanceEstimates={attendanceEstimates}
       />
     </Suspense>

--- a/app/(public)/map/services/mapRouteDb.ts
+++ b/app/(public)/map/services/mapRouteDb.ts
@@ -12,6 +12,7 @@ type MapRoutePointRow = {
   latitude: number | null;
   longitude: number | null;
   sort_order: number | null;
+  branch_from_id: string | null;
 };
 
 type MapRouteConfigRow = {
@@ -34,7 +35,7 @@ export async function fetchMapRouteFromDb(
   const [pointsResult, configResult] = await Promise.all([
     supabase
       .from("map_route_points")
-      .select("id, latitude, longitude, sort_order")
+      .select("id, latitude, longitude, sort_order, branch_from_id")
       .order("sort_order", { ascending: true }),
     supabase
       .from("map_route_configs")
@@ -58,6 +59,7 @@ export async function fetchMapRouteFromDb(
           lat: Number(row.latitude),
           lng: Number(row.longitude),
           order: Number(row.sort_order ?? 0),
+          branchFromId: row.branch_from_id ?? null,
         };
       })
       .filter((row): row is MapRoutePoint => row !== null)

--- a/app/(public)/map/services/mapRouteDb.ts
+++ b/app/(public)/map/services/mapRouteDb.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MapRoute, MapRouteConfig, MapRoutePoint } from "../types/mapRoute";
+import {
+  getDefaultMapRouteConfig,
+  getDefaultMapRoutePoints,
+  getEffectiveMapRouteConfig,
+  normalizeMapRoutePoints,
+} from "../utils/mapRouteGeometry";
+
+type MapRoutePointRow = {
+  id: string;
+  latitude: number | null;
+  longitude: number | null;
+  sort_order: number | null;
+};
+
+type MapRouteConfigRow = {
+  key: string;
+  road_half_width_meters: number | null;
+  snap_distance_meters: number | null;
+  visible_distance_meters: number | null;
+};
+
+export function getFallbackMapRoute(): MapRoute {
+  return {
+    points: getDefaultMapRoutePoints(),
+    config: getDefaultMapRouteConfig(),
+  };
+}
+
+export async function fetchMapRouteFromDb(
+  supabase: SupabaseClient
+): Promise<MapRoute> {
+  const [pointsResult, configResult] = await Promise.all([
+    supabase
+      .from("map_route_points")
+      .select("id, latitude, longitude, sort_order")
+      .order("sort_order", { ascending: true }),
+    supabase
+      .from("map_route_configs")
+      .select("key, road_half_width_meters, snap_distance_meters, visible_distance_meters")
+      .eq("key", "default")
+      .maybeSingle(),
+  ]);
+
+  if (pointsResult.error || configResult.error) {
+    return getFallbackMapRoute();
+  }
+
+  const points = normalizeMapRoutePoints(
+    ((pointsResult.data ?? []) as MapRoutePointRow[])
+      .map((row): MapRoutePoint | null => {
+        if (!row.id || row.latitude == null || row.longitude == null) {
+          return null;
+        }
+        return {
+          id: row.id,
+          lat: Number(row.latitude),
+          lng: Number(row.longitude),
+          order: Number(row.sort_order ?? 0),
+        };
+      })
+      .filter((row): row is MapRoutePoint => row !== null)
+  );
+
+  const configRow = configResult.data as MapRouteConfigRow | null;
+  const config = getEffectiveMapRouteConfig(
+    configRow
+      ? {
+          key: configRow.key,
+          roadHalfWidthMeters: Number(
+            configRow.road_half_width_meters ?? getDefaultMapRouteConfig().roadHalfWidthMeters
+          ),
+          snapDistanceMeters: Number(
+            configRow.snap_distance_meters ?? getDefaultMapRouteConfig().snapDistanceMeters
+          ),
+          visibleDistanceMeters: Number(
+            configRow.visible_distance_meters ?? getDefaultMapRouteConfig().visibleDistanceMeters
+          ),
+        }
+      : null
+  );
+
+  if (points.length < 2) {
+    return {
+      points: getDefaultMapRoutePoints(),
+      config,
+    };
+  }
+
+  return {
+    points,
+    config,
+  };
+}

--- a/app/(public)/map/services/shopDb.ts
+++ b/app/(public)/map/services/shopDb.ts
@@ -72,7 +72,7 @@ function normalizeChome(value: string | null): Shop["chome"] {
   return undefined;
 }
 
-export async function fetchShopsFromDb(
+export async function fetchVendorShopsFromDb(
   supabase: SupabaseClient
 ): Promise<Shop[]> {
   const [
@@ -243,3 +243,5 @@ export async function fetchShopsFromDb(
 
   return shops;
 }
+
+export const fetchShopsFromDb = fetchVendorShopsFromDb;

--- a/app/(public)/map/types/mapRoute.ts
+++ b/app/(public)/map/types/mapRoute.ts
@@ -1,0 +1,25 @@
+export type MapRoutePoint = {
+  id: string;
+  lat: number;
+  lng: number;
+  order: number;
+};
+
+export type MapRouteConfig = {
+  key: string;
+  roadHalfWidthMeters: number;
+  snapDistanceMeters: number;
+  visibleDistanceMeters: number;
+};
+
+export type MapRoute = {
+  points: MapRoutePoint[];
+  config: MapRouteConfig;
+};
+
+export const DEFAULT_MAP_ROUTE_CONFIG: MapRouteConfig = {
+  key: "default",
+  roadHalfWidthMeters: 15.6,
+  snapDistanceMeters: 18,
+  visibleDistanceMeters: 42,
+};

--- a/app/(public)/map/types/mapRoute.ts
+++ b/app/(public)/map/types/mapRoute.ts
@@ -3,6 +3,7 @@ export type MapRoutePoint = {
   lat: number;
   lng: number;
   order: number;
+  branchFromId?: string | null;
 };
 
 export type MapRouteConfig = {

--- a/app/(public)/map/utils/autoRotation.ts
+++ b/app/(public)/map/utils/autoRotation.ts
@@ -1,7 +1,7 @@
 import L from "leaflet";
-const ROAD_ROTATION_BREAK_LNG = 133.5414795;
-const EAST_ROTATION_DEG = 90;
-const WEST_ROTATION_DEG = 105;
+import type { MapRoutePoint } from "../types/mapRoute";
+import { getRoadCenterlinePoints } from "../config/roadConfig";
+import { normalizeMapRoutePoints } from "./mapRouteGeometry";
 
 export function normalizeRotationDeg(value: number): number {
   const normalized = ((value % 360) + 360) % 360;
@@ -12,12 +12,79 @@ export function getShortestAngleDelta(fromDeg: number, toDeg: number): number {
   return normalizeRotationDeg(toDeg - fromDeg);
 }
 
+export function getNearestRoadAlignedRotation(
+  currentDeg: number,
+  targetDeg: number
+): { rotation: number; delta: number } {
+  const normalizedTarget = normalizeRotationDeg(targetDeg);
+  const oppositeTarget = normalizeRotationDeg(normalizedTarget + 180);
+
+  const directDelta = getShortestAngleDelta(currentDeg, normalizedTarget);
+  const oppositeDelta = getShortestAngleDelta(currentDeg, oppositeTarget);
+
+  if (Math.abs(oppositeDelta) < Math.abs(directDelta)) {
+    return { rotation: oppositeTarget, delta: oppositeDelta };
+  }
+
+  return { rotation: normalizedTarget, delta: directDelta };
+}
+
 export function getAutoRotationForVisibleRoad({
   center,
+  routePoints,
 }: {
   center: L.LatLng;
+  routePoints?: MapRoutePoint[];
 }): number | null {
-  const rotationDeg =
-    center.lng >= ROAD_ROTATION_BREAK_LNG ? EAST_ROTATION_DEG : WEST_ROTATION_DEG;
-  return normalizeRotationDeg(rotationDeg);
+  const points = normalizeMapRoutePoints(routePoints ?? []);
+  const activePoints = points.length >= 2 ? points : getRoadCenterlinePoints();
+  if (activePoints.length < 2) {
+    return null;
+  }
+
+  let bestSegmentIndex = 0;
+  let bestDistanceSq = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < activePoints.length - 1; i += 1) {
+    const candidate = projectPointOntoSegment(center, activePoints[i], activePoints[i + 1]);
+    const distanceSq =
+      (candidate.lat - center.lat) * (candidate.lat - center.lat) +
+      (candidate.lng - center.lng) * (candidate.lng - center.lng);
+
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestSegmentIndex = i;
+    }
+  }
+
+  const from = activePoints[bestSegmentIndex];
+  const to = activePoints[bestSegmentIndex + 1];
+  const screenAngleDeg =
+    (Math.atan2(-(to.lat - from.lat), to.lng - from.lng) * 180) / Math.PI;
+
+  return normalizeRotationDeg(270 - screenAngleDeg);
+}
+
+function projectPointOntoSegment(
+  point: { lat: number; lng: number },
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+) {
+  const abLat = b.lat - a.lat;
+  const abLng = b.lng - a.lng;
+  const abLenSq = abLat * abLat + abLng * abLng;
+
+  if (abLenSq === 0) {
+    return a;
+  }
+
+  const apLat = point.lat - a.lat;
+  const apLng = point.lng - a.lng;
+  const rawT = (apLat * abLat + apLng * abLng) / abLenSq;
+  const t = Math.max(0, Math.min(1, rawT));
+
+  return {
+    lat: a.lat + abLat * t,
+    lng: a.lng + abLng * t,
+  };
 }

--- a/app/(public)/map/utils/autoRotation.ts
+++ b/app/(public)/map/utils/autoRotation.ts
@@ -1,7 +1,7 @@
 import L from "leaflet";
 import type { MapRoutePoint } from "../types/mapRoute";
 import { getRoadCenterlinePoints } from "../config/roadConfig";
-import { normalizeMapRoutePoints } from "./mapRouteGeometry";
+import { getRouteSegments, normalizeMapRoutePoints } from "./mapRouteGeometry";
 
 export function normalizeRotationDeg(value: number): number {
   const normalized = ((value % 360) + 360) % 360;
@@ -37,16 +37,27 @@ export function getAutoRotationForVisibleRoad({
   routePoints?: MapRoutePoint[];
 }): number | null {
   const points = normalizeMapRoutePoints(routePoints ?? []);
-  const activePoints = points.length >= 2 ? points : getRoadCenterlinePoints();
-  if (activePoints.length < 2) {
+  const activeSegments =
+    points.length >= 2
+      ? getRouteSegments(points)
+      : getRouteSegments(
+          getRoadCenterlinePoints().map((point, index) => ({
+            id: `fallback-${index}`,
+            lat: point.lat,
+            lng: point.lng,
+            order: index,
+            branchFromId: null,
+          }))
+        );
+  if (activeSegments.length === 0) {
     return null;
   }
 
   let bestSegmentIndex = 0;
   let bestDistanceSq = Number.POSITIVE_INFINITY;
 
-  for (let i = 0; i < activePoints.length - 1; i += 1) {
-    const candidate = projectPointOntoSegment(center, activePoints[i], activePoints[i + 1]);
+  for (let i = 0; i < activeSegments.length; i += 1) {
+    const candidate = projectPointOntoSegment(center, activeSegments[i].start, activeSegments[i].end);
     const distanceSq =
       (candidate.lat - center.lat) * (candidate.lat - center.lat) +
       (candidate.lng - center.lng) * (candidate.lng - center.lng);
@@ -57,8 +68,8 @@ export function getAutoRotationForVisibleRoad({
     }
   }
 
-  const from = activePoints[bestSegmentIndex];
-  const to = activePoints[bestSegmentIndex + 1];
+  const from = activeSegments[bestSegmentIndex].start;
+  const to = activeSegments[bestSegmentIndex].end;
   const screenAngleDeg =
     (Math.atan2(-(to.lat - from.lat), to.lng - from.lng) * 180) / Math.PI;
 

--- a/app/(public)/map/utils/mapRouteGeometry.ts
+++ b/app/(public)/map/utils/mapRouteGeometry.ts
@@ -12,12 +12,20 @@ export type RouteProjection = {
   t: number;
 };
 
+export type RouteSegment = {
+  key: string;
+  start: MapRoutePoint;
+  end: MapRoutePoint;
+  isBranch: boolean;
+};
+
 export function getDefaultMapRoutePoints(): MapRoutePoint[] {
   return getRoadCenterlinePoints().map((point, index) => ({
     id: `default-route-point-${index + 1}`,
     lat: point.lat,
     lng: point.lng,
     order: index,
+    branchFromId: null,
   }));
 }
 
@@ -37,11 +45,61 @@ export function normalizeMapRoutePoints(points: MapRoutePoint[]): MapRoutePoint[
         Number.isFinite(point.lat) &&
         Number.isFinite(point.lng)
     )
-    .sort((a, b) => a.order - b.order)
+    .map((point) => ({
+      ...point,
+      branchFromId: point.branchFromId ?? null,
+    }))
+    .sort((a, b) => {
+      const branchRankA = a.branchFromId ? 1 : 0;
+      const branchRankB = b.branchFromId ? 1 : 0;
+      if (branchRankA !== branchRankB) {
+        return branchRankA - branchRankB;
+      }
+      return a.order - b.order;
+    })
     .map((point, index) => ({
       ...point,
       order: index,
     }));
+}
+
+export function getMainRoutePoints(points: MapRoutePoint[]): MapRoutePoint[] {
+  return normalizeMapRoutePoints(points).filter((point) => !point.branchFromId);
+}
+
+export function getBranchRoutePoints(points: MapRoutePoint[]): MapRoutePoint[] {
+  return normalizeMapRoutePoints(points).filter((point) => Boolean(point.branchFromId));
+}
+
+export function getRouteSegments(points: MapRoutePoint[]): RouteSegment[] {
+  const normalized = normalizeMapRoutePoints(points);
+  const mainline = normalized.filter((point) => !point.branchFromId);
+  const pointById = new Map(normalized.map((point) => [point.id, point]));
+  const segments: RouteSegment[] = [];
+
+  for (let index = 0; index < mainline.length - 1; index += 1) {
+    segments.push({
+      key: `main-${mainline[index].id}-${mainline[index + 1].id}`,
+      start: mainline[index],
+      end: mainline[index + 1],
+      isBranch: false,
+    });
+  }
+
+  normalized
+    .filter((point) => point.branchFromId)
+    .forEach((point) => {
+      const parent = pointById.get(point.branchFromId ?? "");
+      if (!parent) return;
+      segments.push({
+        key: `branch-${parent.id}-${point.id}`,
+        start: parent,
+        end: point,
+        isBranch: true,
+      });
+    });
+
+  return segments;
 }
 
 export function getEffectiveMapRouteConfig(
@@ -173,13 +231,15 @@ export function buildRoadPolygon(
 
 export function projectPointOntoRoute(
   point: { lat: number; lng: number },
-  routePoints: Array<{ lat: number; lng: number }>
+  routePoints: MapRoutePoint[]
 ): RouteProjection | null {
+  const segments = getRouteSegments(routePoints);
+
   if (routePoints.length === 0) {
     return null;
   }
 
-  if (routePoints.length === 1) {
+  if (segments.length === 0 && routePoints.length === 1) {
     return {
       point: { lat: routePoints[0].lat, lng: routePoints[0].lng },
       distanceMeters: distanceMeters(point, routePoints[0]),
@@ -190,8 +250,8 @@ export function projectPointOntoRoute(
 
   let bestProjection: RouteProjection | null = null;
 
-  for (let i = 0; i < routePoints.length - 1; i += 1) {
-    const projection = projectPointOntoSegment(point, routePoints[i], routePoints[i + 1]);
+  for (let i = 0; i < segments.length; i += 1) {
+    const projection = projectPointOntoSegment(point, segments[i].start, segments[i].end);
     const nextProjection: RouteProjection = {
       point: projection.point,
       distanceMeters: distanceMeters(point, projection.point),
@@ -217,8 +277,9 @@ export function getRouteLengthKm(points: Array<{ lat: number; lng: number }>): n
   }
 
   let meters = 0;
-  for (let i = 0; i < points.length - 1; i += 1) {
-    meters += distanceMeters(points[i], points[i + 1]);
+  const routeSegments = getRouteSegments(points as MapRoutePoint[]);
+  for (const segment of routeSegments) {
+    meters += distanceMeters(segment.start, segment.end);
   }
   return meters / 1000;
 }

--- a/app/(public)/map/utils/mapRouteGeometry.ts
+++ b/app/(public)/map/utils/mapRouteGeometry.ts
@@ -1,0 +1,294 @@
+import { ROAD_CONFIG, getRoadCenterlinePoints } from "../config/roadConfig";
+import {
+  DEFAULT_MAP_ROUTE_CONFIG,
+  type MapRouteConfig,
+  type MapRoutePoint,
+} from "../types/mapRoute";
+
+export type RouteProjection = {
+  point: { lat: number; lng: number };
+  distanceMeters: number;
+  segmentIndex: number;
+  t: number;
+};
+
+export function getDefaultMapRoutePoints(): MapRoutePoint[] {
+  return getRoadCenterlinePoints().map((point, index) => ({
+    id: `default-route-point-${index + 1}`,
+    lat: point.lat,
+    lng: point.lng,
+    order: index,
+  }));
+}
+
+export function getDefaultMapRouteConfig(): MapRouteConfig {
+  return {
+    ...DEFAULT_MAP_ROUTE_CONFIG,
+    roadHalfWidthMeters: DEFAULT_MAP_ROUTE_CONFIG.roadHalfWidthMeters,
+  };
+}
+
+export function normalizeMapRoutePoints(points: MapRoutePoint[]): MapRoutePoint[] {
+  return [...points]
+    .filter(
+      (point) =>
+        point &&
+        typeof point.id === "string" &&
+        Number.isFinite(point.lat) &&
+        Number.isFinite(point.lng)
+    )
+    .sort((a, b) => a.order - b.order)
+    .map((point, index) => ({
+      ...point,
+      order: index,
+    }));
+}
+
+export function getEffectiveMapRouteConfig(
+  config?: Partial<MapRouteConfig> | null
+): MapRouteConfig {
+  return {
+    ...getDefaultMapRouteConfig(),
+    ...(config ?? {}),
+    key: config?.key ?? DEFAULT_MAP_ROUTE_CONFIG.key,
+  };
+}
+
+export function getRouteBounds(
+  points: Array<{ lat: number; lng: number }>,
+  fallback: [[number, number], [number, number]] = ROAD_CONFIG.bounds
+): [[number, number], [number, number]] {
+  if (points.length === 0) {
+    return fallback;
+  }
+
+  let north = Number.NEGATIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let west = Number.POSITIVE_INFINITY;
+
+  for (const point of points) {
+    north = Math.max(north, point.lat);
+    south = Math.min(south, point.lat);
+    east = Math.max(east, point.lng);
+    west = Math.min(west, point.lng);
+  }
+
+  return [
+    [north, east],
+    [south, west],
+  ];
+}
+
+export function expandBoundsByMeters(
+  bounds: [[number, number], [number, number]],
+  paddingMeters: number
+): [[number, number], [number, number]] {
+  const centerLat = (bounds[0][0] + bounds[1][0]) / 2;
+  const latPad = metersToLat(paddingMeters);
+  const lngPad = metersToLng(paddingMeters, centerLat);
+  return [
+    [bounds[0][0] + latPad, bounds[0][1] + lngPad],
+    [bounds[1][0] - latPad, bounds[1][1] - lngPad],
+  ];
+}
+
+export function getRouteCenter(
+  points: Array<{ lat: number; lng: number }>,
+  fallbackBounds: [[number, number], [number, number]] = ROAD_CONFIG.bounds
+): [number, number] {
+  const bounds = getRouteBounds(points, fallbackBounds);
+  return [
+    (bounds[0][0] + bounds[1][0]) / 2,
+    (bounds[0][1] + bounds[1][1]) / 2,
+  ];
+}
+
+export function densifyPath(
+  points: Array<{ lat: number; lng: number }>,
+  stepMeters: number
+): Array<[number, number]> {
+  if (points.length < 2) {
+    return points.map((p) => [p.lat, p.lng]);
+  }
+
+  const dense: Array<[number, number]> = [];
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const a = points[i];
+    const b = points[i + 1];
+    const dist = distanceMeters(a, b);
+    const steps = Math.max(1, Math.ceil(dist / stepMeters));
+    for (let k = 0; k < steps; k += 1) {
+      const t = k / steps;
+      dense.push([a.lat + (b.lat - a.lat) * t, a.lng + (b.lng - a.lng) * t]);
+    }
+  }
+  const last = points[points.length - 1];
+  dense.push([last.lat, last.lng]);
+  return dense;
+}
+
+export function smoothPath(path: Array<[number, number]>, radius: number): Array<[number, number]> {
+  if (path.length < 3 || radius <= 0) return path;
+  return path.map((_, idx) => {
+    const start = Math.max(0, idx - radius);
+    const end = Math.min(path.length - 1, idx + radius);
+    let sumLat = 0;
+    let sumLng = 0;
+    let count = 0;
+    for (let i = start; i <= end; i += 1) {
+      sumLat += path[i][0];
+      sumLng += path[i][1];
+      count += 1;
+    }
+    return [sumLat / count, sumLng / count];
+  });
+}
+
+export function buildRoadPolygon(
+  centerline: Array<[number, number]>,
+  halfWidthMeters: number
+): Array<[number, number]> {
+  if (centerline.length < 2) return [];
+
+  const left: Array<[number, number]> = [];
+  const right: Array<[number, number]> = [];
+  for (let i = 0; i < centerline.length; i += 1) {
+    const prev = centerline[Math.max(0, i - 1)];
+    const next = centerline[Math.min(centerline.length - 1, i + 1)];
+    const curr = centerline[i];
+    const tangent = tangentVectorMeters(prev, next, curr[0]);
+    const len = Math.hypot(tangent.x, tangent.y) || 1;
+    const nx = -tangent.y / len;
+    const ny = tangent.x / len;
+
+    const dLat = metersToLat(ny * halfWidthMeters);
+    const dLng = metersToLng(nx * halfWidthMeters, curr[0]);
+    left.push([curr[0] + dLat, curr[1] + dLng]);
+    right.push([curr[0] - dLat, curr[1] - dLng]);
+  }
+
+  return [...left, ...right.reverse()];
+}
+
+export function projectPointOntoRoute(
+  point: { lat: number; lng: number },
+  routePoints: Array<{ lat: number; lng: number }>
+): RouteProjection | null {
+  if (routePoints.length === 0) {
+    return null;
+  }
+
+  if (routePoints.length === 1) {
+    return {
+      point: { lat: routePoints[0].lat, lng: routePoints[0].lng },
+      distanceMeters: distanceMeters(point, routePoints[0]),
+      segmentIndex: 0,
+      t: 0,
+    };
+  }
+
+  let bestProjection: RouteProjection | null = null;
+
+  for (let i = 0; i < routePoints.length - 1; i += 1) {
+    const projection = projectPointOntoSegment(point, routePoints[i], routePoints[i + 1]);
+    const nextProjection: RouteProjection = {
+      point: projection.point,
+      distanceMeters: distanceMeters(point, projection.point),
+      segmentIndex: i,
+      t: projection.t,
+    };
+
+    if (!bestProjection || nextProjection.distanceMeters < bestProjection.distanceMeters) {
+      bestProjection = nextProjection;
+    }
+  }
+
+  return bestProjection;
+}
+
+export function getRouteLengthKm(points: Array<{ lat: number; lng: number }>): number {
+  if (points.length < 2) {
+    const bounds = ROAD_CONFIG.bounds;
+    return Math.max(
+      Math.abs(bounds[0][0] - bounds[1][0]),
+      Math.abs(bounds[0][1] - bounds[1][1])
+    ) * 111;
+  }
+
+  let meters = 0;
+  for (let i = 0; i < points.length - 1; i += 1) {
+    meters += distanceMeters(points[i], points[i + 1]);
+  }
+  return meters / 1000;
+}
+
+export function distanceMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const dLat = latToMeters(b.lat - a.lat);
+  const dLng = lngToMeters(b.lng - a.lng, (a.lat + b.lat) / 2);
+  return Math.hypot(dLat, dLng);
+}
+
+export function latToMeters(latDiff: number): number {
+  return latDiff * 110540;
+}
+
+export function lngToMeters(lngDiff: number, lat: number): number {
+  return lngDiff * (111320 * Math.cos((lat * Math.PI) / 180));
+}
+
+export function metersToLat(meters: number): number {
+  return meters / 110540;
+}
+
+export function metersToLng(meters: number, lat: number): number {
+  const unit = 111320 * Math.cos((lat * Math.PI) / 180);
+  if (Math.abs(unit) < 1e-6) return 0;
+  return meters / unit;
+}
+
+function tangentVectorMeters(
+  prev: [number, number],
+  next: [number, number],
+  latRef: number
+): { x: number; y: number } {
+  const dLng = next[1] - prev[1];
+  const dLat = next[0] - prev[0];
+  return {
+    x: lngToMeters(dLng, latRef),
+    y: latToMeters(dLat),
+  };
+}
+
+function projectPointOntoSegment(
+  point: { lat: number; lng: number },
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): { point: { lat: number; lng: number }; t: number } {
+  const abLat = b.lat - a.lat;
+  const abLng = b.lng - a.lng;
+  const abLenSq = abLat * abLat + abLng * abLng;
+
+  if (abLenSq === 0) {
+    return {
+      point: { lat: a.lat, lng: a.lng },
+      t: 0,
+    };
+  }
+
+  const apLat = point.lat - a.lat;
+  const apLng = point.lng - a.lng;
+  const rawT = (apLat * abLat + apLng * abLng) / abLenSq;
+  const t = Math.max(0, Math.min(1, rawT));
+
+  return {
+    point: {
+      lat: a.lat + abLat * t,
+      lng: a.lng + abLng * t,
+    },
+    t,
+  };
+}

--- a/app/(public)/map/utils/mapRouteGeometry.ts
+++ b/app/(public)/map/utils/mapRouteGeometry.ts
@@ -552,6 +552,14 @@ export function projectPointOntoRoute(
   routePoints: MapRoutePoint[]
 ): RouteProjection | null {
   const segments = getRouteSegments(routePoints);
+  return projectPointOntoSegments(point, routePoints, segments);
+}
+
+export function projectPointOntoSegments(
+  point: { lat: number; lng: number },
+  routePoints: Array<{ lat: number; lng: number }>,
+  segments: RouteSegment[]
+): RouteProjection | null {
 
   if (routePoints.length === 0) {
     return null;

--- a/app/(public)/map/utils/mapRouteGeometry.ts
+++ b/app/(public)/map/utils/mapRouteGeometry.ts
@@ -19,6 +19,21 @@ export type RouteSegment = {
   isBranch: boolean;
 };
 
+export type MapRoutePointRole = "main-start" | "main-middle" | "main-end" | "branch";
+
+export type RouteTopology = {
+  normalizedPoints: MapRoutePoint[];
+  pointById: Map<string, MapRoutePoint>;
+  mainlinePoints: MapRoutePoint[];
+  branchChildrenById: Map<string, MapRoutePoint[]>;
+  segments: RouteSegment[];
+};
+
+export type RouteChain = {
+  key: string;
+  points: MapRoutePoint[];
+};
+
 export function getDefaultMapRoutePoints(): MapRoutePoint[] {
   return getRoadCenterlinePoints().map((point, index) => ({
     id: `default-route-point-${index + 1}`,
@@ -71,10 +86,11 @@ export function getBranchRoutePoints(points: MapRoutePoint[]): MapRoutePoint[] {
   return normalizeMapRoutePoints(points).filter((point) => Boolean(point.branchFromId));
 }
 
-export function getRouteSegments(points: MapRoutePoint[]): RouteSegment[] {
+export function getRouteTopology(points: MapRoutePoint[]): RouteTopology {
   const normalized = normalizeMapRoutePoints(points);
   const mainline = normalized.filter((point) => !point.branchFromId);
   const pointById = new Map(normalized.map((point) => [point.id, point]));
+  const branchChildrenById = new Map<string, MapRoutePoint[]>();
   const segments: RouteSegment[] = [];
 
   for (let index = 0; index < mainline.length - 1; index += 1) {
@@ -91,6 +107,9 @@ export function getRouteSegments(points: MapRoutePoint[]): RouteSegment[] {
     .forEach((point) => {
       const parent = pointById.get(point.branchFromId ?? "");
       if (!parent) return;
+      const children = branchChildrenById.get(parent.id) ?? [];
+      children.push(point);
+      branchChildrenById.set(parent.id, children);
       segments.push({
         key: `branch-${parent.id}-${point.id}`,
         start: parent,
@@ -99,7 +118,306 @@ export function getRouteSegments(points: MapRoutePoint[]): RouteSegment[] {
       });
     });
 
-  return segments;
+  return {
+    normalizedPoints: normalized,
+    pointById,
+    mainlinePoints: mainline,
+    branchChildrenById,
+    segments,
+  };
+}
+
+export function getRouteSegments(points: MapRoutePoint[]): RouteSegment[] {
+  return getRouteTopology(points).segments;
+}
+
+export function getRoutePointRole(points: MapRoutePoint[], pointId: string): MapRoutePointRole | null {
+  const topology = getRouteTopology(points);
+  const point = topology.pointById.get(pointId);
+  if (!point) {
+    return null;
+  }
+  if (point.branchFromId) {
+    return "branch";
+  }
+  const mainIndex = topology.mainlinePoints.findIndex((item) => item.id === pointId);
+  if (mainIndex < 0) {
+    return null;
+  }
+  if (mainIndex === 0) {
+    return "main-start";
+  }
+  if (mainIndex === topology.mainlinePoints.length - 1) {
+    return "main-end";
+  }
+  return "main-middle";
+}
+
+export function getRoutePointStatus(points: MapRoutePoint[], pointId: string): {
+  role: MapRoutePointRole;
+  label: string;
+  description: string;
+} | null {
+  const topology = getRouteTopology(points);
+  const point = topology.pointById.get(pointId);
+  const role = getRoutePointRole(points, pointId);
+  if (!point || !role) {
+    return null;
+  }
+
+  if (role === "branch") {
+    return {
+      role,
+      label: "枝点",
+      description: `分岐元: ${point.branchFromId}`,
+    };
+  }
+
+  if (role === "main-start") {
+    return {
+      role,
+      label: "左端",
+      description: "幹線の始点です。追加すると左方向へ延長します。",
+    };
+  }
+
+  if (role === "main-end") {
+    return {
+      role,
+      label: "右端",
+      description: "幹線の終点です。追加すると右方向へ延長します。",
+    };
+  }
+
+  return {
+    role,
+    label: "幹線の中間点",
+    description: "追加すると上側/下側に分岐する新しい道を作れます。",
+  };
+}
+
+export function getMainRouteNeighbors(
+  points: MapRoutePoint[],
+  pointId: string
+): {
+  previous: MapRoutePoint | null;
+  current: MapRoutePoint | null;
+  next: MapRoutePoint | null;
+} {
+  const topology = getRouteTopology(points);
+  const mainIndex = topology.mainlinePoints.findIndex((point) => point.id === pointId);
+  if (mainIndex < 0) {
+    return {
+      previous: null,
+      current: null,
+      next: null,
+    };
+  }
+
+  return {
+    previous: topology.mainlinePoints[mainIndex - 1] ?? null,
+    current: topology.mainlinePoints[mainIndex] ?? null,
+    next: topology.mainlinePoints[mainIndex + 1] ?? null,
+  };
+}
+
+export function getBranchParent(points: MapRoutePoint[], pointId: string): MapRoutePoint | null {
+  const topology = getRouteTopology(points);
+  const point = topology.pointById.get(pointId);
+  if (!point?.branchFromId) {
+    return null;
+  }
+  return topology.pointById.get(point.branchFromId) ?? null;
+}
+
+export function getBranchChildren(points: MapRoutePoint[], pointId: string): MapRoutePoint[] {
+  return getRouteTopology(points).branchChildrenById.get(pointId) ?? [];
+}
+
+export function getConnectedRouteNeighbors(points: MapRoutePoint[], pointId: string): MapRoutePoint[] {
+  const topology = getRouteTopology(points);
+  const neighbors: MapRoutePoint[] = [];
+  for (const segment of topology.segments) {
+    if (segment.start.id === pointId) {
+      neighbors.push(segment.end);
+    } else if (segment.end.id === pointId) {
+      neighbors.push(segment.start);
+    }
+  }
+  return neighbors;
+}
+
+export function getRouteChains(points: MapRoutePoint[]): RouteChain[] {
+  const topology = getRouteTopology(points);
+  const adjacency = new Map<string, Array<{ neighborId: string; segmentKey: string }>>();
+
+  for (const segment of topology.segments) {
+    const startEdges = adjacency.get(segment.start.id) ?? [];
+    startEdges.push({ neighborId: segment.end.id, segmentKey: segment.key });
+    adjacency.set(segment.start.id, startEdges);
+
+    const endEdges = adjacency.get(segment.end.id) ?? [];
+    endEdges.push({ neighborId: segment.start.id, segmentKey: segment.key });
+    adjacency.set(segment.end.id, endEdges);
+  }
+
+  const visitedEdges = new Set<string>();
+  const chains: RouteChain[] = [];
+  const nodes = topology.normalizedPoints.filter((point) => (adjacency.get(point.id) ?? []).length > 0);
+  const startNodes = nodes.filter((point) => (adjacency.get(point.id) ?? []).length !== 2);
+
+  const walkChain = (startId: string, neighborId: string, segmentKey: string): RouteChain | null => {
+    if (visitedEdges.has(segmentKey)) {
+      return null;
+    }
+
+    const chain: MapRoutePoint[] = [];
+    let currentId = startId;
+    let nextId = neighborId;
+    let nextSegmentKey = segmentKey;
+
+    while (true) {
+      visitedEdges.add(nextSegmentKey);
+
+      const currentPoint = topology.pointById.get(currentId);
+      const nextPoint = topology.pointById.get(nextId);
+      if (!currentPoint || !nextPoint) {
+        return null;
+      }
+
+      if (chain.length === 0) {
+        chain.push(currentPoint);
+      }
+      chain.push(nextPoint);
+
+      const nextEdges = (adjacency.get(nextId) ?? []).filter((edge) => edge.neighborId !== currentId);
+      if ((adjacency.get(nextId) ?? []).length !== 2 || nextEdges.length === 0) {
+        break;
+      }
+
+      const candidate = nextEdges.find((edge) => !visitedEdges.has(edge.segmentKey));
+      if (!candidate) {
+        break;
+      }
+
+      currentId = nextId;
+      nextId = candidate.neighborId;
+      nextSegmentKey = candidate.segmentKey;
+    }
+
+    if (chain.length < 2) {
+      return null;
+    }
+
+    return {
+      key: chain.map((point) => point.id).join("->"),
+      points: chain,
+    };
+  };
+
+  for (const node of startNodes) {
+    for (const edge of adjacency.get(node.id) ?? []) {
+      const chain = walkChain(node.id, edge.neighborId, edge.segmentKey);
+      if (chain) {
+        chains.push(chain);
+      }
+    }
+  }
+
+  for (const node of nodes) {
+    for (const edge of adjacency.get(node.id) ?? []) {
+      const chain = walkChain(node.id, edge.neighborId, edge.segmentKey);
+      if (chain) {
+        chains.push(chain);
+      }
+    }
+  }
+
+  return chains;
+}
+
+export function smoothRoutePath(
+  path: Array<[number, number]>,
+  iterations = 2
+): Array<[number, number]> {
+  if (path.length < 3 || iterations <= 0) {
+    return path;
+  }
+
+  let current = path;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    if (current.length < 3) {
+      break;
+    }
+    const next: Array<[number, number]> = [current[0]];
+    for (let index = 0; index < current.length - 1; index += 1) {
+      const a = current[index];
+      const b = current[index + 1];
+      const q: [number, number] = [
+        a[0] * 0.75 + b[0] * 0.25,
+        a[1] * 0.75 + b[1] * 0.25,
+      ];
+      const r: [number, number] = [
+        a[0] * 0.25 + b[0] * 0.75,
+        a[1] * 0.25 + b[1] * 0.75,
+      ];
+      if (index > 0) {
+        next.push(q);
+      }
+      next.push(r);
+    }
+    next.push(current[current.length - 1]);
+    current = next;
+  }
+
+  return current;
+}
+
+export function stabilizeRoutePointMove(
+  points: MapRoutePoint[],
+  pointId: string,
+  lat: number,
+  lng: number,
+  straightAngleThresholdDeg = 10,
+  snapBackDistanceMeters = 1.5
+): MapRoutePoint[] {
+  const moved = normalizeMapRoutePoints(
+    points.map((point) => (point.id === pointId ? { ...point, lat, lng } : point))
+  );
+  const neighbors = getConnectedRouteNeighbors(moved, pointId);
+  if (neighbors.length !== 2) {
+    return moved;
+  }
+
+  const target = moved.find((point) => point.id === pointId);
+  if (!target) {
+    return moved;
+  }
+
+  const a = neighbors[0];
+  const b = neighbors[1];
+  const angle = getTurnAngleDegrees(a, target, b);
+  if (Math.abs(180 - angle) > straightAngleThresholdDeg) {
+    return moved;
+  }
+
+  const projection = projectPointOntoSegment(target, a, b);
+  const distanceFromSegment = distanceMeters(target, projection.point);
+  if (distanceFromSegment > snapBackDistanceMeters) {
+    return moved;
+  }
+
+  return normalizeMapRoutePoints(
+    moved.map((point) =>
+      point.id === pointId
+        ? {
+            ...point,
+            lat: projection.point.lat,
+            lng: projection.point.lng,
+          }
+        : point
+    )
+  );
 }
 
 export function getEffectiveMapRouteConfig(
@@ -352,4 +670,24 @@ function projectPointOntoSegment(
     },
     t,
   };
+}
+
+function getTurnAngleDegrees(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+  c: { lat: number; lng: number }
+): number {
+  const abx = lngToMeters(a.lng - b.lng, (a.lat + b.lat) / 2);
+  const aby = latToMeters(a.lat - b.lat);
+  const cbx = lngToMeters(c.lng - b.lng, (c.lat + b.lat) / 2);
+  const cby = latToMeters(c.lat - b.lat);
+  const abLength = Math.hypot(abx, aby);
+  const cbLength = Math.hypot(cbx, cby);
+
+  if (abLength === 0 || cbLength === 0) {
+    return 180;
+  }
+
+  const cosine = Math.max(-1, Math.min(1, (abx * cbx + aby * cby) / (abLength * cbLength)));
+  return (Math.acos(cosine) * 180) / Math.PI;
 }

--- a/app/(public)/search/page.tsx
+++ b/app/(public)/search/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
 import SearchClient from "./SearchClient";
 import type { Shop } from "../map/data/shops";
-import { fetchShopsFromDb } from "../map/services/shopDb";
+import { fetchVendorShopsFromDb } from "../map/services/shopDb";
 import type { Landmark } from "../map/types/landmark";
 import { fetchLandmarksFromDb } from "../map/services/landmarksDb";
 
@@ -16,7 +16,7 @@ async function loadShops(): Promise<Shop[]> {
   try {
     const cookieStore = await cookies();
     const supabase = createClient(cookieStore);
-    return await fetchShopsFromDb(supabase);
+    return await fetchVendorShopsFromDb(supabase);
   } catch {
     return [];
   }

--- a/app/api/admin/map-layout/route.ts
+++ b/app/api/admin/map-layout/route.ts
@@ -412,6 +412,7 @@ export async function PUT(request: NextRequest) {
           latitude: point.lat,
           longitude: point.lng,
           sort_order: index,
+          branch_from_id: point.branchFromId ?? null,
         }))
       );
 

--- a/app/api/admin/map-layout/route.ts
+++ b/app/api/admin/map-layout/route.ts
@@ -3,7 +3,9 @@ import { cookies } from "next/headers";
 import { createClient as createServiceClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createClient as createServerClient } from "@/utils/supabase/server";
 import { fetchLandmarksFromDb } from "@/app/(public)/map/services/landmarksDb";
+import { fetchMapRouteFromDb } from "@/app/(public)/map/services/mapRouteDb";
 import type { Landmark as EditableLandmark } from "@/app/(public)/map/types/landmark";
+import type { MapRouteConfig, MapRoutePoint } from "@/app/(public)/map/types/mapRoute";
 
 type EditableShop = {
   locationId: string;
@@ -25,6 +27,8 @@ type SnapshotSummary = {
   deletedShopCount: number;
   upsertLandmarkCount: number;
   deletedLandmarkCount: number;
+  updatedRoutePointCount: number;
+  routeConfigChanged: boolean;
 };
 
 function getRole(user: unknown) {
@@ -140,10 +144,13 @@ async function createMapLayoutSnapshot(
     loadEditableShops(supabase),
     fetchLandmarksFromDb(supabase),
   ]);
+  const mapRoute = await fetchMapRouteFromDb(supabase);
 
   const { error } = await adminWriteClient.from("map_layout_snapshots").insert({
     shops_json: shops,
     landmarks_json: landmarks,
+    route_json: mapRoute.points,
+    route_config_json: mapRoute.config,
     created_by: createdBy,
     summary,
   });
@@ -165,9 +172,10 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const [editableShops, landmarks, vendorsResult] = await Promise.all([
+    const [editableShops, landmarks, mapRoute, vendorsResult] = await Promise.all([
       loadEditableShops(supabase),
       fetchLandmarksFromDb(supabase),
+      fetchMapRouteFromDb(supabase),
       supabase.from("vendors").select("id, shop_name, owner_name").order("shop_name", { ascending: true }),
     ]);
 
@@ -180,7 +188,7 @@ export async function GET() {
       name: ((row.shop_name as string | null) || (row.owner_name as string | null) || "名称未設定").trim(),
     }));
 
-    return NextResponse.json({ shops: editableShops, landmarks, vendors });
+    return NextResponse.json({ shops: editableShops, landmarks, route: mapRoute, vendors });
   } catch {
     return NextResponse.json({ error: "Failed to load map layout" }, { status: 500 });
   }
@@ -208,15 +216,22 @@ export async function PUT(request: NextRequest) {
         upsert?: EditableLandmark[];
         deletedKeys?: string[];
       };
+      route?: {
+        points?: MapRoutePoint[];
+        config?: MapRouteConfig;
+      };
     };
 
     if (
       !body.shops ||
       !body.landmarks ||
+      !body.route ||
       !Array.isArray(body.shops.updated) ||
       !Array.isArray(body.shops.deletedLocationIds) ||
       !Array.isArray(body.landmarks.upsert) ||
-      !Array.isArray(body.landmarks.deletedKeys)
+      !Array.isArray(body.landmarks.deletedKeys) ||
+      !Array.isArray(body.route.points) ||
+      !body.route.config
     ) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
@@ -225,7 +240,8 @@ export async function PUT(request: NextRequest) {
       body.shops.updated.length > 0 ||
       body.shops.deletedLocationIds.length > 0 ||
       body.landmarks.upsert.length > 0 ||
-      body.landmarks.deletedKeys.length > 0;
+      body.landmarks.deletedKeys.length > 0 ||
+      body.route.points.length > 0;
 
     if (hasChanges) {
       await createMapLayoutSnapshot(supabase, adminWriteClient, user.id, {
@@ -233,6 +249,8 @@ export async function PUT(request: NextRequest) {
         deletedShopCount: body.shops.deletedLocationIds.length,
         upsertLandmarkCount: body.landmarks.upsert.length,
         deletedLandmarkCount: body.landmarks.deletedKeys.length,
+        updatedRoutePointCount: body.route.points.length,
+        routeConfigChanged: Boolean(body.route.config),
       });
     }
 
@@ -376,6 +394,44 @@ export async function PUT(request: NextRequest) {
       if (landmarksError) {
         return NextResponse.json({ error: "Failed to save landmarks" }, { status: 500 });
       }
+    }
+
+    const { error: deleteRoutePointsError } = await adminWriteClient
+      .from("map_route_points")
+      .delete()
+      .neq("id", "");
+
+    if (deleteRoutePointsError) {
+      return NextResponse.json({ error: "Failed to clear route points" }, { status: 500 });
+    }
+
+    if (body.route.points.length > 0) {
+      const { error: routePointsError } = await adminWriteClient.from("map_route_points").insert(
+        body.route.points.map((point, index) => ({
+          id: point.id,
+          latitude: point.lat,
+          longitude: point.lng,
+          sort_order: index,
+        }))
+      );
+
+      if (routePointsError) {
+        return NextResponse.json({ error: "Failed to save route points" }, { status: 500 });
+      }
+    }
+
+    const { error: routeConfigError } = await adminWriteClient.from("map_route_configs").upsert(
+      {
+        key: body.route.config.key,
+        road_half_width_meters: body.route.config.roadHalfWidthMeters,
+        snap_distance_meters: body.route.config.snapDistanceMeters,
+        visible_distance_meters: body.route.config.visibleDistanceMeters,
+      },
+      { onConflict: "key" }
+    );
+
+    if (routeConfigError) {
+      return NextResponse.json({ error: "Failed to save route config" }, { status: 500 });
     }
 
     return NextResponse.json({ ok: true });

--- a/app/api/admin/map-layout/snapshots/route.ts
+++ b/app/api/admin/map-layout/snapshots/route.ts
@@ -300,6 +300,7 @@ async function applySnapshot(
         latitude: point.lat,
         longitude: point.lng,
         sort_order: index,
+        branch_from_id: point.branchFromId ?? null,
       }))
     );
     if (error) {

--- a/app/api/admin/map-layout/snapshots/route.ts
+++ b/app/api/admin/map-layout/snapshots/route.ts
@@ -3,7 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createClient as createServerClient } from "@/utils/supabase/server";
 import { fetchLandmarksFromDb } from "@/app/(public)/map/services/landmarksDb";
+import { fetchMapRouteFromDb } from "@/app/(public)/map/services/mapRouteDb";
 import type { Landmark as EditableLandmark } from "@/app/(public)/map/types/landmark";
+import type { MapRouteConfig, MapRoutePoint } from "@/app/(public)/map/types/mapRoute";
 
 type EditableShop = {
   locationId: string;
@@ -20,6 +22,8 @@ type SnapshotSummary = {
   deletedShopCount?: number;
   upsertLandmarkCount?: number;
   deletedLandmarkCount?: number;
+  updatedRoutePointCount?: number;
+  routeConfigChanged?: boolean;
   restoreSourceSnapshotId?: string;
 };
 
@@ -136,10 +140,13 @@ async function createMapLayoutSnapshot(
     loadEditableShops(supabase),
     fetchLandmarksFromDb(supabase),
   ]);
+  const mapRoute = await fetchMapRouteFromDb(supabase);
 
   const { error } = await adminWriteClient.from("map_layout_snapshots").insert({
     shops_json: shops,
     landmarks_json: landmarks,
+    route_json: mapRoute.points,
+    route_config_json: mapRoute.config,
     created_by: createdBy,
     summary,
   });
@@ -152,7 +159,9 @@ async function createMapLayoutSnapshot(
 async function applySnapshot(
   adminWriteClient: SupabaseClient,
   snapshotShops: EditableShop[],
-  snapshotLandmarks: EditableLandmark[]
+  snapshotLandmarks: EditableLandmark[],
+  snapshotRoutePoints: MapRoutePoint[],
+  snapshotRouteConfig: MapRouteConfig | null
 ) {
   const { data: currentLocations, error: currentLocationsError } = await adminWriteClient
     .from("market_locations")
@@ -173,6 +182,14 @@ async function applySnapshot(
     .select("key");
   if (currentLandmarksError) {
     throw new Error("Failed to load current landmarks");
+  }
+
+  const { error: clearRoutePointsError } = await adminWriteClient
+    .from("map_route_points")
+    .delete()
+    .neq("id", "");
+  if (clearRoutePointsError) {
+    throw new Error("Failed to clear current route points");
   }
 
   if (snapshotShops.length > 0) {
@@ -275,6 +292,35 @@ async function applySnapshot(
       throw new Error("Failed to delete extra landmarks during restore");
     }
   }
+
+  if (snapshotRoutePoints.length > 0) {
+    const { error } = await adminWriteClient.from("map_route_points").insert(
+      snapshotRoutePoints.map((point, index) => ({
+        id: point.id,
+        latitude: point.lat,
+        longitude: point.lng,
+        sort_order: index,
+      }))
+    );
+    if (error) {
+      throw new Error("Failed to restore route points");
+    }
+  }
+
+  if (snapshotRouteConfig) {
+    const { error } = await adminWriteClient.from("map_route_configs").upsert(
+      {
+        key: snapshotRouteConfig.key,
+        road_half_width_meters: snapshotRouteConfig.roadHalfWidthMeters,
+        snap_distance_meters: snapshotRouteConfig.snapDistanceMeters,
+        visible_distance_meters: snapshotRouteConfig.visibleDistanceMeters,
+      },
+      { onConflict: "key" }
+    );
+    if (error) {
+      throw new Error("Failed to restore route config");
+    }
+  }
 }
 
 export async function GET() {
@@ -326,7 +372,7 @@ export async function POST(request: NextRequest) {
 
     const { data, error } = await adminWriteClient
       .from("map_layout_snapshots")
-      .select("id, shops_json, landmarks_json")
+      .select("id, shops_json, landmarks_json, route_json, route_config_json")
       .eq("id", body.snapshotId)
       .single();
 
@@ -338,11 +384,24 @@ export async function POST(request: NextRequest) {
     const snapshotLandmarks = Array.isArray(data.landmarks_json)
       ? (data.landmarks_json as EditableLandmark[])
       : [];
+    const snapshotRoutePoints = Array.isArray(data.route_json)
+      ? (data.route_json as MapRoutePoint[])
+      : [];
+    const snapshotRouteConfig =
+      data.route_config_json && typeof data.route_config_json === "object"
+        ? (data.route_config_json as MapRouteConfig)
+        : null;
 
     await createMapLayoutSnapshot(supabase, adminWriteClient, user.id, {
       restoreSourceSnapshotId: body.snapshotId,
     });
-    await applySnapshot(adminWriteClient, snapshotShops, snapshotLandmarks);
+    await applySnapshot(
+      adminWriteClient,
+      snapshotShops,
+      snapshotLandmarks,
+      snapshotRoutePoints,
+      snapshotRouteConfig
+    );
 
     return NextResponse.json({ ok: true });
   } catch {

--- a/app/api/map-agent/route.ts
+++ b/app/api/map-agent/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { fetchShopsFromDb } from "@/app/(public)/map/services/shopDb";
+import { fetchVendorShopsFromDb } from "@/app/(public)/map/services/shopDb";
 
 type Answers = {
   purpose?: string;
@@ -48,7 +48,7 @@ async function loadShops(): Promise<BaseShop[]> {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
     auth: { persistSession: false },
   });
-  const shops = await fetchShopsFromDb(supabase);
+  const shops = await fetchVendorShopsFromDb(supabase);
   return shops.map((shop) => ({
     id: shop.id,
     name: shop.name,

--- a/app/api/shops/route.ts
+++ b/app/api/shops/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { fetchShopsFromDb } from "@/app/(public)/map/services/shopDb";
+import { fetchVendorShopsFromDb } from "@/app/(public)/map/services/shopDb";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -18,7 +18,7 @@ export async function GET() {
   });
 
   try {
-    const shops = await fetchShopsFromDb(supabase);
+    const shops = await fetchVendorShopsFromDb(supabase);
     return NextResponse.json({ shops }, { status: 200 });
   } catch (error) {
     console.error(error);

--- a/app/components/MapLoadingProvider.tsx
+++ b/app/components/MapLoadingProvider.tsx
@@ -13,7 +13,7 @@ type MapLoadingContextValue = {
 
 const MapLoadingContext = createContext<MapLoadingContextValue | null>(null);
 
-const MIN_LOADING_MS = 1300;
+const MIN_LOADING_MS = 120;
 
 export function useMapLoading() {
   const value = useContext(MapLoadingContext);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/supabase/migrations/20260322120000_create_map_route_tables.sql
+++ b/supabase/migrations/20260322120000_create_map_route_tables.sql
@@ -1,0 +1,71 @@
+create table if not exists map_route_points (
+  id text primary key,
+  latitude double precision not null,
+  longitude double precision not null,
+  sort_order integer not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists map_route_points_sort_order_idx
+on map_route_points (sort_order asc);
+
+create table if not exists map_route_configs (
+  key text primary key,
+  road_half_width_meters double precision not null default 15.6,
+  snap_distance_meters double precision not null default 18,
+  visible_distance_meters double precision not null default 42,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+insert into map_route_configs (
+  key,
+  road_half_width_meters,
+  snap_distance_meters,
+  visible_distance_meters
+)
+values ('default', 15.6, 18, 42)
+on conflict (key) do nothing;
+
+alter table map_route_points enable row level security;
+alter table map_route_configs enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'map_route_points'
+      and policyname = 'public read map_route_points'
+  ) then
+    create policy "public read map_route_points"
+    on map_route_points
+    for select
+    using (true);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'map_route_configs'
+      and policyname = 'public read map_route_configs'
+  ) then
+    create policy "public read map_route_configs"
+    on map_route_configs
+    for select
+    using (true);
+  end if;
+end
+$$;
+
+alter table map_layout_snapshots
+add column if not exists route_json jsonb not null default '[]'::jsonb;
+
+alter table map_layout_snapshots
+add column if not exists route_config_json jsonb not null default '{}'::jsonb;

--- a/supabase/migrations/20260322133000_add_branch_from_id_to_map_route_points.sql
+++ b/supabase/migrations/20260322133000_add_branch_from_id_to_map_route_points.sql
@@ -1,0 +1,5 @@
+alter table map_route_points
+add column if not exists branch_from_id text references map_route_points(id) on delete set null;
+
+create index if not exists map_route_points_branch_from_id_idx
+on map_route_points (branch_from_id);


### PR DESCRIPTION
 ## 概要

  マップ表示と map-edit の両方に、道路・通路データを扱う仕組みを導入しました。
  あわせて、マップの回転・ズーム操作まわりを整理し、表示ロジックの責務分離と編集UIの強化を行っています。

  ## 主な変更

  - 道路・通路データの基盤を追加
  - map_route_points / map_route_configs テーブルを追加
  - 分岐用の branch_from_id を追加
  - スナップショットに route_json / route_config_json を保存するよう対応
  - マップ表示を道路データベース連携ベースに変更
  - mapRoute 型・DB取得処理・幾何計算ユーティリティを追加
  - 道路形状に沿った表示、可視範囲計算、自動回転計算を見直し
  - マップ操作系を整理
  - 2本指ジェスチャーで回転/ズームを扱う独自処理を追加
  - 自動回転の適用しきい値を ±20度 から ±15度 に変更
  - 回転操作後 3秒 は自動回転を抑止するクールダウンを追加
  - ズーム更新を requestAnimationFrame ベースにしてカクつきを軽減
  - 道路レイヤーを非インタラクティブ化し、タッチ対象による挙動差を抑制
  - MapView の責務を分割
  - useMapGestures に入力処理を分離
  - useMapCameraController にカメラ/自動回転制御を分離
  - MapOverlays にオーバーレイ描画を分離
  - map-edit の道路編集機能を追加
  - 道路ポイントの追加・削除・ドラッグ移動に対応
  - 線分途中への挿入、接続ポイント追加、分岐編集に対応
  - 道路設定値（幅、スナップ距離、表示距離）の編集に対応
  - スナップショット保存/復元で道路データも扱うよう対応
  - 関連APIを更新
  - /api/admin/map-layout
  - /api/admin/map-layout/snapshots
  - /api/shops
  - /api/map-agent

  ## 影響範囲

  - app/(public)/map
  - app/(public)/map-edit
  - app/api/admin/map-layout
  - supabase/migrations

  ## 確認

  - npm run build 実行済み
  - Next.js ビルドおよび TypeScript チェック通過

  ## 補足

  - 変更範囲はマップ表示だけでなく、道路編集UI・保存API・スナップショット・DB migration を含みます
  - 実機でのタッチ操作感は引き続き確認余地があります
  - 現時点で、回転後3秒経過後の自動回転再開タイミングや、ピンチズーム時の追従解除挙動は仕様確認の余地があり
    ます
