### PR TITLE
#207 管理者・出店者ページにサーバーサイド認証ガードを追加する

### DIFF
--- a/app/(public)/admin/layout.tsx
+++ b/app/(public)/admin/layout.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { createClient } from "@/utils/supabase/server";
+import type { ReactNode } from "react";
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const role = (user?.app_metadata as { role?: string } | undefined)?.role;
+  const isAllowed = role === "super_admin" || role === "admin" || role === "moderator";
+
+  if (!user || !isAllowed) {
+    redirect("/");
+  }
+
+  return <>{children}</>;
+}

--- a/app/(public)/moderator/layout.tsx
+++ b/app/(public)/moderator/layout.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { createClient } from "@/utils/supabase/server";
+import type { ReactNode } from "react";
+
+export default async function ModeratorLayout({ children }: { children: ReactNode }) {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const role = (user?.app_metadata as { role?: string } | undefined)?.role;
+  const isAllowed = role === "super_admin" || role === "admin" || role === "moderator";
+
+  if (!user || !isAllowed) {
+    redirect("/");
+  }
+
+  return <>{children}</>;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,8 +7,25 @@ export async function middleware(request: NextRequest) {
   // セッション更新（Supabase Auth）
   // getUser() 内でセッションリフレッシュが起きると createClient 内の supabaseResponse が
   // 再代入されるため、呼び出し後に getResponse() で最新のレスポンスを取得する
-  await supabase.auth.getUser();
+  const { data: { user } } = await supabase.auth.getUser();
   const supabaseResponse = getResponse();
+
+  // パスベースのアクセス制御
+  const pathname = request.nextUrl.pathname;
+  const appRole = (user?.app_metadata as { role?: string } | undefined)?.role ?? null;
+
+  if (pathname.startsWith("/admin") || pathname.startsWith("/moderator")) {
+    const allowed = appRole === "super_admin" || appRole === "admin" || appRole === "moderator";
+    if (!user || !allowed) {
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+  }
+
+  if (pathname.startsWith("/my-shop")) {
+    if (!user || appRole !== "vendor") {
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+  }
 
   // ノンスを生成してCSPヘッダーに設定
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");


### PR DESCRIPTION
## 概要

Issue #207 対応。管理者・モデレーター・出店者向けページにサーバーサイドの認証ガードを追加する。
`app_metadata.role`（サービスロールのみ書き込み可能な安全な値）を参照し、未認証・権限不足のユーザーをトップへリダイレクトする。

## 主な変更

- **`app/(public)/admin/layout.tsx`（新規）**: Admin 配下の全ページに Server Component ガードを追加。`super_admin` / `admin` / `moderator` 以外はトップへリダイレクト
- **`app/(public)/moderator/layout.tsx`（新規）**: Moderator 配下にも同様のガードを追加
- **`middleware.ts`**: `/admin` / `/moderator` / `/my-shop` パスへのリクエストをミドルウェアレイヤーでも早期ブロック

## 二重ガードの意図

| 層 | 実装 | 役割 |
|----|------|------|
| Middleware | `middleware.ts` | 早期リダイレクト（ページレンダリング前） |
| Layout Server Component | `admin/layout.tsx` 等 | 最終的な権限確認（Supabase getUser） |

ミドルウェアは Edge Runtime で動作し Cookie のみ参照するため、layout.tsx での `getUser()` による最終確認が主防衛ライン。ミドルウェアは UX 上の早期リダイレクトを担う。

## 変更ファイル

- `middleware.ts`
- `app/(public)/admin/layout.tsx`（新規）
- `app/(public)/moderator/layout.tsx`（新規）

## 確認してほしいこと

- [ ] `super_admin` / `admin` / `moderator` ロールのユーザーが `/admin` ページにアクセスできること
- [ ] `vendor` ロールのユーザーが `/my-shop` にアクセスできること
- [ ] 未認証ユーザーが `/admin`・`/moderator`・`/my-shop` にアクセスするとトップへリダイレクトされること
- [ ] 権限不足のユーザー（例: 一般ユーザーが `/admin` に直接アクセス）もリダイレクトされること

## 補足

- `app_metadata.role` のみを参照（`user_metadata.role` は参照しない）。#203 の修正と一貫性あり
- `/vendor/*` パスは `/my-shop` とは別の出店者向け設定ページ。現状は Supabase Auth でのログイン確認のみのため、今回の middleware 保護対象は `/my-shop` のみとした

Closes #207