### PR TITLE
fix: Supabase Cookie リフレッシュ漏れと JST 日付ズレを修正

### DIFF
--- a/app/(public)/map/fetch-map-data.ts
+++ b/app/(public)/map/fetch-map-data.ts
@@ -1,6 +1,7 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database.types';
 import { fetchVendorShopsFromDb } from './services/shopDb';
+import { todayJstString } from '@/lib/time/jstDate';
 
 export type AttendanceEstimate = {
   label: string;
@@ -14,7 +15,7 @@ export async function fetchMapData(supabase: SupabaseClient<Database>) {
   let attendanceEstimates: Record<number, AttendanceEstimate> = {};
 
   try {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayJstString();
     const [shops, estimatesResult] = await Promise.all([
       fetchVendorShopsFromDb(supabase),
       supabase.rpc('get_shop_attendance_estimates', {

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,10 +2,13 @@ import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/middleware";
 
 export async function middleware(request: NextRequest) {
-  const { supabase, response } = createClient(request);
+  const { supabase, getResponse } = createClient(request);
 
   // セッション更新（Supabase Auth）
+  // getUser() 内でセッションリフレッシュが起きると createClient 内の supabaseResponse が
+  // 再代入されるため、呼び出し後に getResponse() で最新のレスポンスを取得する
   await supabase.auth.getUser();
+  const supabaseResponse = getResponse();
 
   // ノンスを生成してCSPヘッダーに設定
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -32,9 +35,9 @@ export async function middleware(request: NextRequest) {
     request: { headers: requestHeaders },
   });
 
-  // レスポンスにCSPヘッダーとSupabase Cookieを設定
+  // レスポンスにCSPヘッダーとSupabase Cookieを設定（リフレッシュ後の最新 Cookie を使用）
   res.headers.set("content-security-policy", csp);
-  response.cookies.getAll().forEach(({ name, value }) => {
+  supabaseResponse.cookies.getAll().forEach(({ name, value }) => {
     res.cookies.set(name, value);
   });
 

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -20,7 +20,7 @@ export const createClient = (request: NextRequest) => {
         getUser: async () => ({ data: { user: null }, error: null }),
       },
     };
-    return { supabase: mockSupabase, response: supabaseResponse };
+    return { supabase: mockSupabase, getResponse: () => supabaseResponse };
   }
 
   const supabase = createServerClient(supabaseUrl!, supabaseKey!, {
@@ -30,6 +30,7 @@ export const createClient = (request: NextRequest) => {
       },
       setAll(cookiesToSet) {
         cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        // setAll は supabaseResponse を再代入するため、呼び出し元は getResponse() で最新を取得する
         supabaseResponse = NextResponse.next({ request });
         cookiesToSet.forEach(({ name, value, options }) =>
           supabaseResponse.cookies.set(name, value, options)
@@ -38,5 +39,5 @@ export const createClient = (request: NextRequest) => {
     },
   });
 
-  return { supabase, response: supabaseResponse };
+  return { supabase, getResponse: () => supabaseResponse };
 };


### PR DESCRIPTION
## 概要

PR #253（develop → main）の Codex レビューで指摘された 2 件の P2 バグを修正します。

## 修正内容

### 🔴 middleware: セッションリフレッシュ時に Cookie が消える問題

**原因**

`createClient(request)` の戻り値 `response` は関数呼び出し時点のスナップショットです。`supabase.auth.getUser()` がセッションをリフレッシュすると、内部の `setAll` が `supabaseResponse` を**再代入**しますが、取り出し済みの `response` は古いオブジェクトのまま残ります。そのため `response.cookies.getAll()` が空になり、ブラウザへ新しい認証 Cookie が送られずユーザーがログアウトされます。

**修正**

`utils/supabase/middleware.ts` の戻り値を `response`（静的）から `getResponse()`（ゲッター）に変更。`getUser()` 呼び出し後に `getResponse()` で最新の `supabaseResponse` を取得するようにしました。

```ts
// 変更前
const { supabase, response } = createClient(request);
await supabase.auth.getUser();
response.cookies.getAll().forEach(...); // 古いレスポンスを参照

// 変更後
const { supabase, getResponse } = createClient(request);
await supabase.auth.getUser();
const supabaseResponse = getResponse(); // リフレッシュ後の最新レスポンスを取得
supabaseResponse.cookies.getAll().forEach(...);
```

---

### 🔴 fetch-map-data: JST 00:00〜08:59 に前日の日付が返る問題

**原因**

`new Date().toISOString().slice(0, 10)` は UTC 日付を返します。Vercel のサーバーは UTC で動作するため、JST 0〜8 時台（UTC 前日）は「前の日付」が `get_shop_attendance_estimates` に渡され、日曜市の出店データが取れなくなります（特に日曜朝の開催時間帯に影響）。

**修正**

プロジェクトに既存の `todayJstString()`（`lib/time/jstDate.ts`）を使用するよう変更しました。

```ts
// 変更前
const today = new Date().toISOString().slice(0, 10); // UTC

// 変更後
const today = todayJstString(); // Asia/Tokyo 基準
```

## 関連

- Closes [PR #253](https://github.com/Yutodesuy/nicchyo-platform/pull/253) の Codex レビュー指摘