### PR TITLE
perf: 大型コンポーネントの不要な re-render を削減する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
-  merge_group:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  merge_group:
 
 jobs:
   ci:

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import React, { useEffect, useMemo, useState, useRef } from "react";
+import React, { memo, useEffect, useMemo, useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
@@ -185,7 +185,7 @@ function ThinkingDiscussion({ data }: { data: ThinkingEntry[] }) {
   );
 }
 
-export default function GrandmaChatter({
+const GrandmaChatter = memo(function GrandmaChatter({
   comments,
   titleLabel = "おせっかいばあちゃん",
   priorityMessage,
@@ -2043,7 +2043,7 @@ export default function GrandmaChatter({
       )}
     </div>
   );
-}
+});
 
 function pickCommentIcon(comment: { genre: string; text: string }) {
   const text = comment.text;
@@ -2161,3 +2161,5 @@ function ConsultShopSuggestionCard({
     </div>
   );
 }
+
+export default GrandmaChatter;

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -1118,6 +1118,7 @@ const MapView = memo(function MapView({
     [onZoomChange]
   );
 
+  // deps が [] なのは setState 関数のみ参照しているため（React が安定を保証）
   const handleCloseBanner = useCallback(() => {
     setSelectedShop(null);
     setShopBannerOrigin(null);

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -1118,6 +1118,16 @@ const MapView = memo(function MapView({
     [onZoomChange]
   );
 
+  const handleCloseBanner = useCallback(() => {
+    setSelectedShop(null);
+    setShopBannerOrigin(null);
+    setShopBannerInitialSurface("detail");
+    setShopBannerMainSurface("detail");
+  }, []);
+
+  const handleSelectPreviousShop = useCallback(() => handleSelectByOffset(-1), [handleSelectByOffset]);
+  const handleSelectNextShop = useCallback(() => handleSelectByOffset(1), [handleSelectByOffset]);
+
   const landmarkScale = useMemo(() => {
     const factor = Math.pow(1.22, mapUiZoom - 18);
     return Math.min(2.8, Math.max(0.5, factor));
@@ -1381,14 +1391,9 @@ const MapView = memo(function MapView({
             canNavigateBetweenShops={canNavigate}
             selectedShopPosition={selectedShopIndex + 1}
             totalShopCount={shops.length}
-            onSelectPreviousShop={() => handleSelectByOffset(-1)}
-            onSelectNextShop={() => handleSelectByOffset(1)}
-            onClose={() => {
-              setSelectedShop(null);
-              setShopBannerOrigin(null);
-              setShopBannerInitialSurface("detail");
-              setShopBannerMainSurface("detail");
-            }}
+            onSelectPreviousShop={handleSelectPreviousShop}
+            onSelectNextShop={handleSelectNextShop}
+            onClose={handleCloseBanner}
             onAddToBag={handleAddToBag}
             variant={shopBannerVariant}
             originRect={shopBannerOrigin ?? undefined}

--- a/app/(public)/map/components/ShopDetailBanner.tsx
+++ b/app/(public)/map/components/ShopDetailBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { memo, useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { safeJsonParse } from "@/lib/utils/safeJsonParse";
 import type { CSSProperties, RefObject } from "react";
 import Image from "next/image";
@@ -146,7 +146,7 @@ function useCenterBounceTrigger(
 
 
 // ─── Main Component ───────────────────────────────────────────────────────────
-export default function ShopDetailBanner({
+const ShopDetailBanner = memo(function ShopDetailBanner({
   shop,
   onClose,
   onAddToBag,
@@ -180,8 +180,6 @@ export default function ShopDetailBanner({
       min_purchase_amount: number;
     }>;
   } | null>(null);
-  // セッション中のクーポン情報キャッシュ（vendorId → データ）
-  const couponInfoCacheRef = useRef<Map<string, typeof couponInfo>>(new Map());
   const [currentPostIndex, setCurrentPostIndex] = useState(0);
   const [heroImageError, setHeroImageError] = useState(false);
 
@@ -281,18 +279,9 @@ export default function ShopDetailBanner({
       setCouponInfo(null);
       return;
     }
-    const cached = couponInfoCacheRef.current.get(vendorId);
-    if (cached !== undefined) {
-      setCouponInfo(cached);
-      return;
-    }
     fetch(`/api/coupons/shop-info?vendor_id=${encodeURIComponent(vendorId)}`)
       .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        const value = data ?? null;
-        couponInfoCacheRef.current.set(vendorId, value);
-        setCouponInfo(value);
-      })
+      .then((data) => setCouponInfo(data ?? null))
       .catch(() => {
         // クーポン情報取得失敗は無視
       });
@@ -1403,6 +1392,8 @@ export default function ShopDetailBanner({
       )}
     </div>
   );
-}
+});
+
+export default ShopDetailBanner;
 
 

--- a/app/(public)/map/components/ShopDetailBanner.tsx
+++ b/app/(public)/map/components/ShopDetailBanner.tsx
@@ -146,6 +146,43 @@ function useCenterBounceTrigger(
 
 
 // ─── Main Component ───────────────────────────────────────────────────────────
+function areShopDetailBannerPropsEqual(
+  prev: ShopDetailBannerProps,
+  next: ShopDetailBannerProps
+): boolean {
+  // shop は DB 再フェッチで参照が変わることがあるため id で比較する
+  if (prev.shop.id !== next.shop.id) return false;
+  // stampedVendorIds は配列なので内容で比較する
+  const ps = prev.stampedVendorIds ?? [];
+  const ns = next.stampedVendorIds ?? [];
+  if (ps.length !== ns.length || ps.some((id, i) => id !== ns[i])) return false;
+  // originRect はオブジェクトなので各フィールドで比較する
+  if (
+    prev.originRect?.x !== next.originRect?.x ||
+    prev.originRect?.y !== next.originRect?.y ||
+    prev.originRect?.width !== next.originRect?.width ||
+    prev.originRect?.height !== next.originRect?.height
+  ) return false;
+  // 残りは primitive または useCallback / setState で安定した参照
+  return (
+    prev.bagCount === next.bagCount &&
+    prev.onClose === next.onClose &&
+    prev.onAddToBag === next.onAddToBag &&
+    prev.variant === next.variant &&
+    prev.layout === next.layout &&
+    prev.openNonce === next.openNonce &&
+    prev.initialMobileSurface === next.initialMobileSurface &&
+    prev.onMobileMainSurfaceChange === next.onMobileMainSurfaceChange &&
+    prev.canNavigateBetweenShops === next.canNavigateBetweenShops &&
+    prev.selectedShopPosition === next.selectedShopPosition &&
+    prev.totalShopCount === next.totalShopCount &&
+    prev.onSelectPreviousShop === next.onSelectPreviousShop &&
+    prev.onSelectNextShop === next.onSelectNextShop &&
+    prev.activeCouponTypeId === next.activeCouponTypeId &&
+    prev.reserveBottomNavSpace === next.reserveBottomNavSpace
+  );
+}
+
 const ShopDetailBanner = memo(function ShopDetailBanner({
   shop,
   onClose,
@@ -1392,7 +1429,7 @@ const ShopDetailBanner = memo(function ShopDetailBanner({
       )}
     </div>
   );
-});
+}, areShopDetailBannerPropsEqual);
 
 export default ShopDetailBanner;
 


### PR DESCRIPTION
## 概要

Issue #200 の対応。`ShopDetailBanner` と `GrandmaChatter` に `React.memo` を適用し、親コンポーネントの無関係な state 変更による不要な re-render を防ぐ。

## 主な変更

### `React.memo` 適用
- `ShopDetailBanner` — `memo(function ShopDetailBanner({...}))` に変更
- `GrandmaChatter` — `memo(function GrandmaChatter({...}))` に変更

### `MapView.tsx` — inline 矢印関数を `useCallback` に抽出
memo の効果を有効にするため、ShopDetailBanner に渡す inline 関数を安定した参照に変更：

| 変更前 | 変更後 |
|---|---|
| `onSelectPreviousShop={() => handleSelectByOffset(-1)}` | `handleSelectPreviousShop`（useCallback） |
| `onSelectNextShop={() => handleSelectByOffset(1)}` | `handleSelectNextShop`（useCallback） |
| `onClose={() => { setSelectedShop(null); ... }}` | `handleCloseBanner`（useCallback） |

### `ShopDetailBanner` — `couponInfoCacheRef` 削除
- `couponInfoCacheRef`（useRef の Map）と `couponInfo`（useState）の二重管理を解消
- コンポーネントは `key` プロパティでリマウントされるためセッション内キャッシュが機能していなかった
- `couponInfo` state のみに統一し、フェッチロジックを簡略化

## 変更ファイル

- `app/(public)/map/components/ShopDetailBanner.tsx`
- `app/(public)/map/components/GrandmaChatter.tsx`
- `app/(public)/map/components/MapView.tsx`

## 確認してほしいこと

- [ ] 店舗バナーが正常に開閉するか
- [ ] 店舗ナビゲーション（前へ・次へ）が動作するか
- [ ] クーポン情報が正しく表示されるか