### PR TITLE
fix: user_metadata.role フォールバックを削除して権限昇格脆弱性を修正する

### DIFF
--- a/app/api/admin/audit-logs/route.ts
+++ b/app/api/admin/audit-logs/route.ts
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const r = user as { app_metadata?: { role?: string }; user_metadata?: { role?: string } };
-  return r.app_metadata?.role ?? r.user_metadata?.role ?? null;
+  return r.app_metadata?.role ?? null;
 }
 function isAdmin(role: string | null) {
   return role === "super_admin" || role === "admin";

--- a/app/api/admin/content/[id]/route.ts
+++ b/app/api/admin/content/[id]/route.ts
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const r = user as { app_metadata?: { role?: string }; user_metadata?: { role?: string } };
-  return r.app_metadata?.role ?? r.user_metadata?.role ?? null;
+  return r.app_metadata?.role ?? null;
 }
 function isAdminRole(role: string | null) {
   return role === "super_admin" || role === "admin";

--- a/app/api/admin/danger/route.ts
+++ b/app/api/admin/danger/route.ts
@@ -14,7 +14,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 type DangerAction = "clean-map-history" | "delete-analytics";

--- a/app/api/admin/kotodute/[id]/route.ts
+++ b/app/api/admin/kotodute/[id]/route.ts
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const r = user as { app_metadata?: { role?: string }; user_metadata?: { role?: string } };
-  return r.app_metadata?.role ?? r.user_metadata?.role ?? null;
+  return r.app_metadata?.role ?? null;
 }
 function canModerate(role: string | null) {
   return role === "super_admin" || role === "admin" || role === "moderator";

--- a/app/api/admin/kotodute/bulk/route.ts
+++ b/app/api/admin/kotodute/bulk/route.ts
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const r = user as { app_metadata?: { role?: string }; user_metadata?: { role?: string } };
-  return r.app_metadata?.role ?? r.user_metadata?.role ?? null;
+  return r.app_metadata?.role ?? null;
 }
 function canModerate(role: string | null) {
   return role === "super_admin" || role === "admin" || role === "moderator";

--- a/app/api/admin/map-layout/route.ts
+++ b/app/api/admin/map-layout/route.ts
@@ -63,7 +63,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {

--- a/app/api/admin/map-layout/snapshots/route.ts
+++ b/app/api/admin/map-layout/snapshots/route.ts
@@ -35,7 +35,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -12,7 +12,7 @@ export const dynamic = "force-dynamic";
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const r = user as { app_metadata?: { role?: string }; user_metadata?: { role?: string } };
-  return r.app_metadata?.role ?? r.user_metadata?.role ?? null;
+  return r.app_metadata?.role ?? null;
 }
 function canModerate(role: string | null) {
   return role === "super_admin" || role === "admin" || role === "moderator";

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -44,7 +44,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {

--- a/app/api/admin/shops/bulk/route.ts
+++ b/app/api/admin/shops/bulk/route.ts
@@ -20,7 +20,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 export async function POST(request: Request) {

--- a/app/api/admin/shops/route.ts
+++ b/app/api/admin/shops/route.ts
@@ -37,7 +37,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 export async function GET() {

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -14,7 +14,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {

--- a/app/api/admin/users/bulk/route.ts
+++ b/app/api/admin/users/bulk/route.ts
@@ -16,7 +16,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -39,7 +39,7 @@ function getRole(user: unknown) {
     app_metadata?: { role?: string };
     user_metadata?: { role?: string };
   };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {
@@ -153,7 +153,7 @@ export async function GET() {
 
     const users: AdminUserRecord[] = allUsers.map((authUser) => {
       const vendor = vendorById.get(authUser.id);
-      const role = normalizeRole(authUser.app_metadata?.role ?? authUser.user_metadata?.role);
+      const role = normalizeRole(authUser.app_metadata?.role );
       const name =
         vendor?.shop_name ??
         authUser.user_metadata?.name ??

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -50,7 +50,7 @@ function mapSupabaseUser(user: SupabaseUser): User {
     phone?: string;
   } | undefined;
 
-  const role = normalizeRole(appMeta?.role ?? userMeta?.role);
+  const role = normalizeRole(appMeta?.role);
   const vendorId = getVendorId(userMeta?.vendorId);
   const name = userMeta?.name ?? userMeta?.full_name ?? (user.email ? user.email.split("@")[0] : "user");
   const avatarUrl = userMeta?.avatarUrl ?? userMeta?.avatar_url;


### PR DESCRIPTION
## 概要

Issue #203 の対応です。`user_metadata.role` を認可判定に使用していた脆弱性を修正します。

## 問題

`user_metadata` はユーザー自身が `supabase.auth.updateUser()` で書き換え可能なため、一般ユーザーが `role: 'super_admin'` を自己申告して全 admin API にアクセスできてしまう状態でした。

修正前（脆弱）: `record.app_metadata?.role ?? record.user_metadata?.role ?? null`
修正後（安全）: `record.app_metadata?.role ?? null`

`app_metadata` は service_role key からのみ書き換え可能です。

## 主な変更

- `lib/auth/AuthContext.tsx`: `?? userMeta?.role` フォールバックを削除
- `app/api/admin/` 配下 14 ファイルの `getRole()` 関数から `?? user_metadata?.role` を削除

## 変更ファイル

- `lib/auth/AuthContext.tsx`
- `app/api/admin/` 配下 14 ファイル

## ⚠️ マージ前に必須の確認作業

[Supabase SQL Editor](https://supabase.com/dashboard/project/dbaufykimgzfgoeyyxwz/sql/new) で以下のクエリを実行し、`要移行` のユーザーがいないことを確認してください。

```sql
SELECT
  id,
  email,
  app_metadata->>'role'       AS app_role,
  raw_user_meta_data->>'role' AS user_role,
  CASE
    WHEN app_metadata->>'role' IS NOT NULL          THEN '✅ 安全（app_metadata）'
    WHEN raw_user_meta_data->>'role' IS NOT NULL    THEN '⚠️ 要移行（user_metadata のみ）'
    ELSE '一般ユーザー'
  END AS status
FROM auth.users
WHERE
  app_metadata->>'role' IS NOT NULL
  OR raw_user_meta_data->>'role' IS NOT NULL
ORDER BY created_at;
```

### 結果の見方

| status | 意味 | 対応 |
|--------|------|------|
| ✅ 安全（app_metadata） | 問題なし | 不要 |
| ⚠️ 要移行（user_metadata のみ） | マージ後にアクセス不能になる | 下記の手順で移行が必要 |

### ⚠️ 要移行ユーザーがいた場合

Supabase ダッシュボード → Authentication → Users → 該当ユーザー → Edit で `app_metadata` に以下を設定してください。

```json
{ "role": "super_admin" }
```

設定後、再度 SQL で `app_role` に値が入っていることを確認してからマージしてください。

## 確認チェックリスト

- [ ] 上記 SQL を実行して `⚠️ 要移行` のユーザーがいないことを確認した
- [ ] 既存の admin ユーザーが引き続きアクセスできること
