### PR TITLE
perf: fetchSeasonalProductContext の N+1 クエリを JOIN 1回に削減する

### DIFF
--- a/lib/grandma/vendorSearch.ts
+++ b/lib/grandma/vendorSearch.ts
@@ -98,51 +98,24 @@ export async function fetchSeasonalProductContext(
   supabase: SupabaseClient<Database>,
   seasonId: number
 ): Promise<SeasonalProductRow[]> {
-  const { data: productSeasonRows } = await supabase
+  const { data: rows } = await supabase
     .from("product_seasons")
-    .select("product_id, season_id")
+    .select("products(id, vendor_id, name, vendors(id, shop_name))")
     .eq("season_id", seasonId)
     .limit(24);
 
-  const productIds = (productSeasonRows ?? [])
-    .map((row) => row.product_id)
-    .filter((value): value is string => !!value);
-  if (productIds.length === 0) return [];
-
-  const { data: productsData } = await supabase
-    .from("products")
-    .select("id, vendor_id, name")
-    .in("id", productIds);
-  const products = Array.isArray(productsData) ? productsData : [];
-  if (products.length === 0) return [];
-
-  const vendorIds = Array.from(
-    new Set(
-      products
-        .map((row) => row.vendor_id)
-        .filter((value): value is string => !!value)
-    )
-  );
-  const { data: vendorsData } =
-    vendorIds.length > 0
-      ? await supabase.from("vendors").select("id, shop_name").in("id", vendorIds)
-      : { data: [] as { id: string; shop_name: string | null }[] };
-
-  const vendorNameById = new Map<string, string>();
-  (vendorsData ?? []).forEach((row) => {
-    if (row.id) {
-      vendorNameById.set(row.id, row.shop_name ?? "");
-    }
-  });
+  if (!Array.isArray(rows) || rows.length === 0) return [];
 
   const seasonName = getCurrentSeasonInfo().seasonName;
-  return products
+  return rows
     .map((row) => {
-      if (!row.vendor_id || !row.name) return null;
+      const product = Array.isArray(row.products) ? row.products[0] : row.products;
+      if (!product?.vendor_id || !product?.name) return null;
+      const vendor = Array.isArray(product.vendors) ? product.vendors[0] : product.vendors;
       return {
-        vendorId: row.vendor_id,
-        shopName: vendorNameById.get(row.vendor_id) ?? "",
-        productName: row.name,
+        vendorId: product.vendor_id,
+        shopName: vendor?.shop_name ?? "",
+        productName: product.name,
         seasonName,
       } satisfies SeasonalProductRow;
     })


### PR DESCRIPTION
## 概要

Issue #198 の対応。`lib/grandma/vendorSearch.ts` の `fetchSeasonalProductContext` で発生していた N+1 クエリを Supabase のリレーショナルクエリで1回に統合する。

## 主な変更

**Before（3クエリ）:**
1. `product_seasons` → product_ids 取得
2. `products` → product_ids で IN 検索
3. `vendors` → vendor_ids で IN 検索

**After（1クエリ）:**
```typescript
await supabase
  .from("product_seasons")
  .select("products(id, vendor_id, name, vendors(id, shop_name))")
  .eq("season_id", seasonId)
  .limit(24);
```

## 変更ファイル

- `lib/grandma/vendorSearch.ts`（37行削除・10行追加）

## 確認してほしいこと

- [ ] AI相談（にちよさん）で季節の商品が正しく表示されるか
- [ ] `product_seasons` → `products` → `vendors` のリレーションがDBに正しく設定されているか

## 補足

このクエリはAI相談の応答生成のクリティカルパスにあるため、クエリ削減は応答速度の改善に直結する。Supabaseのリレーショナルクエリは内部的にPostgreSQLのJOINに変換される。