### PR TITLE
#209 クーポン・アナリティクス API に Origin チェックとレート制限を追加する

### DIFF
--- a/app/api/analytics/coupon-impression/route.ts
+++ b/app/api/analytics/coupon-impression/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import type { DatabaseWithExtensions } from "@/types/database.extensions";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -16,6 +18,16 @@ function getServiceClient() {
 
 export async function POST(request: Request) {
   try {
+    const originCheck = requireSameOrigin(request);
+    if (!originCheck.ok) return originCheck.response;
+
+    const rateLimited = enforceRateLimit(request, {
+      bucket: "analytics-coupon-impression",
+      limit: 30,
+      windowMs: 10 * 60 * 1000,
+    });
+    if (rateLimited) return rateLimited;
+
     const body = (await request.json()) as {
       coupon_id: string;
       visitor_key?: string;

--- a/app/api/analytics/shop-interaction/route.ts
+++ b/app/api/analytics/shop-interaction/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import type { DatabaseWithExtensions } from "@/types/database.extensions";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -16,6 +18,16 @@ function getServiceClient() {
 
 export async function POST(request: Request) {
   try {
+    const originCheck = requireSameOrigin(request);
+    if (!originCheck.ok) return originCheck.response;
+
+    const rateLimited = enforceRateLimit(request, {
+      bucket: "analytics-shop-interaction",
+      limit: 60,
+      windowMs: 10 * 60 * 1000,
+    });
+    if (rateLimited) return rateLimited;
+
     const body = (await request.json()) as {
       visitor_key?: string;
       shop_id: string;

--- a/app/api/coupons/issue-initial/route.ts
+++ b/app/api/coupons/issue-initial/route.ts
@@ -5,6 +5,8 @@ import type { Database } from "@/types/database.types";
 import type { IssueInitialResponse } from "@/lib/coupons/types";
 import { normalizeCouponIssuance } from "@/lib/coupons/types";
 import type { SupabaseCouponIssuanceRow } from "@/lib/coupons/types";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
 
 const IssueInitialBodySchema = z.object({
   visitor_key: z.string().min(1),
@@ -33,6 +35,16 @@ function getServiceClient() {
  */
 export async function POST(request: Request) {
   try {
+    const originCheck = requireSameOrigin(request);
+    if (!originCheck.ok) return originCheck.response;
+
+    const rateLimited = enforceRateLimit(request, {
+      bucket: "coupons-issue-initial",
+      limit: 10,
+      windowMs: 10 * 60 * 1000,
+    });
+    if (rateLimited) return rateLimited;
+
     const isDevCouponOverride = process.env.NODE_ENV !== "production";
     const parsed = IssueInitialBodySchema.safeParse(await request.json());
     if (!parsed.success) {

--- a/app/api/coupons/my/route.ts
+++ b/app/api/coupons/my/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database.types";
 import type { MyCouponsResponse, CouponIssuance, CouponType } from "@/lib/coupons/types";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,6 +24,16 @@ function getServiceClient() {
  */
 export async function GET(request: Request) {
   try {
+    const originCheck = requireSameOrigin(request);
+    if (!originCheck.ok) return originCheck.response;
+
+    const rateLimited = enforceRateLimit(request, {
+      bucket: "coupons-my",
+      limit: 30,
+      windowMs: 10 * 60 * 1000,
+    });
+    if (rateLimited) return rateLimited;
+
     const { searchParams } = new URL(request.url);
     const visitor_key = searchParams.get("visitor_key")?.trim();
     const market_date = searchParams.get("market_date")?.trim();

--- a/app/api/coupons/qr-token/route.ts
+++ b/app/api/coupons/qr-token/route.ts
@@ -6,6 +6,8 @@ import {
   createCouponQrToken,
   getSecondsUntilNextCouponQrSlot,
 } from "@/lib/coupons/qrToken";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,6 +23,16 @@ function getServiceClient() {
 
 export async function GET(request: Request) {
   try {
+    const originCheck = requireSameOrigin(request);
+    if (!originCheck.ok) return originCheck.response;
+
+    const rateLimited = enforceRateLimit(request, {
+      bucket: "coupons-qr-token",
+      limit: 30,
+      windowMs: 10 * 60 * 1000,
+    });
+    if (rateLimited) return rateLimited;
+
     const { searchParams } = new URL(request.url);
     const visitorKey = searchParams.get("visitor_key")?.trim();
     const marketDate = searchParams.get("market_date")?.trim();


### PR DESCRIPTION
## 概要

Issue #209 対応。クーポン関連・アナリティクス API エンドポイントに `requireSameOrigin()` と `enforceRateLimit()` を追加し、外部からの不正利用・発行枠の消費・アナリティクス汚染を防止する。

## 主な変更

| エンドポイント | Origin チェック | レート制限 |
|---------------|---------------|------------|
| `POST /api/coupons/issue-initial` | ✅ | 10件 / 10分 / IP |
| `GET /api/coupons/qr-token` | ✅ | 30件 / 10分 / IP |
| `GET /api/coupons/my` | ✅ | 30件 / 10分 / IP |
| `POST /api/analytics/coupon-impression` | ✅ | 30件 / 10分 / IP |
| `POST /api/analytics/shop-interaction` | ✅ | 60件 / 10分 / IP |

### レート制限値の根拠

- `issue-initial`: 最も重要な保護対象（1日の発行枠を枯渇させる攻撃を防ぐ）。正規ユーザーは1セッションで1回しか呼ばないため 10件/10分 で十分
- `qr-token` / `my`: QRコード表示・クーポン確認は数回程度の操作。30件/10分 は十分な余裕あり
- `shop-interaction`: マップ操作のたびに送信されるため他より緩く 60件/10分

## 変更ファイル

- `app/api/coupons/issue-initial/route.ts`
- `app/api/coupons/qr-token/route.ts`
- `app/api/coupons/my/route.ts`
- `app/api/analytics/coupon-impression/route.ts`
- `app/api/analytics/shop-interaction/route.ts`

## 確認してほしいこと

- [ ] 正規のクーポン発行フロー（マップ初訪問 → issue-initial）が正常に動作すること
- [ ] クーポン確認画面（my / qr-token）が正常に表示されること
- [ ] 店舗インタラクション・クーポンインプレッションのアナリティクスが記録されること

## 補足

Issue #209 では `visitor_key` をサーバー発行 Cookie に切り替えることも改善方針として挙げられていますが、これは大きなアーキテクチャ変更を伴うため、今回のPRでは対応しません。別 Issue での対応を推奨します。

Closes #209