### PR TITLE
test: Add unit tests for lib/storage and lib/auth modules

### DIFF
--- a/lib/auth/AuthContext.test.tsx
+++ b/lib/auth/AuthContext.test.tsx
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from './AuthContext';
+import React from 'react';
+import * as supabaseClientModule from '@/utils/supabase/client';
+
+vi.mock('@/utils/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('AuthContext', () => {
+  let mockSupabaseClient: any;
+  let mockAuthSession: any;
+  let onAuthStateChangeUnsubscribe: any;
+  let authStateChangeCallback: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    onAuthStateChangeUnsubscribe = vi.fn();
+    mockAuthSession = {
+      data: { session: null }
+    };
+
+    mockSupabaseClient = {
+      auth: {
+        getSession: vi.fn().mockImplementation(() => Promise.resolve(mockAuthSession)),
+        onAuthStateChange: vi.fn().mockImplementation((callback) => {
+          authStateChangeCallback = callback;
+          return { data: { subscription: { unsubscribe: onAuthStateChangeUnsubscribe } } };
+        }),
+        signInWithPassword: vi.fn(),
+        signOut: vi.fn().mockResolvedValue({}),
+        updateUser: vi.fn(),
+      }
+    };
+
+    (supabaseClientModule.createClient as any).mockReturnValue(mockSupabaseClient);
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AuthProvider>{children}</AuthProvider>
+  );
+
+  describe('initialization', () => {
+    it('initializes as logged out when no session exists', async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isLoggedIn).toBe(false);
+      expect(result.current.user).toBeNull();
+    });
+
+    it('initializes as logged in when session exists', async () => {
+      mockAuthSession = {
+        data: {
+          session: {
+            user: {
+              id: 'user-1',
+              email: 'test@example.com',
+              app_metadata: {},
+              user_metadata: { full_name: 'Test User' }
+            }
+          }
+        }
+      };
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isLoggedIn).toBe(true);
+      expect(result.current.user).toMatchObject({
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+      });
+    });
+  });
+
+  describe('loginWithCredentials', () => {
+    it('logs in successfully and maps user data', async () => {
+      const mockUser = {
+        id: 'user-2',
+        email: 'vendor@example.com',
+        app_metadata: { role: 'vendor' },
+        user_metadata: { vendorId: 10, full_name: 'Shop Owner' }
+      };
+
+      mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      let loginResult;
+      await act(async () => {
+        loginResult = await result.current.loginWithCredentials(' vendor@example.com ', 'password');
+      });
+
+      expect(mockSupabaseClient.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'vendor@example.com',
+        password: 'password',
+        options: undefined,
+      });
+
+      expect(loginResult).toMatchObject({
+        id: 'user-2',
+        email: 'vendor@example.com',
+        role: 'vendor',
+        vendorId: 10,
+        name: 'Shop Owner',
+      });
+
+      expect(result.current.isLoggedIn).toBe(true);
+      expect(result.current.user).toEqual(loginResult);
+    });
+
+    it('returns null on login failure', async () => {
+      mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+        data: { user: null },
+        error: new Error('Invalid credentials'),
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      let loginResult;
+      await act(async () => {
+        loginResult = await result.current.loginWithCredentials('test@example.com', 'wrong');
+      });
+
+      expect(loginResult).toBeNull();
+      expect(result.current.isLoggedIn).toBe(false);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('updates user profile successfully', async () => {
+      mockAuthSession = {
+        data: {
+          session: {
+            user: {
+              id: 'user-1',
+              email: 'old@example.com',
+              app_metadata: {},
+              user_metadata: { name: 'Old Name' }
+            }
+          }
+        }
+      };
+
+      mockSupabaseClient.auth.updateUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-1',
+            email: 'new@example.com',
+            app_metadata: {},
+            user_metadata: { name: 'New Name', phone: '1234' }
+          }
+        },
+        error: null
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.updateProfile({
+          name: 'New Name',
+          email: 'new@example.com',
+          phone: '1234',
+          avatarUrl: undefined
+        });
+      });
+
+      expect(mockSupabaseClient.auth.updateUser).toHaveBeenCalledWith({
+        data: { name: 'New Name', phone: '1234', avatarUrl: '' },
+        email: 'new@example.com',
+      });
+
+      expect(result.current.user).toMatchObject({
+        name: 'New Name',
+        email: 'new@example.com',
+        phone: '1234'
+      });
+    });
+
+    it('does nothing if no user is logged in', async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.updateProfile({ name: 'Test' });
+      });
+
+      expect(mockSupabaseClient.auth.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logout', () => {
+    it('logs out user and resets state', async () => {
+      mockAuthSession = {
+        data: {
+          session: {
+            user: { id: 'user-1', email: 'test@example.com', app_metadata: {}, user_metadata: {} }
+          }
+        }
+      };
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isLoggedIn).toBe(true);
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
+      expect(result.current.isLoggedIn).toBe(false);
+      expect(result.current.user).toBeNull();
+    });
+  });
+
+  describe('permissions', () => {
+    it('calculates super admin permissions', async () => {
+      mockAuthSession = {
+        data: {
+          session: {
+            user: { id: 'admin', email: 'admin@example.com', app_metadata: { role: 'super_admin' }, user_metadata: {} }
+          }
+        }
+      };
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => { expect(result.current.isLoading).toBe(false); });
+
+      const p = result.current.permissions;
+      expect(p.isSuperAdmin).toBe(true);
+      expect(p.canManageAllShops).toBe(true);
+      expect(p.canModerateContent).toBe(true);
+      expect(p.canEditShop(10)).toBe(true); // Super admin can edit any shop
+    });
+
+    it('calculates vendor permissions', async () => {
+      mockAuthSession = {
+        data: {
+          session: {
+            user: { id: 'vendor', email: 'vendor@example.com', app_metadata: { role: 'vendor' }, user_metadata: { vendorId: 10 } }
+          }
+        }
+      };
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => { expect(result.current.isLoading).toBe(false); });
+
+      const p = result.current.permissions;
+      expect(p.isVendor).toBe(true);
+      expect(p.isSuperAdmin).toBe(false);
+      expect(p.canEditShop(10)).toBe(true); // Can edit own shop
+      expect(p.canEditShop(20)).toBe(false); // Cannot edit other shops
+    });
+  });
+
+  describe('auth state change listener', () => {
+    it('updates state when session changes externally', async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => { expect(result.current.isLoading).toBe(false); });
+
+      expect(result.current.isLoggedIn).toBe(false);
+
+      act(() => {
+        authStateChangeCallback('SIGNED_IN', {
+          user: { id: 'new-user', email: 'new@example.com', app_metadata: {}, user_metadata: {} }
+        });
+      });
+
+      expect(result.current.isLoggedIn).toBe(true);
+      expect(result.current.user?.id).toBe('new-user');
+
+      act(() => {
+        authStateChangeCallback('SIGNED_OUT', null);
+      });
+
+      expect(result.current.isLoggedIn).toBe(false);
+      expect(result.current.user).toBeNull();
+    });
+  });
+
+  describe('useAuth without provider', () => {
+    it('throws error if used outside provider', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => renderHook(() => useAuth())).toThrow('useAuth must be used within an AuthProvider');
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/lib/consultVisitorKey.test.ts
+++ b/lib/consultVisitorKey.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { getOrCreateConsultVisitorKey } from './consultVisitorKey';
+
+describe('consultVisitorKey', () => {
+  const CONSULT_VISITOR_KEY_STORAGE_KEY = "nicchyo-consult-visitor-key";
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null if window is undefined', () => {
+    const originalWindow = global.window;
+    // @ts-ignore
+    delete global.window;
+    expect(getOrCreateConsultVisitorKey()).toBeNull();
+    global.window = originalWindow;
+  });
+
+  it('returns existing key if present in localStorage', () => {
+    const existingKey = 'visitor-123-abc';
+    localStorage.setItem(CONSULT_VISITOR_KEY_STORAGE_KEY, existingKey);
+    expect(getOrCreateConsultVisitorKey()).toBe(existingKey);
+  });
+
+  it('generates a new key using randomUUID if available', () => {
+    const originalCrypto = window.crypto;
+    const mockUUID = 'mock-uuid-1234';
+
+    // Setup mock crypto with randomUUID
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        randomUUID: vi.fn().mockReturnValue(mockUUID),
+      },
+      configurable: true,
+    });
+
+    const result = getOrCreateConsultVisitorKey();
+
+    expect(result).toBe(mockUUID);
+    expect(window.crypto.randomUUID).toHaveBeenCalled();
+    expect(localStorage.getItem(CONSULT_VISITOR_KEY_STORAGE_KEY)).toBe(mockUUID);
+
+    // Restore original
+    Object.defineProperty(window, 'crypto', { value: originalCrypto, configurable: true });
+  });
+
+  it('generates a fallback key if randomUUID is not available', () => {
+    const originalCrypto = window.crypto;
+
+    // Ensure randomUUID is not available
+    Object.defineProperty(window, 'crypto', {
+      value: {},
+      configurable: true,
+    });
+
+    vi.setSystemTime(new Date(1600000000000));
+
+    // Mock Math.random to return predictable slice
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.123456789);
+
+    const result = getOrCreateConsultVisitorKey();
+
+    // '0.123456789'.toString(36) behaves differently across engines, so we just check prefix and length roughly
+    expect(result).toMatch(/^visitor-1600000000000-/);
+    expect(localStorage.getItem(CONSULT_VISITOR_KEY_STORAGE_KEY)).toBe(result);
+
+    randomSpy.mockRestore();
+    // Restore original
+    Object.defineProperty(window, 'crypto', { value: originalCrypto, configurable: true });
+  });
+});

