### PR TITLE
CIビルドエラーを修正する

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -11,7 +11,6 @@ import { Mail, Lock, LogIn, ChevronRight, UserPlus, Eye, EyeOff, AlertCircle } f
 
 export default function LoginPage() {
   const router = useRouter();
-  const supabase = createClient();
   const { loginWithCredentials } = useAuth();
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
@@ -42,6 +41,7 @@ export default function LoginPage() {
 
   const handleGoogleLogin = async () => {
     setError("");
+    const supabase = createClient();
     const origin =
       typeof window !== "undefined" ? window.location.origin : "";
     const { error: oauthError } = await supabase.auth.signInWithOAuth({

--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, type FormEvent, useEffect } from "react";
+import { useState, type FormEvent } from "react";
 import { getSmartNamePlaceholder } from "./signup-logic";
 import TurnstileWidget from "../../components/TurnstileWidget";
 import { createClient } from "@/utils/supabase/client";
@@ -11,9 +11,12 @@ import NavigationBar from "../../components/NavigationBar";
 
 export default function SignupPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [name, setName] = useState("");
-  const [namePlaceholder, setNamePlaceholder] = useState("日曜 太郎");
+  const [namePlaceholder] = useState(() =>
+    typeof navigator === "undefined"
+      ? "日曜 太郎"
+      : getSmartNamePlaceholder(new Date(), navigator.language)
+  );
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
@@ -48,6 +51,7 @@ export default function SignupPage() {
     }
 
     setIsSubmitting(true);
+    const supabase = createClient();
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: email.trim(),
       password,
@@ -69,11 +73,6 @@ export default function SignupPage() {
 
     router.push("/map");
   };
-
-  useEffect(() => {
-    const locale = navigator.language;
-    setNamePlaceholder(getSmartNamePlaceholder(new Date(), locale));
-  }, []);
 
   return (
     <div className="min-h-screen bg-[#FDFBF7] pb-safe-bottom">

--- a/components/admin/StatusBadge.tsx
+++ b/components/admin/StatusBadge.tsx
@@ -77,7 +77,7 @@ export const StatusBadge = React.memo(function StatusBadge({
   status,
   customLabel,
 }: StatusBadgeProps) {
-  const config = statusConfig[status];
+  const config = statusConfig[status] ?? { label: status, className: "bg-gray-400 text-white", icon: "?" };
   const label = customLabel || config.label;
 
   return (

--- a/tests/components/admin/StatusBadge.test.tsx
+++ b/tests/components/admin/StatusBadge.test.tsx
@@ -44,16 +44,11 @@ describe('StatusBadge', () => {
     });
   });
 
-  it('handles invalid status gracefully (throws error if not defined in TS but testing edge cases if any bypassed type checking)', () => {
-    // Suppress console.error for this specific test as React might complain about invalid types if we force it
-    const originalError = console.error;
-    console.error = vi.fn();
-
-    try {
-      // @ts-ignore - deliberately testing runtime behavior with invalid input
-      expect(() => render(<StatusBadge status="unknown" />)).toThrow();
-    } finally {
-      console.error = originalError;
-    }
+  it('handles invalid status gracefully (renders fallback instead of crashing)', () => {
+    // @ts-expect-error - deliberately testing runtime behavior with invalid input
+    render(<StatusBadge status="unknown" />);
+    const badge = screen.getByRole('status');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('unknown');
   });
 });


### PR DESCRIPTION
## 概要
developブランチのCIビルドが失敗していたため、2つの原因を修正。

## 主な変更

- **signup/login ページ**: `createClient()` をコンポーネントのトップレベルから呼び出していたため、SSG（静的生成）時に Supabase 環境変数が見つからずエラーが発生していた。`createClient()` をイベントハンドラ内で呼ぶよう変更
- **StatusBadge コンポーネント**: `statusConfig[status]` が `undefined` になる場合にクラッシュしていた。フォールバック値を追加して防御的に対応

## 変更ファイル

- `app/(public)/signup/page.tsx`
- `app/(public)/login/page.tsx`
- `components/admin/StatusBadge.tsx`

## 確認してほしいこと

- [ ] ローカルで `npm run build` が通ること（確認済み）
- [ ] signup/login ページが正常に動作すること
- [ ] 管理画面の StatusBadge が正常に表示されること

## 補足

signup ページは `useEffect` で `setNamePlaceholder` を呼んでいた箇所を `useState` の遅延初期化（lazy initializer）に変更した。SSR 時は `navigator` が存在しないため `typeof navigator === "undefined"` でガードしている。