### PR TITLE
ci: Merge Queue 対応のため merge_group トリガーを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  merge_group:
 
 jobs:
   ci:


### PR DESCRIPTION
## 概要

Merge Queue に追加された PR が「Waiting for status to be reported」のまま動かない問題を修正します。

## 主な変更

- `.github/workflows/ci.yml` に `merge_group:` トリガーを追加

## 変更ファイル

- `.github/workflows/ci.yml`

## 原因

GitHub の Merge Queue は `merge_group` イベントで CI を起動します。従来の設定は `push` と `pull_request` しか監視していなかったため、キュー内では CI が走らず永遠に「Waiting for status to be reported」になっていました。

## 確認してほしいこと

- [ ] このPRをマージ後、他のPRをMerge Queueに追加してCIが正常に走ること

## 補足

このPR自体もMerge Queue を通る必要があるため、`merge_group` トリガーを含めた状態でキューに入れれば自己適用されます。