--- a/lib/storage/BagContext.test.tsx
+++ b/lib/storage/BagContext.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act, render, screen } from '@testing-library/react';
+import { BagProvider, useBag } from './BagContext';
+import React, { useEffect } from 'react';
+
+const STORAGE_KEY = 'nicchyo-fridge-items';
+
+describe('BagContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <BagProvider>{children}</BagProvider>
+  );
+
+  describe('initialization', () => {
+    it('loads items from localStorage on mount', () => {
+      const mockItems = [{ id: '1', name: 'Tomato', createdAt: 12345 }];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      expect(result.current.items).toEqual(mockItems);
+    });
+
+    it('handles invalid JSON in localStorage safely', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid-json');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      expect(result.current.items).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith('[BagContext] Failed to load bag items:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('starts empty when localStorage is empty', () => {
+      const { result } = renderHook(() => useBag(), { wrapper });
+      expect(result.current.items).toEqual([]);
+    });
+  });
+
+  describe('addItem', () => {
+    it('adds an item to the bag and saves to localStorage (debounced)', () => {
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      act(() => {
+        result.current.addItem({ name: 'Apple', price: 100 });
+      });
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0]).toMatchObject({
+        name: 'Apple',
+        price: 100
+      });
+      expect(result.current.items[0].id).toBeDefined();
+      expect(result.current.items[0].createdAt).toBeDefined();
+
+      // Before timeout, localStorage is empty
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // After timeout, it's saved
+      const savedItems = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(savedItems).toHaveLength(1);
+      expect(savedItems[0].name).toBe('Apple');
+    });
+
+    it('prevents adding duplicates', () => {
+      const { result } = renderHook(() => useBag(), { wrapper });
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      act(() => {
+        result.current.addItem({ name: 'Apple', fromShopId: 1 });
+      });
+
+      expect(result.current.items).toHaveLength(1);
+
+      // Add exactly the same name and shop ID
+      act(() => {
+        result.current.addItem({ name: 'apple ', fromShopId: 1 });
+      });
+
+      expect(result.current.items).toHaveLength(1); // Still 1
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[BagContext] Item already exists:', 'apple ');
+
+      // Add same name, different shop ID (should add)
+      act(() => {
+        result.current.addItem({ name: 'Apple', fromShopId: 2 });
+      });
+
+      expect(result.current.items).toHaveLength(2);
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('removeItem', () => {
+    it('removes an item by id', () => {
+      const mockItems = [
+        { id: '1', name: 'Tomato', createdAt: 100 },
+        { id: '2', name: 'Potato', createdAt: 200 }
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      act(() => {
+        result.current.removeItem('1');
+      });
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].id).toBe('2');
+    });
+  });
+
+  describe('updateItem', () => {
+    it('updates an existing item by id', () => {
+      const mockItems = [
+        { id: '1', name: 'Tomato', price: 100, createdAt: 100 }
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      act(() => {
+        result.current.updateItem('1', { price: 200, qty: '2 pcs' });
+      });
+
+      expect(result.current.items[0]).toMatchObject({
+        name: 'Tomato',
+        price: 200,
+        qty: '2 pcs'
+      });
+    });
+  });
+
+  describe('isInBag', () => {
+    it('checks if item is in bag by name and optionally shopId', () => {
+      const mockItems = [
+        { id: '1', name: 'Tomato', fromShopId: 10, createdAt: 100 },
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      expect(result.current.isInBag('tomato')).toBe(true); // Ignore case
+      expect(result.current.isInBag(' Tomato ')).toBe(true); // Ignore whitespace
+      expect(result.current.isInBag('Potato')).toBe(false);
+
+      expect(result.current.isInBag('Tomato', 10)).toBe(true); // Matching shopId
+      expect(result.current.isInBag('Tomato', 20)).toBe(false); // Different shopId
+    });
+  });
+
+  describe('clearBag', () => {
+    it('clears all items', () => {
+      const mockItems = [
+        { id: '1', name: 'Tomato', createdAt: 100 },
+        { id: '2', name: 'Potato', createdAt: 200 }
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      act(() => {
+        result.current.clearBag();
+      });
+
+      expect(result.current.items).toEqual([]);
+    });
+  });
+
+  describe('totalPrice', () => {
+    it('calculates total price correctly', () => {
+      const mockItems = [
+        { id: '1', name: 'Tomato', price: 100, createdAt: 100 },
+        { id: '2', name: 'Potato', price: 250, createdAt: 200 },
+        { id: '3', name: 'Onion', createdAt: 300 } // No price
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      expect(result.current.totalPrice).toBe(350);
+    });
+  });
+
+  describe('storage event sync', () => {
+    it('syncs state when storage event fires from another tab', () => {
+      const { result } = renderHook(() => useBag(), { wrapper });
+
+      expect(result.current.items).toEqual([]);
+
+      const mockItems = [{ id: '99', name: 'Remote Item', createdAt: 999 }];
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: STORAGE_KEY,
+            newValue: JSON.stringify(mockItems),
+          })
+        );
+      });
+
+      expect(result.current.items).toEqual(mockItems);
+    });
+
+    it('clears state when storage event fires with empty newValue', () => {
+      const mockItems = [{ id: '99', name: 'Remote Item', createdAt: 999 }];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockItems));
+
+      const { result } = renderHook(() => useBag(), { wrapper });
+      expect(result.current.items).toHaveLength(1);
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: STORAGE_KEY,
+            newValue: null,
+          })
+        );
+      });
+
+      expect(result.current.items).toEqual([]);
+    });
+  });
+
+  describe('useBag without provider', () => {
+    it('throws error if used outside provider', () => {
+      // Temporarily suppress console.error for expected thrown error
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => renderHook(() => useBag())).toThrow('useBag must be used within BagProvider');
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/lib/storage/marketStats.test.ts
+++ b/lib/storage/marketStats.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  incrementBannerOpens,
+  getBannerOpens,
+  recordMarketEnter,
+  recordMarketExit,
+  getAccumulatedMarketTimeMs,
+} from './marketStats';
+
+describe('marketStats', () => {
+  let originalWindow: typeof window;
+
+  beforeEach(() => {
+    // Save original window and localStorage
+    originalWindow = global.window;
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    // Restore window
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('bannerOpens', () => {
+    it('returns 0 when there are no banner opens', () => {
+      expect(getBannerOpens()).toBe(0);
+    });
+
+    it('increments banner opens correctly', () => {
+      incrementBannerOpens();
+      expect(getBannerOpens()).toBe(1);
+
+      incrementBannerOpens();
+      expect(getBannerOpens()).toBe(2);
+    });
+
+    it('handles undefined window safely for getBannerOpens', () => {
+      const originalWindow = global.window;
+      // @ts-ignore
+      delete global.window;
+      expect(getBannerOpens()).toBe(0);
+      global.window = originalWindow;
+    });
+
+    it('handles undefined window safely for incrementBannerOpens', () => {
+      const originalWindow = global.window;
+      // @ts-ignore
+      delete global.window;
+      expect(() => incrementBannerOpens()).not.toThrow();
+      global.window = originalWindow;
+    });
+  });
+
+  describe('marketTimeMs', () => {
+    it('records market enter and sets entry timestamp', () => {
+      vi.setSystemTime(new Date(1000));
+      recordMarketEnter();
+      expect(localStorage.getItem('nicchyo-market-entry-ts')).toBe('1000');
+    });
+
+    it('does not overwrite entry timestamp if already entered', () => {
+      vi.setSystemTime(new Date(1000));
+      recordMarketEnter();
+
+      vi.setSystemTime(new Date(2000));
+      recordMarketEnter();
+      expect(localStorage.getItem('nicchyo-market-entry-ts')).toBe('1000');
+    });
+
+    it('handles undefined window safely for recordMarketEnter', () => {
+      const originalWindow = global.window;
+      // @ts-ignore
+      delete global.window;
+      expect(() => recordMarketEnter()).not.toThrow();
+      global.window = originalWindow;
+    });
+
+    it('calculates accumulated time correctly while entered', () => {
+      vi.setSystemTime(new Date(1000));
+      recordMarketEnter();
+
+      vi.setSystemTime(new Date(2500));
+      expect(getAccumulatedMarketTimeMs()).toBe(1500);
+    });
+
+    it('records exit and accumulates time', () => {
+      vi.setSystemTime(new Date(1000));
+      recordMarketEnter();
+
+      vi.setSystemTime(new Date(3000));
+      recordMarketExit();
+
+      expect(localStorage.getItem('nicchyo-market-entry-ts')).toBeNull();
+      expect(localStorage.getItem('nicchyo-market-time-ms')).toBe('2000');
+      expect(getAccumulatedMarketTimeMs()).toBe(2000);
+    });
+
+    it('does nothing on exit if never entered', () => {
+      recordMarketExit();
+      expect(localStorage.getItem('nicchyo-market-time-ms')).toBeNull();
+    });
+
+    it('accumulates time correctly across multiple sessions', () => {
+      // Session 1
+      vi.setSystemTime(new Date(1000));
+      recordMarketEnter();
+      vi.setSystemTime(new Date(3000));
+      recordMarketExit(); // 2000ms
+
+      // Session 2
+      vi.setSystemTime(new Date(5000));
+      recordMarketEnter();
+      vi.setSystemTime(new Date(6000));
+
+      // getAccumulatedMarketTimeMs calculates: base(2000) + elapsed(1000) = 3000ms
+      expect(getAccumulatedMarketTimeMs()).toBe(3000);
+
+      recordMarketExit(); // accumulated(3000) + elapsed(1000) = 3000ms total
+      expect(getAccumulatedMarketTimeMs()).toBe(3000);
+    });
+
+    it('handles undefined window safely for recordMarketExit', () => {
+      const originalWindow = global.window;
+      // @ts-ignore
+      delete global.window;
+      expect(() => recordMarketExit()).not.toThrow();
+      global.window = originalWindow;
+    });
+
+    it('handles undefined window safely for getAccumulatedMarketTimeMs', () => {
+      const originalWindow = global.window;
+      // @ts-ignore
+      delete global.window;
+      expect(getAccumulatedMarketTimeMs()).toBe(0);
+      global.window = originalWindow;
+    });
+  });
+});

--- a/lib/storage/marketStats.ts
+++ b/lib/storage/marketStats.ts
@@ -35,8 +35,8 @@ export function recordMarketExit(): void {
   if (!entryTsStr) return;
   const entryTs = parseInt(entryTsStr, 10);
   const elapsed = Date.now() - entryTs;
-  const accumulated = getAccumulatedMarketTimeMs();
-  localStorage.setItem(KEYS.marketTimeMs, String(accumulated + elapsed));
+  const base = parseInt(localStorage.getItem(KEYS.marketTimeMs) ?? "0", 10) || 0;
+  localStorage.setItem(KEYS.marketTimeMs, String(base + elapsed));
   localStorage.removeItem(KEYS.marketEntryTs);
 }
 


### PR DESCRIPTION
## すること
- テスト未作成のコンポーネントに対する単体テストの追加
- 境界値テストおよび正常系・異常系パターンの網羅

## したこと
- `lib/storage/marketStats.ts`, `lib/storage/BagContext.tsx`, `lib/auth/AuthContext.tsx`, `lib/consultVisitorKey.ts` に対するテストファイルを作成しました。
- 以下のテストケースを実装しました：
    - 入力が空の場合の挙動（初期状態、未入場時の退出など）
    - 正常なデータが渡された場合の返り値検証（状態更新、ログイン・ログアウト処理の成功など）
    - エラー発生時（無効なJSON、未定義のwindow環境など）の例外処理確認
- `lib/storage/marketStats.ts` において、退場時に経過時間が二重に加算されるバグを修正しました。

## 目的
- プロジェクトのテストカバレッジを向上させるため
- 将来的なリファクタリング時の安全性を担保するため
- バグの早期発見を促進するため

## 影響
- `marketStats` のバグ修正を除き、プロダクションコードへの大きな変更はありません。
- テスト対象の機能が正しく動作することが保証され、CI/CDパイプラインでのカバレッジ計測値が向上します。

---
*PR created automatically by Jules for task [13983216475996424385](https://jules.google.com/task/13983216475996424385) started by @Yutodesuy*