### PR TITLE
fix: 開発環境でも CSRF Origin チェックを有効にする

### DIFF
--- a/lib/security/requestGuards.test.ts
+++ b/lib/security/requestGuards.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { requireSameOrigin } from './requestGuards';
 
 describe('requestGuards', () => {
@@ -61,19 +61,19 @@ describe('requestGuards', () => {
       }
     });
 
-    it('returns ok when both origin and referer are missing in non-production', () => {
-      vi.stubEnv('NODE_ENV', 'development');
-
-      const req = new Request('https://example.com/api');
+    it('returns ok when both origin and referer are missing on localhost', () => {
+      const req = new Request('http://localhost:3000/api');
       const result = requireSameOrigin(req);
       expect(result.ok).toBe(true);
-
-      vi.unstubAllEnvs();
     });
 
-    it('returns error when both origin and referer are missing in production', async () => {
-      vi.stubEnv('NODE_ENV', 'production');
+    it('returns ok when both origin and referer are missing on 127.0.0.1', () => {
+      const req = new Request('http://127.0.0.1:3000/api');
+      const result = requireSameOrigin(req);
+      expect(result.ok).toBe(true);
+    });
 
+    it('returns error when both origin and referer are missing on non-localhost', async () => {
       const req = new Request('https://example.com/api');
       const result = requireSameOrigin(req);
       expect(result.ok).toBe(false);
@@ -83,8 +83,6 @@ describe('requestGuards', () => {
         const body = await result.response.json();
         expect(body.error).toBe('Origin header required');
       }
-
-      vi.unstubAllEnvs();
     });
   });
 });

--- a/lib/security/requestGuards.ts
+++ b/lib/security/requestGuards.ts
@@ -29,7 +29,8 @@ export function requireSameOrigin(request: Request) {
     }
   }
 
-  if (!origin && !referer && process.env.NODE_ENV === "production") {
+  const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(targetOrigin);
+  if (!origin && !referer && !isLocalhost) {
     return {
       ok: false as const,
       response: NextResponse.json({ error: "Origin header required" }, { status: 403 }),


### PR DESCRIPTION
## 概要

Issue #196 の対応。`lib/security/requestGuards.ts` の Origin チェックが `NODE_ENV === "production"` の場合のみ有効になっており、開発環境で CSRF 保護が機能していなかった問題を修正する。

## 主な変更

- `process.env.NODE_ENV === "production"` による条件分岐を廃止
- リクエスト先 URL が `localhost` / `127.0.0.1` かどうかで判定する方式に変更
- 本番環境では常に Origin/Referer ヘッダーが必須
- 開発環境はリクエスト先が localhost の場合のみ例外として許可（開発フローを壊さない）

## 変更ファイル

- `lib/security/requestGuards.ts`

## 確認してほしいこと

- [ ] 開発環境（localhost）で各APIが正常に動作するか
- [ ] `NODE_ENV` に依存しない判定になっているか

## 補足

`NODE_ENV` ベースの判定だと「開発環境と本番でセキュリティ挙動が異なる」問題があったが、URL ベースの判定にすることで環境変数に依存しない一貫した動作になる。