### PR TITLE
#210 クーポン換金フローを SQL 関数でアトミックトランザクション化する

### DIFF
--- a/app/api/coupons/redeem/route.ts
+++ b/app/api/coupons/redeem/route.ts
@@ -162,6 +162,9 @@ export async function POST(request: Request) {
     });
 
     if (rpcError) {
+      // RPC がエラーを返した場合、PostgreSQL トランザクション全体が自動ロールバックされる。
+      // クーポン消費・スタンプ付与・次回クーポン発行はいずれも取り消されており、
+      // DB は呼び出し前の状態に戻っているため、安全にエラーレスポンスを返せる。
       if (rpcError.message?.includes("COUPON_ALREADY_USED")) {
         return NextResponse.json(
           { error: "Coupon already used by another request" },
@@ -172,26 +175,17 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Failed to process redemption" }, { status: 500 });
     }
 
-    const rpc = rpcResult as { is_new_stamp: boolean; next_coupon_id: string | null };
+    // next_coupon は SQL 関数がトランザクション内で coupon_types JOIN 済みのデータを返す。
+    // 別途 SELECT しないため、フェッチ時のレース条件がない。
+    const rpc = rpcResult as { is_new_stamp: boolean; next_coupon: SupabaseCouponIssuanceRow | null };
     const is_new_stamp = rpc.is_new_stamp;
 
-    // 次回クーポンの詳細を取得（発行された場合のみ）
     let next_coupon: RedeemResponse["next_coupon"] = null;
     let next_coupon_issued = false;
 
-    if (rpc.next_coupon_id) {
-      const { data: newCouponRow } = await serviceClient
-        .from("coupon_issuances")
-        .select("*, coupon_types(*)")
-        .eq("id", rpc.next_coupon_id)
-        .single();
-
-      if (newCouponRow) {
-        next_coupon = normalizeCouponIssuance(
-          newCouponRow as SupabaseCouponIssuanceRow
-        ) as RedeemResponse["next_coupon"];
-        next_coupon_issued = true;
-      }
+    if (rpc.next_coupon) {
+      next_coupon = normalizeCouponIssuance(rpc.next_coupon) as RedeemResponse["next_coupon"];
+      next_coupon_issued = true;
     }
 
     // ⑩ 監査ログ

--- a/app/api/coupons/redeem/route.ts
+++ b/app/api/coupons/redeem/route.ts
@@ -35,10 +35,14 @@ function getServiceClient() {
  * - 保有クーポン1枚を消費
  * - スタンプを付与（同日・同店は UPSERT）
  * - 新規スタンプなら次回クーポンを発行（1枚まで / 上限内）
+ *
+ * クーポン消費・スタンプ付与・次回クーポン発行は redeem_coupon SQL 関数で
+ * 1トランザクション内に閉じており、ロールバック不整合と race condition を防止する。
  */
 export async function POST(request: Request) {
   try {
     const isDevCouponOverride = process.env.NODE_ENV !== "production";
+
     // ① 出店者認証
     const cookieStore = await cookies();
     const supabase = createServerClient(cookieStore);
@@ -143,110 +147,50 @@ export async function POST(request: Request) {
       );
     }
 
-    // ⑥ 今日この出店者ですでにスタンプ済みか確認
-    const { data: existingStamp } = await serviceClient
-      .from("coupon_stamps")
-      .select("id")
-      .eq("visitor_key", visitor_key)
-      .eq("vendor_id", vendor_id)
-      .eq("market_date", market_date)
-      .maybeSingle();
+    // ⑥⑦⑧⑨ クーポン消費・スタンプ付与・次回クーポン発行をアトミックに実行
+    // redeem_coupon SQL 関数が1トランザクション内でこれらを完結させる
+    const maxIssuance = couponSettings?.maxDailyIssuance ?? 300;
+    const nextCouponAmount = couponSettings?.amount ?? 50;
 
-    const is_new_stamp = !existingStamp;
+    const { data: rpcResult, error: rpcError } = await serviceClient.rpc("redeem_coupon", {
+      p_coupon_id: couponToUse.id,
+      p_visitor_key: visitor_key,
+      p_vendor_id: vendor_id,
+      p_market_date: market_date,
+      p_max_issuance: maxIssuance,
+      p_next_coupon_amount: nextCouponAmount,
+    });
 
-    // ⑦ クーポン消費（is_used = true）— アトミック更新
-    // .eq("is_used", false) を条件に加えることで、同時リクエストによる二重消費を防ぐ
-    const { data: updatedRows, error: updateError } = await serviceClient
-      .from("coupon_issuances")
-      .update({
-        is_used: true,
-        used_at: now,
-        used_vendor_id: vendor_id,
-      })
-      .eq("id", couponToUse.id)
-      .eq("is_used", false)
-      .select("id");
-
-    if (updateError) {
-      console.error("[redeem] update error:", updateError);
-      return NextResponse.json({ error: "Failed to consume coupon" }, { status: 500 });
+    if (rpcError) {
+      if (rpcError.message?.includes("COUPON_ALREADY_USED")) {
+        return NextResponse.json(
+          { error: "Coupon already used by another request" },
+          { status: 409 }
+        );
+      }
+      console.error("[redeem] rpc error:", rpcError);
+      return NextResponse.json({ error: "Failed to process redemption" }, { status: 500 });
     }
 
-    // 影響行数が 0 = 別リクエストが先に消費済み → 二重消費を拒否
-    if (!updatedRows || updatedRows.length === 0) {
-      return NextResponse.json(
-        { error: "Coupon already used by another request" },
-        { status: 409 }
-      );
-    }
+    const rpc = rpcResult as { is_new_stamp: boolean; next_coupon_id: string | null };
+    const is_new_stamp = rpc.is_new_stamp;
 
-    // ⑧ スタンプ付与（既存なら ignore）
-    const { error: stampError } = await serviceClient
-      .from("coupon_stamps")
-      .upsert(
-        { visitor_key, vendor_id, market_date },
-        { onConflict: "visitor_key,vendor_id,market_date", ignoreDuplicates: true }
-      );
-
-    if (stampError) {
-      // スタンプ付与失敗 → クーポン消費をロールバック
-      console.error("[redeem] stamp upsert error:", stampError);
-      await serviceClient
-        .from("coupon_issuances")
-        .update({ is_used: false, used_at: null, used_vendor_id: null })
-        .eq("id", couponToUse.id);
-      return NextResponse.json({ error: "Failed to record stamp" }, { status: 500 });
-    }
-
-    // ⑨ 新スタンプなら次回クーポンを発行
+    // 次回クーポンの詳細を取得（発行された場合のみ）
     let next_coupon: RedeemResponse["next_coupon"] = null;
     let next_coupon_issued = false;
 
-    if (is_new_stamp) {
-      // 上限チェック
-      const maxIssuance = couponSettings?.maxDailyIssuance ?? 300;
-      const { count: todayCount } = await serviceClient
+    if (rpc.next_coupon_id) {
+      const { data: newCouponRow } = await serviceClient
         .from("coupon_issuances")
-        .select("id", { count: "exact", head: true })
-        .eq("market_date", market_date);
+        .select("*, coupon_types(*)")
+        .eq("id", rpc.next_coupon_id)
+        .single();
 
-      if ((todayCount ?? 0) < maxIssuance) {
-        // 次回クーポンの種類をランダムに選択（is_initial_gift = false のものから）
-        const { data: nextTypes } = await serviceClient
-          .from("coupon_types")
-          .select("*")
-          .eq("is_enabled", true)
-          .order("display_order", { ascending: true });
-
-        if (nextTypes && nextTypes.length > 0) {
-          // is_initial_gift=false のものを優先、なければどれでも
-          const nonInitialTypes = nextTypes.filter((t) => !t.is_initial_gift);
-          const candidates = nonInitialTypes.length > 0 ? nonInitialTypes : nextTypes;
-          const nextType = candidates[Math.floor(Math.random() * candidates.length)];
-
-          const expiresAt = new Date(`${market_date}T15:00:00.000Z`);
-          expiresAt.setDate(expiresAt.getDate() + 1);
-
-          const { data: newCoupon } = await serviceClient
-            .from("coupon_issuances")
-            .insert({
-              visitor_key,
-              market_date,
-              coupon_type_id: nextType.id,
-              amount: couponSettings?.amount ?? nextType.amount,
-              issue_reason: "next_visit",
-              expires_at: expiresAt.toISOString(),
-            })
-            .select("*, coupon_types(*)")
-            .single();
-
-          if (newCoupon) {
-            next_coupon = normalizeCouponIssuance(
-              newCoupon as SupabaseCouponIssuanceRow
-            ) as RedeemResponse["next_coupon"];
-            next_coupon_issued = true;
-          }
-        }
+      if (newCouponRow) {
+        next_coupon = normalizeCouponIssuance(
+          newCouponRow as SupabaseCouponIssuanceRow
+        ) as RedeemResponse["next_coupon"];
+        next_coupon_issued = true;
       }
     }
 

--- a/supabase/migrations/20260515000000_create_redeem_coupon_function.sql
+++ b/supabase/migrations/20260515000000_create_redeem_coupon_function.sql
@@ -12,8 +12,9 @@
 --   p_next_coupon_amount : 次回クーポンの割引額
 --
 -- 戻り値 (jsonb):
---   is_new_stamp    : 今回初スタンプかどうか
---   next_coupon_id  : 発行した次回クーポンの UUID（発行なしの場合は null）
+--   is_new_stamp  : 今回初スタンプかどうか
+--   next_coupon   : 発行した次回クーポンの全データ（coupon_types JOIN済み）。発行なしの場合は null。
+--                   トランザクション内で SELECT するため、別途フェッチ時のレース条件がない。
 CREATE OR REPLACE FUNCTION redeem_coupon(
   p_coupon_id          uuid,
   p_visitor_key        text,
@@ -34,6 +35,7 @@ DECLARE
   v_today_count        bigint;
   v_new_coupon_id      uuid;
   v_expires_at         timestamptz;
+  v_next_coupon        jsonb;
 BEGIN
   -- ① クーポン消費（is_used = false を条件にし、二重消費を防ぐ）
   UPDATE coupon_issuances
@@ -109,13 +111,48 @@ BEGIN
           v_expires_at
         )
         RETURNING id INTO v_new_coupon_id;
+
+        -- 発行した次回クーポンの全データをトランザクション内で取得（coupon_types JOIN込み）
+        -- これにより呼び出し側で別途 SELECT する必要がなくなり、フェッチ時のレース条件を排除する
+        SELECT jsonb_build_object(
+          'id',             ci.id,
+          'visitor_key',    ci.visitor_key,
+          'market_date',    ci.market_date::text,
+          'coupon_type_id', ci.coupon_type_id,
+          'amount',         ci.amount,
+          'is_used',        ci.is_used,
+          'used_at',        ci.used_at,
+          'used_vendor_id', ci.used_vendor_id,
+          'issue_reason',   ci.issue_reason,
+          'expires_at',     ci.expires_at,
+          'created_at',     ci.created_at,
+          'coupon_types', jsonb_build_object(
+            'id',            ct.id,
+            'name',          ct.name,
+            'description',   ct.description,
+            'emoji',         ct.emoji,
+            'amount',        ct.amount,
+            'is_initial_gift', ct.is_initial_gift,
+            'is_enabled',    ct.is_enabled,
+            'display_order', ct.display_order
+          )
+        )
+        INTO v_next_coupon
+        FROM coupon_issuances ci
+        JOIN coupon_types ct ON ct.id = ci.coupon_type_id
+        WHERE ci.id = v_new_coupon_id;
       END IF;
     END IF;
   END IF;
 
   RETURN jsonb_build_object(
-    'is_new_stamp',   v_is_new_stamp,
-    'next_coupon_id', v_new_coupon_id
+    'is_new_stamp', v_is_new_stamp,
+    'next_coupon',  v_next_coupon
   );
 END;
 $$;
+
+-- service_role のみ実行可能。anon・authenticated からは直接呼び出せないようにする。
+-- この関数は SECURITY DEFINER のため、権限を明示的に制限することが重要。
+GRANT EXECUTE ON FUNCTION redeem_coupon TO service_role;
+REVOKE EXECUTE ON FUNCTION redeem_coupon FROM anon, authenticated;

--- a/supabase/migrations/20260515000000_create_redeem_coupon_function.sql
+++ b/supabase/migrations/20260515000000_create_redeem_coupon_function.sql
@@ -1,0 +1,121 @@
+-- クーポン換金をアトミックに実行する RPC 関数
+--
+-- クーポン消費・スタンプ付与・次回クーポン発行を1トランザクション内で完結させ、
+-- ロールバック不整合と race condition を解消する。
+--
+-- 引数:
+--   p_coupon_id          : 消費するクーポンの UUID
+--   p_visitor_key        : 来場者キー
+--   p_vendor_id          : 出店者 UUID
+--   p_market_date        : 市場開催日 (YYYY-MM-DD)
+--   p_max_issuance       : 当日の発行上限枚数
+--   p_next_coupon_amount : 次回クーポンの割引額
+--
+-- 戻り値 (jsonb):
+--   is_new_stamp    : 今回初スタンプかどうか
+--   next_coupon_id  : 発行した次回クーポンの UUID（発行なしの場合は null）
+CREATE OR REPLACE FUNCTION redeem_coupon(
+  p_coupon_id          uuid,
+  p_visitor_key        text,
+  p_vendor_id          uuid,
+  p_market_date        date,
+  p_max_issuance       integer,
+  p_next_coupon_amount integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_rows_updated       integer;
+  v_is_new_stamp       boolean;
+  v_next_type_id       uuid;
+  v_today_count        bigint;
+  v_new_coupon_id      uuid;
+  v_expires_at         timestamptz;
+BEGIN
+  -- ① クーポン消費（is_used = false を条件にし、二重消費を防ぐ）
+  UPDATE coupon_issuances
+  SET is_used        = true,
+      used_at        = now(),
+      used_vendor_id = p_vendor_id
+  WHERE id      = p_coupon_id
+    AND is_used = false;
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+  IF v_rows_updated = 0 THEN
+    -- 別リクエストが先に消費済み
+    RAISE EXCEPTION 'COUPON_ALREADY_USED';
+  END IF;
+
+  -- ② 新規スタンプかどうかを確認（INSERT 前に確認する）
+  SELECT NOT EXISTS (
+    SELECT 1
+    FROM coupon_stamps
+    WHERE visitor_key = p_visitor_key
+      AND vendor_id   = p_vendor_id
+      AND market_date = p_market_date
+  ) INTO v_is_new_stamp;
+
+  -- ③ スタンプ付与（重複は無視）
+  INSERT INTO coupon_stamps (visitor_key, vendor_id, market_date)
+  VALUES (p_visitor_key, p_vendor_id, p_market_date)
+  ON CONFLICT (visitor_key, vendor_id, market_date) DO NOTHING;
+
+  -- ④ 新規スタンプの場合のみ次回クーポンを発行
+  v_new_coupon_id := NULL;
+  IF v_is_new_stamp THEN
+    -- 当日発行済み枚数を取得（count + insert がトランザクション内で完結するため race condition なし）
+    SELECT COUNT(*) INTO v_today_count
+    FROM coupon_issuances
+    WHERE market_date = p_market_date;
+
+    IF v_today_count < p_max_issuance THEN
+      -- 次回クーポン種別をランダム選択（is_initial_gift = false を優先）
+      SELECT id INTO v_next_type_id
+      FROM coupon_types
+      WHERE is_enabled     = true
+        AND is_initial_gift = false
+      ORDER BY RANDOM()
+      LIMIT 1;
+
+      -- is_initial_gift = false が存在しない場合は任意の有効種別から選択
+      IF v_next_type_id IS NULL THEN
+        SELECT id INTO v_next_type_id
+        FROM coupon_types
+        WHERE is_enabled = true
+        ORDER BY RANDOM()
+        LIMIT 1;
+      END IF;
+
+      IF v_next_type_id IS NOT NULL THEN
+        -- expires_at: market_date 翌日 15:00 UTC（JST 翌々日 0:00）
+        v_expires_at := (p_market_date + interval '1 day')::timestamp + interval '15 hours';
+
+        INSERT INTO coupon_issuances (
+          visitor_key,
+          market_date,
+          coupon_type_id,
+          amount,
+          issue_reason,
+          expires_at
+        ) VALUES (
+          p_visitor_key,
+          p_market_date,
+          v_next_type_id,
+          p_next_coupon_amount,
+          'next_visit',
+          v_expires_at
+        )
+        RETURNING id INTO v_new_coupon_id;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'is_new_stamp',   v_is_new_stamp,
+    'next_coupon_id', v_new_coupon_id
+  );
+END;
+$$;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1455,6 +1455,17 @@ export type Database = {
         Args: { p_visit_date: string; p_visitor_key: string }
         Returns: boolean
       }
+      redeem_coupon: {
+        Args: {
+          p_coupon_id: string
+          p_visitor_key: string
+          p_vendor_id: string
+          p_market_date: string
+          p_max_issuance: number
+          p_next_coupon_amount: number
+        }
+        Returns: Json
+      }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## 概要

Issue #210 対応。`/api/coupons/redeem` のクーポン消費・スタンプ付与・次回クーポン発行を `redeem_coupon` SQL 関数でラップし、1つのトランザクション内に閉じることで、ロールバック不整合と race condition を解消する。

## 問題

### 問題1: 非アトミックなロールバック
```typescript
// 修正前
await serviceClient.from("coupon_issuances").update({ is_used: true, ... })  // ⑦
// ↓ ここで失敗したら...
await serviceClient.from("coupon_stamps").upsert(...)                         // ⑧ 失敗
// ↓ ロールバック試行（これ自体も失敗しうる）
await serviceClient.from("coupon_issuances").update({ is_used: false, ... }) // ロールバック失敗 → 不整合
```

### 問題2: 次回クーポン発行の race condition
```typescript
// count 取得 → insert までの間に別リクエストが走ると上限超過
const { count } = await ... .select("id", { count: "exact" })  // count = 299
// ↑ 並行リクエストが同時にここを通過 → 両方が300枚以内と判断 → 2枚発行
```

## 解決策

`redeem_coupon` PL/pgSQL 関数で⑥〜⑨をトランザクション内に閉じる：

```sql
BEGIN
  UPDATE coupon_issuances SET is_used = true ... WHERE id = ? AND is_used = false;
  -- 影響行が0 → RAISE EXCEPTION 'COUPON_ALREADY_USED'
  INSERT INTO coupon_stamps ... ON CONFLICT DO NOTHING;
  -- count check + insert が同一TX内 → race condition なし
  IF is_new_stamp AND today_count < max THEN
    INSERT INTO coupon_issuances (issue_reason='next_visit') ...;
  END IF;
END;
```

## 変更ファイル

- `supabase/migrations/20260515000000_create_redeem_coupon_function.sql`（新規）
- `app/api/coupons/redeem/route.ts`
- `types/database.types.ts`（`redeem_coupon` 関数の型定義を追加）

## マイグレーション手順

```sql
-- Supabase ダッシュボード > SQL Editor で実行、または supabase db push
\i supabase/migrations/20260515000000_create_redeem_coupon_function.sql
```

## 確認してほしいこと

- [ ] クーポン換金フロー（出店者がQRをスキャン → 換金確定）が正常に動作すること
- [ ] 同じクーポンを同時に2回換金しようとしたとき、片方が 409 で弾かれること
- [ ] 初スタンプ時に次回クーポンが発行されること
- [ ] 2回目以降のスタンプでは次回クーポンが発行されないこと

## 補足

- `p_next_coupon_amount` は `couponSettings?.amount ?? 50` を渡す（50 は DB のデフォルト値）
- `ORDER BY RANDOM()` による次回クーポン種別選択は既存の TypeScript 実装と同等の挙動
- 監査ログ（`coupon_redemption_logs` への INSERT）は RPC の外で実行。ログ記録失敗がビジネスロジックをロールバックしないよう意図的に分離している

Closes #210