### PR TITLE
PR-C: Cookie同意バナー刷新と analytics consent 改善

### DIFF
--- a/app/(public)/map/components/UserLocationMarker.tsx
+++ b/app/(public)/map/components/UserLocationMarker.tsx
@@ -95,7 +95,7 @@ export default function UserLocationMarker({
   }, [isTracking, map]);
 
   useEffect(() => {
-    if (locationConsent !== "accepted") {
+    if (locationConsent === "declined") {
       onLocationUpdateRef.current?.(false, MARKET_CENTER);
     }
   }, [locationConsent]);

--- a/app/(public)/map/components/UserLocationMarker.tsx
+++ b/app/(public)/map/components/UserLocationMarker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef } from 'react';
+import { useConsentValue } from '@/lib/analytics/consentClient';
 import { useMap } from 'react-leaflet';
 import L from 'leaflet';
 import type { MapRouteConfig, MapRoutePoint } from '../types/mapRoute';
@@ -58,6 +59,7 @@ export default function UserLocationMarker({
   // 初回位置取得フラグ（マップを位置に移動させるため）
   const isFirstLocationRef = useRef(true);
   const routeVisibleRef = useRef(false);
+  const locationConsent = useConsentValue("location");
   const effectiveRoutePoints = useMemo(() => {
     const activeRoutePoints = normalizeMapRoutePoints(routePoints ?? []);
     return activeRoutePoints.length >= 2 ? activeRoutePoints : getDefaultMapRoutePoints();
@@ -92,6 +94,12 @@ export default function UserLocationMarker({
     }
   }, [isTracking, map]);
 
+  useEffect(() => {
+    if (locationConsent !== "accepted") {
+      onLocationUpdateRef.current?.(false, MARKET_CENTER);
+    }
+  }, [locationConsent]);
+
   // Handle device orientation
   useEffect(() => {
     const handleOrientation = (event: DeviceOrientationEvent) => {
@@ -118,6 +126,10 @@ export default function UserLocationMarker({
   }, []);
 
   useEffect(() => {
+    if (locationConsent !== "accepted") {
+      return;
+    }
+
     if (!map) return;
 
     // Create marker with direction arrow structure
@@ -356,7 +368,7 @@ export default function UserLocationMarker({
     return () => {
       removeMarker();
     };
-  }, [effectiveRouteConfig, effectiveRoutePoints, map, routeSegments, suppressInitialFocus]);
+  }, [effectiveRouteConfig, effectiveRoutePoints, locationConsent, map, routeSegments, suppressInitialFocus]);
 
   return null;
 }

--- a/app/(public)/map/hooks/useTimeBadge.ts
+++ b/app/(public)/map/hooks/useTimeBadge.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useConsentValue } from '@/lib/analytics/consentClient';
 import { claimTimeBadge, type TimeBadgeResult } from '../services/timeBadgeService';
 
 type PriorityState = {
@@ -9,8 +10,14 @@ type PriorityState = {
 export function useTimeBadge() {
   const [priority, setPriority] = useState<PriorityState | null>(null);
   const tickingRef = useRef(false);
+  const locationConsent = useConsentValue("location");
 
   useEffect(() => {
+    if (locationConsent !== "accepted") {
+      tickingRef.current = false;
+      return;
+    }
+
     let intervalId: number | null = null;
 
     const tick = () => {
@@ -67,7 +74,7 @@ export function useTimeBadge() {
       stop();
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, []);
+  }, [locationConsent]);
 
   const clearPriority = () => setPriority(null);
 

--- a/app/components/CookieConsent.tsx
+++ b/app/components/CookieConsent.tsx
@@ -1,70 +1,200 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { getConsent, setConsent, loadGA } from "@/lib/analytics/consentClient";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+
+import {
+  getAnalyticsConsent,
+  getLocationConsent,
+  loadGA,
+  setAnalyticsConsent,
+  setLocationConsent,
+  type ConsentValue,
+} from "@/lib/analytics/consentClient";
+
+type ConsentChoice = Exclude<ConsentValue, null>;
 
 export default function CookieConsent() {
-  const [consent, setLocalConsent] = useState<string | null>(null);
+  const [analyticsConsent, setAnalyticsConsentState] = useState<ConsentValue>(null);
+  const [locationConsent, setLocationConsentState] = useState<ConsentValue>(null);
+  const [showDetail, setShowDetail] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
   useEffect(() => {
-    const stored = getConsent();
-    setLocalConsent(stored);
-    if (stored === "accepted") {
-      const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-      if (gaId && process.env.NODE_ENV === "production") {
-        loadGA(gaId);
-      }
-    }
-  }, []);
-
-  if (consent !== null) return null; // already decided
-
-  const accept = () => {
-    setConsent("accepted");
-    setLocalConsent("accepted");
-    // GAをここで初期化してから page_view を送る
-    const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-    if (gaId && process.env.NODE_ENV === "production") {
+    const storedAnalytics = getAnalyticsConsent();
+    const storedLocation = getLocationConsent();
+    setAnalyticsConsentState(storedAnalytics);
+    setLocationConsentState(storedLocation);
+    if (storedAnalytics === "accepted" && gaId && process.env.NODE_ENV === "production") {
       loadGA(gaId);
     }
-    // GAスクリプト読み込み後に page_view を送信
-    setTimeout(() => {
-      try {
-        const w = window as Window & { gtag?: (...args: unknown[]) => void };
-        if (typeof w?.gtag === "function") {
-          w.gtag("event", "page_view", { page_path: window.location.pathname + window.location.search });
-        }
-      } catch {}
-    }, 1000);
+    setIsReady(true);
+  }, [gaId]);
+
+  useEffect(() => {
+    if (analyticsConsent === "accepted" && gaId && process.env.NODE_ENV === "production") {
+      loadGA(gaId);
+    }
+  }, [analyticsConsent, gaId]);
+
+  const needsPrompt = analyticsConsent === null || locationConsent === null;
+
+  const persist = (nextAnalytics: ConsentChoice, nextLocation: ConsentChoice) => {
+    setAnalyticsConsent(nextAnalytics);
+    setLocationConsent(nextLocation);
+    setAnalyticsConsentState(nextAnalytics);
+    setLocationConsentState(nextLocation);
   };
 
-  const decline = () => {
-    setConsent("declined");
-    setLocalConsent("declined");
+  const acceptAll = () => persist("accepted", "accepted");
+  const declineAll = () => persist("declined", "declined");
+  const savePreferences = () => {
+    persist(
+      analyticsConsent === "accepted" ? "accepted" : "declined",
+      locationConsent === "accepted" ? "accepted" : "declined"
+    );
   };
+
+  if (!isReady || !needsPrompt) return null;
 
   return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 pointer-events-none">
-      <div className="bg-white/95 text-sm rounded-lg shadow-lg p-4 max-w-3xl w-[90%] md:w-auto pointer-events-auto">
-        <div className="flex flex-col md:flex-row md:items-center md:gap-4">
-          <div className="flex-1 text-gray-800">
-            本サイトでは利用状況把握のために Google Analytics を利用しています。解析データの収集に同意しますか？
+    <div className="fixed inset-x-0 bottom-0 z-[9999] p-3 sm:p-4">
+      <div className="mx-auto max-w-2xl rounded-2xl border border-gray-200 bg-white shadow-xl">
+
+        {/* メインバナー */}
+        {!showDetail ? (
+          <div className="px-5 py-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-gray-700 leading-relaxed">
+                🍪 当サイトはサービス改善のため Cookie および位置情報を利用します。詳細は
+                <Link href="/privacy" className="mx-1 text-green-600 underline underline-offset-2 hover:text-green-700">
+                  プライバシーポリシー
+                </Link>
+                をご確認ください。
+              </p>
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={acceptAll}
+                className="rounded-lg bg-green-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-600"
+              >
+                すべて許可
+              </button>
+              <button
+                type="button"
+                onClick={declineAll}
+                className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-50"
+              >
+                拒否する
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowDetail(true)}
+                className="px-2 py-2 text-sm text-gray-400 underline underline-offset-2 hover:text-gray-600"
+              >
+                設定を変更
+              </button>
+            </div>
           </div>
-          <div className="mt-3 md:mt-0 flex gap-2">
-            <button
-              className="bg-nicchyo-primary text-white px-3 py-1 rounded"
-              onClick={accept}
-            >
-              同意する
-            </button>
-            <button
-              className="bg-gray-200 text-gray-800 px-3 py-1 rounded"
-              onClick={decline}
-            >
-              同意しない
-            </button>
+        ) : (
+          /* 詳細設定パネル */
+          <div className="px-5 py-4">
+            <div className="mb-4 flex items-center justify-between">
+              <p className="text-sm font-semibold text-gray-800">Cookie の設定</p>
+              <button
+                type="button"
+                onClick={() => setShowDetail(false)}
+                className="flex h-7 w-7 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                aria-label="閉じる"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {/* 必須 */}
+              <div className="flex items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-800">必須 Cookie</p>
+                  <p className="mt-0.5 text-xs text-gray-500">サービスの動作に必要なため、常に有効です。</p>
+                </div>
+                <span className="shrink-0 rounded-full bg-gray-200 px-2.5 py-1 text-xs font-medium text-gray-500">
+                  常に有効
+                </span>
+              </div>
+
+              {/* 解析 */}
+              <label className="flex cursor-pointer items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-800">解析 Cookie</p>
+                  <p className="mt-0.5 text-xs text-gray-500">Google Analytics による利用状況の計測に使います。</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={analyticsConsent === "accepted"}
+                  onClick={() =>
+                    setAnalyticsConsentState(analyticsConsent === "accepted" ? "declined" : "accepted")
+                  }
+                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none ${
+                    analyticsConsent === "accepted" ? "bg-green-500" : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                      analyticsConsent === "accepted" ? "translate-x-5" : "translate-x-0.5"
+                    }`}
+                  />
+                </button>
+              </label>
+
+              {/* 位置情報 */}
+              <label className="flex cursor-pointer items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-800">位置情報</p>
+                  <p className="mt-0.5 text-xs text-gray-500">現在地表示や周辺案内のために使います。</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={locationConsent === "accepted"}
+                  onClick={() =>
+                    setLocationConsentState(locationConsent === "accepted" ? "declined" : "accepted")
+                  }
+                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none ${
+                    locationConsent === "accepted" ? "bg-green-500" : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                      locationConsent === "accepted" ? "translate-x-5" : "translate-x-0.5"
+                    }`}
+                  />
+                </button>
+              </label>
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={savePreferences}
+                className="flex-1 rounded-lg bg-green-500 py-2 text-sm font-semibold text-white transition hover:bg-green-600"
+              >
+                設定を保存
+              </button>
+              <button
+                type="button"
+                onClick={acceptAll}
+                className="flex-1 rounded-lg border border-gray-300 bg-white py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-50"
+              >
+                すべて許可
+              </button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app/components/CookieConsent.tsx
+++ b/app/components/CookieConsent.tsx
@@ -127,8 +127,8 @@ export default function CookieConsent() {
               </div>
 
               {/* 解析 */}
-              <label className="flex cursor-pointer items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-                <div>
+              <div className="flex items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                <div id="analytics-label">
                   <p className="text-sm font-medium text-gray-800">解析 Cookie</p>
                   <p className="mt-0.5 text-xs text-gray-500">Google Analytics による利用状況の計測に使います。</p>
                 </div>
@@ -136,10 +136,11 @@ export default function CookieConsent() {
                   type="button"
                   role="switch"
                   aria-checked={analyticsConsent === "accepted"}
+                  aria-labelledby="analytics-label"
                   onClick={() =>
                     setAnalyticsConsentState(analyticsConsent === "accepted" ? "declined" : "accepted")
                   }
-                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none ${
+                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 ${
                     analyticsConsent === "accepted" ? "bg-green-500" : "bg-gray-300"
                   }`}
                 >
@@ -149,11 +150,11 @@ export default function CookieConsent() {
                     }`}
                   />
                 </button>
-              </label>
+              </div>
 
               {/* 位置情報 */}
-              <label className="flex cursor-pointer items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
-                <div>
+              <div className="flex items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                <div id="location-label">
                   <p className="text-sm font-medium text-gray-800">位置情報</p>
                   <p className="mt-0.5 text-xs text-gray-500">現在地表示や周辺案内のために使います。</p>
                 </div>
@@ -161,10 +162,11 @@ export default function CookieConsent() {
                   type="button"
                   role="switch"
                   aria-checked={locationConsent === "accepted"}
+                  aria-labelledby="location-label"
                   onClick={() =>
                     setLocationConsentState(locationConsent === "accepted" ? "declined" : "accepted")
                   }
-                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none ${
+                  className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 ${
                     locationConsent === "accepted" ? "bg-green-500" : "bg-gray-300"
                   }`}
                 >
@@ -174,7 +176,7 @@ export default function CookieConsent() {
                     }`}
                   />
                 </button>
-              </label>
+              </div>
             </div>
 
             <div className="mt-4 flex gap-2">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import type { Metadata, Viewport } from "next";
-import Script from "next/script";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth/AuthContext";
 import { MenuProvider } from "@/lib/ui/MenuContext";
@@ -52,8 +51,6 @@ export const viewport: Viewport = {
   userScalable: true,
   viewportFit: "cover",
 };
-
-const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://nicchyo.jp";
 

--- a/lib/analytics/consentClient.ts
+++ b/lib/analytics/consentClient.ts
@@ -1,17 +1,64 @@
-const CONSENT_KEY = "nicchyo_ga_consent";
+import * as React from "react";
+
+const ANALYTICS_CONSENT_KEY = "nicchyo_analytics_consent";
+const LOCATION_CONSENT_KEY = "nicchyo_location_consent";
+const CONSENT_CHANGE_EVENT = "nicchyo-consent-change";
+
+export type ConsentValue = "accepted" | "declined" | null;
+
+function readConsent(key: string): ConsentValue {
+  if (typeof window === "undefined") return null;
+  const value = window.localStorage.getItem(key);
+  return value === "accepted" || value === "declined" ? value : null;
+}
+
+function writeConsent(key: string, value: Exclude<ConsentValue, null>): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(key, value);
+  window.dispatchEvent(new Event(CONSENT_CHANGE_EVENT));
+}
 
 export function isAnalyticsAllowed(): boolean {
-  return getConsent() === "accepted";
+  return getAnalyticsConsent() === "accepted";
 }
 
-export function getConsent(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(CONSENT_KEY);
+export function isLocationAllowed(): boolean {
+  return getLocationConsent() === "accepted";
 }
 
-export function setConsent(value: "accepted" | "declined"): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(CONSENT_KEY, value);
+export function getAnalyticsConsent(): ConsentValue {
+  return readConsent(ANALYTICS_CONSENT_KEY);
+}
+
+export function getLocationConsent(): ConsentValue {
+  return readConsent(LOCATION_CONSENT_KEY);
+}
+
+export function setAnalyticsConsent(value: Exclude<ConsentValue, null>): void {
+  writeConsent(ANALYTICS_CONSENT_KEY, value);
+}
+
+export function setLocationConsent(value: Exclude<ConsentValue, null>): void {
+  writeConsent(LOCATION_CONSENT_KEY, value);
+}
+
+export function useConsentValue(kind: "analytics" | "location"): ConsentValue {
+  const [value, setValue] = React.useState<ConsentValue>(null);
+
+  React.useEffect(() => {
+    const key = kind === "analytics" ? ANALYTICS_CONSENT_KEY : LOCATION_CONSENT_KEY;
+    const sync = () => setValue(readConsent(key));
+
+    sync();
+    window.addEventListener("storage", sync);
+    window.addEventListener(CONSENT_CHANGE_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(CONSENT_CHANGE_EVENT, sync);
+    };
+  }, [kind]);
+
+  return value;
 }
 
 export function loadGA(gaId: string): void {

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -2,13 +2,21 @@ import { test, expect } from '@playwright/test';
 
 test('cookie consent flow and analytics opt-in', async ({ page }) => {
   await page.goto('/');
-  // Wait for cookie consent to appear
-  const consent = page.locator('text=解析データの収集に同意しますか');
+  const consent = page.locator('text=Cookie と位置情報の利用について');
   await expect(consent).toBeVisible({ timeout: 30000 });
 
-  // Simulate consent by setting localStorage (ensures app behaves as if user accepted)
-  await page.evaluate(() => localStorage.setItem('nicchyo_analytics_consent', 'accepted'));
+  await page.getByRole('button', { name: 'すべて許可して続行' }).click();
+
+  await expect(consent).toBeHidden({ timeout: 30000 });
+
+  const values = await page.evaluate(() => ({
+    analytics: localStorage.getItem('nicchyo_analytics_consent'),
+    location: localStorage.getItem('nicchyo_location_consent'),
+  }));
+
+  expect(values.analytics).toBe('accepted');
+  expect(values.location).toBe('accepted');
+
   await page.reload();
-  const val = await page.evaluate(() => localStorage.getItem('nicchyo_analytics_consent'));
-  expect(val).toBe('accepted');
+  await expect(page.locator('text=Cookie と位置情報の利用について')).toHaveCount(0);
 });

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -2,10 +2,10 @@ import { test, expect } from '@playwright/test';
 
 test('cookie consent flow and analytics opt-in', async ({ page }) => {
   await page.goto('/');
-  const consent = page.locator('text=Cookie と位置情報の利用について');
+  const consent = page.locator('text=当サイトはサービス改善のため Cookie および位置情報を利用します');
   await expect(consent).toBeVisible({ timeout: 30000 });
 
-  await page.getByRole('button', { name: 'すべて許可して続行' }).click();
+  await page.getByRole('button', { name: 'すべて許可' }).first().click();
 
   await expect(consent).toBeHidden({ timeout: 30000 });
 
@@ -18,5 +18,5 @@ test('cookie consent flow and analytics opt-in', async ({ page }) => {
   expect(values.location).toBe('accepted');
 
   await page.reload();
-  await expect(page.locator('text=Cookie と位置情報の利用について')).toHaveCount(0);
+  await expect(page.locator('text=当サイトはサービス改善のため Cookie および位置情報を利用します')).toHaveCount(0);
 });


### PR DESCRIPTION
## 概要
Cookie 同意バナーを標準的な同意 UI に刷新し、analytics と位置情報の同意フローを整理します。GA の読み込みを同意状態に合わせて制御し、位置情報の追跡も同意前提に揃えました。
この PR は PR-B の上に積んでいます。

## 主な変更
- Cookie 同意バナーを 3 選択の一般的な CMP 風 UI に刷新
- 同意バナーのアクセシビリティを修正し、無効な HTML 構造を解消
- `consentClient` から analytics / location consent の参照を整理
- `layout.tsx` の GA 直読み込みをやめ、同意ベースの読み込みへ寄せる
- `UserLocationMarker` と `useTimeBadge` で位置情報 consent を反映
- E2E テストを新 UI と consent フローに合わせて更新

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `app/components/CookieConsent.tsx` | 同意バナーの UI / 挙動 / アクセシビリティを刷新 |
| `lib/analytics/consentClient.ts` | analytics / location consent の取得・判定を整理 |
| `app/(public)/map/components/UserLocationMarker.tsx` / `useTimeBadge.ts` | 位置情報 consent に応じて追跡を制御 |
| `app/layout.tsx` | GA の直接読み込みを削除し、同意側に寄せる |
| `tests/e2e/analytics.spec.ts` | 新しい consent UI と保存挙動に合わせて更新 |

## 確認してほしいこと
- [ ] 解析同意・位置情報同意が同じ導線で自然に取れること
- [ ] 同意前に GA が読み込まれないこと
- [ ] 同意前は位置情報トラッキングが有効にならないこと
- [ ] E2E が新しい同意 UI に追従していること

## 動作確認
- [ ] `npm run build` が通ることを確認した
- [ ] ローカルで動作確認した
- [ ] 関連するテストを追加・更新した（該当する場合）

## 補足
- PR-A / PR-B の変更を前提にした stacked PR です。
- 位置情報 consent を analytics consent と近いタイミングで確認する設計です。