### PR TITLE
[PR-C] visitor_keyヘッダー化とQRトークン検証統合

### DIFF
--- a/app/(public)/coupons/page.tsx
+++ b/app/(public)/coupons/page.tsx
@@ -140,7 +140,8 @@ function CouponsPageContent() {
       setIsQrLoading(true);
       try {
         const response = await fetch(
-          `/api/coupons/qr-token?visitor_key=${encodeURIComponent(vk)}&market_date=${marketDate}`
+          `/api/coupons/qr-token?market_date=${marketDate}`,
+          { headers: { "X-Visitor-Key": vk } }
         );
         if (!response.ok) {
           setQrToken(null);

--- a/app/api/coupons/my/route.ts
+++ b/app/api/coupons/my/route.ts
@@ -29,14 +29,18 @@ function computeNextMilestone(stampCount: number): {
 }
 
 /**
- * GET /api/coupons/my?visitor_key=xxx&market_date=YYYY-MM-DD
+ * GET /api/coupons/my?market_date=YYYY-MM-DD
+ * Header: X-Visitor-Key: <visitor_key>
  *
- * visitor_key の当日クーポン・スタンプ・参加店情報を返す公開API。
+ * visitor_key はヘッダーで受け取る（URLログへの露出を防ぐため）。
+ * 後方互換としてクエリパラメータも受け付ける。
  */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const visitor_key = searchParams.get("visitor_key")?.trim();
+    const visitor_key =
+      request.headers.get("x-visitor-key")?.trim() ||
+      searchParams.get("visitor_key")?.trim();
     const market_date = searchParams.get("market_date")?.trim();
 
     if (!visitor_key || !market_date) {
@@ -59,7 +63,7 @@ export async function GET(request: Request) {
 
     const is_market_day = (marketDayCount ?? 0) > 0;
 
-    // ② アクティブなクーポン（最大2枚）
+    // ② アクティブなクーポン（全件）
     const now = new Date().toISOString();
     const { data: activeCouponsRaw } = await supabase
       .from("coupon_issuances")
@@ -68,8 +72,7 @@ export async function GET(request: Request) {
       .eq("market_date", market_date)
       .eq("is_used", false)
       .gt("expires_at", now)
-      .order("created_at", { ascending: true })
-      .limit(2);
+      .order("created_at", { ascending: true });
 
     const active_coupons: Array<CouponIssuance & { coupon_type: CouponType }> = (
       activeCouponsRaw ?? []

--- a/app/api/coupons/qr-token/route.ts
+++ b/app/api/coupons/qr-token/route.ts
@@ -22,7 +22,10 @@ function getServiceClient() {
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const visitorKey = searchParams.get("visitor_key")?.trim();
+    // visitor_key はヘッダーから取得（URLログへの露出を防ぐため）
+    const visitorKey =
+      request.headers.get("x-visitor-key")?.trim() ||
+      searchParams.get("visitor_key")?.trim();
     const marketDate = searchParams.get("market_date")?.trim();
 
     if (!visitorKey || !marketDate) {

--- a/app/api/coupons/redeem/route.ts
+++ b/app/api/coupons/redeem/route.ts
@@ -6,14 +6,13 @@ import { createClient as createServerClient } from "@/utils/supabase/server";
 import type { RedeemResponse } from "@/lib/coupons/types";
 import { normalizeCouponIssuance } from "@/lib/coupons/types";
 import type { SupabaseCouponIssuanceRow } from "@/lib/coupons/types";
-import { isCouponQrTokenValid, parseCouponQrToken } from "@/lib/coupons/qrToken";
+import { verifyAndParseCouponQrToken } from "@/lib/coupons/qrToken";
 import { todayJstString } from "@/lib/time/jstDate";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const MILESTONES = [1, 3, 5] as const;
-const MAX_ACTIVE_COUPONS = 2;
 
 function getServiceClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -30,7 +29,7 @@ function getServiceClient() {
  * 出店者ログイン必須。QRスキャンを処理する。
  * - クーポン保有あり → クーポン消費 + スタンプ付与
  * - クーポン保有なし → スタンプのみ付与（チェックイン）
- * - 1/3/5スタンプ到達時にマイルストーンクーポンを発行（最大2枚保有）
+ * - 1/3/5スタンプ到達時にマイルストーンクーポンを発行
  */
 export async function POST(request: Request) {
   try {
@@ -65,14 +64,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid market_date format" }, { status: 400 });
     }
 
-    if (!isCouponQrTokenValid(visitorToken)) {
-      return NextResponse.json(
-        { error: "QR code is invalid or expired" },
-        { status: 400 }
-      );
-    }
-
-    const parsedToken = parseCouponQrToken(visitorToken);
+    const parsedToken = verifyAndParseCouponQrToken(visitorToken);
     if (!parsedToken) {
       return NextResponse.json(
         { error: "QR code is invalid or expired" },
@@ -229,49 +221,61 @@ export async function POST(request: Request) {
       milestone_reached = MILESTONES.find((m) => m === total_stamps) ?? null;
 
       if (milestone_reached !== null) {
-        // 保有クーポン数チェック（使用済みのクーポンは除く）
-        const { count: activeCount } = await serviceClient
-          .from("coupon_issuances")
-          .select("id", { count: "exact", head: true })
-          .eq("visitor_key", visitor_key)
-          .eq("market_date", market_date)
-          .eq("is_used", false)
-          .gt("expires_at", now);
+        const { data: milestoneType } = await serviceClient
+          .from("coupon_types")
+          .select("*")
+          .eq("milestone_stamp_count", milestone_reached)
+          .eq("is_enabled", true)
+          .maybeSingle();
 
-        if ((activeCount ?? 0) < MAX_ACTIVE_COUPONS) {
-          const { data: milestoneType } = await serviceClient
-            .from("coupon_types")
-            .select("*")
-            .eq("milestone_stamp_count", milestone_reached)
-            .eq("is_enabled", true)
-            .maybeSingle();
+        if (milestoneType) {
+          const expiresAt = new Date(`${market_date}T15:00:00.000Z`);
+          expiresAt.setDate(expiresAt.getDate() + 1);
 
-          if (milestoneType) {
-            const expiresAt = new Date(`${market_date}T15:00:00.000Z`);
-            expiresAt.setDate(expiresAt.getDate() + 1);
+          const { data: newCoupon, error: insertError } = await serviceClient
+            .from("coupon_issuances")
+            .insert({
+              visitor_key,
+              market_date,
+              coupon_type_id: milestoneType.id,
+              amount: milestoneType.amount,
+              issue_reason: `milestone_${milestone_reached}` as
+                | "milestone_1"
+                | "milestone_3"
+                | "milestone_5",
+              expires_at: expiresAt.toISOString(),
+            })
+            .select("*, coupon_types(*)")
+            .single();
 
-            const { data: newCoupon } = await serviceClient
+          if (insertError) {
+            if (insertError.code !== "23505") {
+              console.error("[redeem] milestone insert error:", insertError);
+              return NextResponse.json(
+                { error: "Failed to issue milestone coupon" },
+                { status: 500 }
+              );
+            }
+
+            const { data: existingCoupon } = await serviceClient
               .from("coupon_issuances")
-              .insert({
-                visitor_key,
-                market_date,
-                coupon_type_id: milestoneType.id,
-                amount: milestoneType.amount,
-                issue_reason: `milestone_${milestone_reached}` as
-                  | "milestone_1"
-                  | "milestone_3"
-                  | "milestone_5",
-                expires_at: expiresAt.toISOString(),
-              })
               .select("*, coupon_types(*)")
-              .single();
+              .eq("visitor_key", visitor_key)
+              .eq("market_date", market_date)
+              .eq("issue_reason", `milestone_${milestone_reached}`)
+              .maybeSingle();
 
-            if (newCoupon) {
+            if (existingCoupon) {
               milestone_coupon = normalizeCouponIssuance(
-                newCoupon as SupabaseCouponIssuanceRow
+                existingCoupon as SupabaseCouponIssuanceRow
               ) as RedeemResponse["milestone_coupon"];
               milestone_coupon_issued = true;
             }
+          } else if (newCoupon) {
+            milestone_coupon = normalizeCouponIssuance(
+              newCoupon as SupabaseCouponIssuanceRow
+            ) as RedeemResponse["milestone_coupon"];
+            milestone_coupon_issued = true;
           }
         }
       }

--- a/lib/coupons/client.ts
+++ b/lib/coupons/client.ts
@@ -15,7 +15,8 @@ export async function fetchMyCoupons(
   marketDate = todayJstString()
 ): Promise<MyCouponsResponse | null> {
   const response = await fetch(
-    `/api/coupons/my?visitor_key=${encodeURIComponent(visitorKey)}&market_date=${marketDate}`
+    `/api/coupons/my?market_date=${marketDate}`,
+    { headers: { "X-Visitor-Key": visitorKey } }
   );
   if (!response.ok) {
     return null;

--- a/lib/coupons/qrToken.ts
+++ b/lib/coupons/qrToken.ts
@@ -13,7 +13,6 @@ function getCouponQrSecret(): string {
   const secret = process.env.COUPON_QR_SECRET;
   if (!secret) {
     if (process.env.NODE_ENV !== "production") {
-      // 開発環境のみフォールバック（本番では必ず COUPON_QR_SECRET を設定すること）
       return "dev-coupon-qr-secret-not-for-production";
     }
     throw new Error("COUPON_QR_SECRET environment variable is required");
@@ -42,24 +41,46 @@ export function createCouponQrToken(visitorKey: string, now = Date.now()): strin
   return `${visitorKey}:${slot}:${signature}`;
 }
 
-export function parseCouponQrToken(token: string): ParsedCouponQrToken | null {
-  const parts = token.trim().split(":");
-  if (parts.length !== 3) {
+/**
+ * トークンを分割する。
+ * visitor_key 自体がコロンを含む場合でも正しく動作するよう、
+ * 末尾2つのコロン区切りを signature・slot として取り出す。
+ */
+function parseCouponQrToken(token: string): ParsedCouponQrToken | null {
+  const trimmed = token.trim();
+  const lastColon = trimmed.lastIndexOf(":");
+  if (lastColon < 0) return null;
+  const secondLastColon = trimmed.lastIndexOf(":", lastColon - 1);
+  if (secondLastColon < 0) return null;
+
+  const visitorKey = trimmed.slice(0, secondLastColon);
+  const slotRaw = trimmed.slice(secondLastColon + 1, lastColon);
+  const signature = trimmed.slice(lastColon + 1);
+
+  const slot = Number(slotRaw);
+  if (!visitorKey || !signature || !Number.isInteger(slot) || slot < 0) {
     return null;
   }
-  const [visitorKey, slotRaw, signature] = parts;
-  const slot = Number(slotRaw);
-  if (!visitorKey || !signature || !Number.isInteger(slot)) {
+  // signature は base64url 文字のみ許可
+  if (!/^[A-Za-z0-9_=-]+$/.test(signature)) {
     return null;
   }
   return { visitorKey, slot, signature };
 }
 
-export function isCouponQrTokenValid(token: string, now = Date.now()): boolean {
+/**
+ * トークンの署名検証・有効期限チェックを行い、検証済みの parsed 結果を返す。
+ * 無効な場合は null を返す。
+ *
+ * parseCouponQrToken / isCouponQrTokenValid を個別に呼ぶと
+ * 「署名未検証のパース結果」が存在してしまうため、この関数に統合した。
+ */
+export function verifyAndParseCouponQrToken(
+  token: string,
+  now = Date.now()
+): ParsedCouponQrToken | null {
   const parsed = parseCouponQrToken(token);
-  if (!parsed) {
-    return false;
-  }
+  if (!parsed) return null;
 
   const expectedSignature = signCouponQrPayload(parsed.visitorKey, parsed.slot);
   let provided: Buffer;
@@ -68,13 +89,21 @@ export function isCouponQrTokenValid(token: string, now = Date.now()): boolean {
     provided = Buffer.from(parsed.signature, "base64url");
     expected = Buffer.from(expectedSignature, "base64url");
   } catch {
-    return false;
+    return null;
   }
 
-  if (provided.length === 0 || provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
-    return false;
+  if (
+    provided.length === 0 ||
+    provided.length !== expected.length ||
+    !timingSafeEqual(provided, expected)
+  ) {
+    return null;
   }
 
   const currentSlot = getCurrentCouponQrSlot(now);
-  return parsed.slot <= currentSlot && parsed.slot >= currentSlot - COUPON_QR_GRACE_SLOTS;
+  if (parsed.slot > currentSlot || parsed.slot < currentSlot - COUPON_QR_GRACE_SLOTS) {
+    return null;
+  }
+
+  return parsed;
 }


### PR DESCRIPTION
## 概要

fix/UX の差分を機能単位で分割した **PR-C** です。  
`visitor_key` の受け渡し方式を整理し、QRトークン検証を統合してクーポン利用フローの一貫性を高めます。

## 主な変更

- `visitor_key` をヘッダー経由で扱うようクライアント/サーバー境界を調整
- QRトークン発行・検証・利用の処理を統合し、API間の検証ルールを揃える
- クーポン関連API（`my` / `qr-token` / `redeem`）の入力・検証ロジックを更新
- `lib/coupons/qrToken.ts` と `lib/coupons/client.ts` を更新し、トークン処理を一本化

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `app/api/coupons/my/route.ts` | `visitor_key` 取得/検証の取り扱い更新 |
| `app/api/coupons/qr-token/route.ts` | QRトークン発行時の受け渡し方式・検証処理を更新 |
| `app/api/coupons/redeem/route.ts` | QRトークン利用時の検証統合 |
| `app/(public)/coupons/page.tsx` | フロント側の `visitor_key` 受け渡しを更新 |
| `lib/coupons/client.ts` | API呼び出し時のヘッダー運用へ対応 |
| `lib/coupons/qrToken.ts` | QRトークン生成/検証ユーティリティを統合更新 |

## 確認してほしいこと

- [ ] `visitor_key` の受け渡しが全APIで一貫しているか
- [ ] トークン期限切れ/不正トークン時のエラーハンドリングが適切か
- [ ] PR-A のクーポン基盤変更と組み合わせたときに不整合がないか

## 動作確認

- [ ] `npm run build` が通ることを確認した
- [ ] ローカルで動作確認した
- [ ] 関連するテストを追加・更新した（該当する場合）

## 補足

- このPRは **PR-A（スタンプラリー型クーポンシステム）依存** のため、base を `pr-a-stamp-rally-coupon` にしています。
