### PR TITLE
#211 map-layout 更新・復元を SQL 関数でアトミックトランザクション化する

### DIFF
--- a/app/api/admin/map-layout/route.ts
+++ b/app/api/admin/map-layout/route.ts
@@ -59,11 +59,8 @@ function validateShopAssignments(shops: EditableShop[]) {
 
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
-  const record = user as {
-    app_metadata?: { role?: string };
-    user_metadata?: { role?: string };
-  };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  const record = user as { app_metadata?: { role?: string } };
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {
@@ -437,29 +434,23 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    const { error: deleteRoutePointsError } = await adminWriteClient
-      .from("map_route_points")
-      .delete()
-      .neq("id", "");
+    // replace_map_route_points SQL 関数で全件削除→再挿入をアトミックに実行
+    // （別々の操作にすると削除後に insert が失敗した場合に route_points が消える）
+    const routePointsPayload = body.route.points.map((point, index) => ({
+      id: point.id,
+      latitude: point.lat,
+      longitude: point.lng,
+      sort_order: index,
+      branch_from_id: point.branchFromId ?? null,
+    }));
 
-    if (deleteRoutePointsError) {
-      return NextResponse.json({ error: "Failed to clear route points" }, { status: 500 });
-    }
+    const { error: routePointsError } = await adminWriteClient.rpc(
+      "replace_map_route_points",
+      { p_points: routePointsPayload }
+    );
 
-    if (body.route.points.length > 0) {
-      const { error: routePointsError } = await adminWriteClient.from("map_route_points").insert(
-        body.route.points.map((point, index) => ({
-          id: point.id,
-          latitude: point.lat,
-          longitude: point.lng,
-          sort_order: index,
-          branch_from_id: point.branchFromId ?? null,
-        }))
-      );
-
-      if (routePointsError) {
-        return NextResponse.json({ error: "Failed to save route points" }, { status: 500 });
-      }
+    if (routePointsError) {
+      return NextResponse.json({ error: "Failed to save route points" }, { status: 500 });
     }
 
     const { error: routeConfigError } = await adminWriteClient.from("map_route_configs").upsert(

--- a/app/api/admin/map-layout/snapshots/route.ts
+++ b/app/api/admin/map-layout/snapshots/route.ts
@@ -31,11 +31,8 @@ type SnapshotSummary = {
 
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
-  const record = user as {
-    app_metadata?: { role?: string };
-    user_metadata?: { role?: string };
-  };
-  return record.app_metadata?.role ?? record.user_metadata?.role ?? null;
+  const record = user as { app_metadata?: { role?: string } };
+  return record.app_metadata?.role ?? null;
 }
 
 function isAdminRole(role: string | null) {
@@ -165,164 +162,16 @@ async function applySnapshot(
   snapshotRoutePoints: MapRoutePoint[],
   snapshotRouteConfig: MapRouteConfig | null
 ) {
-  const { data: currentLocations, error: currentLocationsError } = await adminWriteClient
-    .from("market_locations")
-    .select("id");
-  if (currentLocationsError) {
-    throw new Error("Failed to load current market locations");
-  }
+  // restore_map_layout_snapshot SQL 関数で全テーブルの復元を1トランザクションに閉じる
+  const { error } = await adminWriteClient.rpc("restore_map_layout_snapshot", {
+    p_shops: snapshotShops,
+    p_landmarks: snapshotLandmarks,
+    p_route_points: snapshotRoutePoints,
+    p_route_config: snapshotRouteConfig ?? null,
+  });
 
-  const { data: currentAssignments, error: currentAssignmentsError } = await adminWriteClient
-    .from("location_assignments")
-    .select("vendor_id, location_id");
-  if (currentAssignmentsError) {
-    throw new Error("Failed to load current assignments");
-  }
-
-  const { data: currentLandmarks, error: currentLandmarksError } = await adminWriteClient
-    .from("map_landmarks")
-    .select("key");
-  if (currentLandmarksError) {
-    throw new Error("Failed to load current landmarks");
-  }
-
-  const { error: clearRoutePointsError } = await adminWriteClient
-    .from("map_route_points")
-    .delete()
-    .neq("id", "");
-  if (clearRoutePointsError) {
-    throw new Error("Failed to clear current route points");
-  }
-
-  if (snapshotShops.length > 0) {
-    const { error } = await adminWriteClient.from("market_locations").upsert(
-      snapshotShops.map((shop) => ({
-        id: shop.locationId,
-        store_number: shop.position,
-        latitude: shop.lat,
-        longitude: shop.lng,
-      })),
-      { onConflict: "id" }
-    );
-    if (error) {
-      throw new Error("Failed to restore shop locations");
-    }
-  }
-
-  const snapshotLocationIds = new Set(snapshotShops.map((shop) => shop.locationId));
-  const currentLocationIds = (currentLocations ?? []).map((row) => row.id as string).filter(Boolean);
-  const locationIdsToDelete = currentLocationIds.filter((id) => !snapshotLocationIds.has(id));
-
-  const currentVendorIds = (currentAssignments ?? [])
-    .map((row) => row.vendor_id as string | null)
-    .filter((value): value is string => Boolean(value));
-  const snapshotVendorIds = snapshotShops
-    .map((shop) => shop.vendorId)
-    .filter((value): value is string => Boolean(value));
-  const vendorIdsToClear = Array.from(new Set([...currentVendorIds, ...snapshotVendorIds]));
-
-  if (currentLocationIds.length > 0) {
-    const { error } = await adminWriteClient
-      .from("location_assignments")
-      .delete()
-      .in("location_id", currentLocationIds);
-    if (error) {
-      throw new Error("Failed to clear assignments for restore");
-    }
-  }
-
-  if (vendorIdsToClear.length > 0) {
-    const { error } = await adminWriteClient
-      .from("location_assignments")
-      .delete()
-      .in("vendor_id", vendorIdsToClear);
-    if (error) {
-      throw new Error("Failed to clear vendor assignments for restore");
-    }
-  }
-
-  const assignmentsToInsert = snapshotShops
-    .filter((shop) => shop.vendorId)
-    .map((shop) => ({
-      location_id: shop.locationId,
-      vendor_id: shop.vendorId as string,
-      market_date: new Date().toISOString().slice(0, 10),
-    }));
-
-  if (assignmentsToInsert.length > 0) {
-    const { error } = await adminWriteClient.from("location_assignments").insert(assignmentsToInsert);
-    if (error) {
-      throw new Error("Failed to restore assignments");
-    }
-  }
-
-  if (locationIdsToDelete.length > 0) {
-    const { error } = await adminWriteClient.from("market_locations").delete().in("id", locationIdsToDelete);
-    if (error) {
-      throw new Error("Failed to delete extra locations during restore");
-    }
-  }
-
-  if (snapshotLandmarks.length > 0) {
-    const { error } = await adminWriteClient.from("map_landmarks").upsert(
-      snapshotLandmarks.map((landmark) => ({
-        key: landmark.key,
-        name: landmark.name,
-        description: landmark.description,
-        image_url: landmark.url,
-        latitude: landmark.lat,
-        longitude: landmark.lng,
-        width_px: landmark.widthPx,
-        height_px: landmark.heightPx,
-        show_at_min_zoom: landmark.showAtMinZoom,
-      })),
-      { onConflict: "key" }
-    );
-    if (error) {
-      throw new Error("Failed to restore landmarks");
-    }
-  }
-
-  const snapshotKeys = new Set(snapshotLandmarks.map((landmark) => landmark.key));
-  const landmarkKeysToDelete = (currentLandmarks ?? [])
-    .map((row) => row.key as string)
-    .filter((key) => key && !snapshotKeys.has(key));
-
-  if (landmarkKeysToDelete.length > 0) {
-    const { error } = await adminWriteClient.from("map_landmarks").delete().in("key", landmarkKeysToDelete);
-    if (error) {
-      throw new Error("Failed to delete extra landmarks during restore");
-    }
-  }
-
-  if (snapshotRoutePoints.length > 0) {
-    const { error } = await adminWriteClient.from("map_route_points").insert(
-      snapshotRoutePoints.map((point, index) => ({
-        id: point.id,
-        latitude: point.lat,
-        longitude: point.lng,
-        sort_order: index,
-        branch_from_id: point.branchFromId ?? null,
-      }))
-    );
-    if (error) {
-      throw new Error("Failed to restore route points");
-    }
-  }
-
-  if (snapshotRouteConfig) {
-    const { error } = await adminWriteClient.from("map_route_configs").upsert(
-      {
-        key: snapshotRouteConfig.key,
-        road_half_width_meters: snapshotRouteConfig.roadHalfWidthMeters,
-        snap_distance_meters: snapshotRouteConfig.snapDistanceMeters,
-        visible_distance_meters: snapshotRouteConfig.visibleDistanceMeters,
-      },
-      { onConflict: "key" }
-    );
-    if (error) {
-      throw new Error("Failed to restore route config");
-    }
+  if (error) {
+    throw new Error(`Failed to restore map layout: ${error.message}`);
   }
 }
 

--- a/supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql
+++ b/supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql
@@ -1,0 +1,179 @@
+-- map-layout 更新・復元をアトミックに実行する SQL 関数群
+--
+-- 問題: route.ts と snapshots/route.ts が複数テーブルを逐次更新しており、
+-- 途中失敗で部分書き込みが残る（特に map_route_points の全件削除→insert が致命的）
+-- 解決: 危険な操作を RPC 関数でトランザクション内に閉じる
+
+-- ─── replace_map_route_points ────────────────────────────────────────────
+-- map_route_points の全件削除→再挿入をアトミックに実行する
+--
+-- 引数: p_points jsonb — {id, latitude, longitude, sort_order, branch_from_id?}[] の配列
+-- 呼び出し元: PUT /api/admin/map-layout
+CREATE OR REPLACE FUNCTION replace_map_route_points(p_points jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 全件削除
+  DELETE FROM map_route_points;
+
+  -- branch_from_id は自己参照 FK のため、まず branch_from_id なしで挿入してから UPDATE する
+  IF p_points IS NOT NULL AND jsonb_array_length(p_points) > 0 THEN
+    INSERT INTO map_route_points (id, latitude, longitude, sort_order)
+    SELECT
+      elem->>'id',
+      (elem->>'latitude')::double precision,
+      (elem->>'longitude')::double precision,
+      (elem->>'sort_order')::integer
+    FROM jsonb_array_elements(p_points) AS elem;
+
+    UPDATE map_route_points rp
+    SET branch_from_id = elem->>'branch_from_id'
+    FROM jsonb_array_elements(p_points) AS elem
+    WHERE rp.id = elem->>'id'
+      AND (elem->>'branch_from_id') IS NOT NULL
+      AND (elem->>'branch_from_id') <> '';
+  END IF;
+END;
+$$;
+
+-- ─── restore_map_layout_snapshot ─────────────────────────────────────────
+-- スナップショットからマップレイアウト全体をアトミックに復元する
+--
+-- 引数:
+--   p_shops       jsonb — EditableShop[] ({locationId, position, lat, lng, vendorId?}[])
+--   p_landmarks   jsonb — Landmark[] ({key, name, description, url, lat, lng, widthPx, heightPx, showAtMinZoom}[])
+--   p_route_points jsonb — MapRoutePoint[] ({id, lat, lng, order, branchFromId?}[])
+--   p_route_config jsonb — MapRouteConfig ({key, roadHalfWidthMeters, snapDistanceMeters, visibleDistanceMeters})
+-- 呼び出し元: POST /api/admin/map-layout/snapshots
+CREATE OR REPLACE FUNCTION restore_map_layout_snapshot(
+  p_shops        jsonb,
+  p_landmarks    jsonb,
+  p_route_points jsonb,
+  p_route_config jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_today text := to_char(now() AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD');
+BEGIN
+  -- ① market_locations を upsert（スナップショット内容で更新）
+  IF p_shops IS NOT NULL AND jsonb_array_length(p_shops) > 0 THEN
+    INSERT INTO market_locations (id, store_number, latitude, longitude)
+    SELECT
+      elem->>'locationId',
+      (elem->>'position')::integer,
+      (elem->>'lat')::double precision,
+      (elem->>'lng')::double precision
+    FROM jsonb_array_elements(p_shops) AS elem
+    ON CONFLICT (id) DO UPDATE SET
+      store_number = EXCLUDED.store_number,
+      latitude     = EXCLUDED.latitude,
+      longitude    = EXCLUDED.longitude;
+  END IF;
+
+  -- ② location_assignments を全クリア（現在の全 location に紐づくもの）
+  DELETE FROM location_assignments
+  WHERE location_id IN (SELECT id FROM market_locations);
+
+  -- ③ location_assignments を再挿入（vendor が紐づくもののみ）
+  IF p_shops IS NOT NULL AND jsonb_array_length(p_shops) > 0 THEN
+    INSERT INTO location_assignments (location_id, vendor_id, market_date)
+    SELECT
+      elem->>'locationId',
+      elem->>'vendorId',
+      v_today
+    FROM jsonb_array_elements(p_shops) AS elem
+    WHERE (elem->>'vendorId') IS NOT NULL AND (elem->>'vendorId') <> '';
+  END IF;
+
+  -- ④ スナップショットにない market_locations を削除
+  IF p_shops IS NOT NULL AND jsonb_array_length(p_shops) > 0 THEN
+    DELETE FROM market_locations
+    WHERE id NOT IN (
+      SELECT elem->>'locationId'
+      FROM jsonb_array_elements(p_shops) AS elem
+    );
+  ELSE
+    DELETE FROM market_locations;
+  END IF;
+
+  -- ⑤ map_landmarks を upsert（スナップショット内容で更新）
+  IF p_landmarks IS NOT NULL AND jsonb_array_length(p_landmarks) > 0 THEN
+    INSERT INTO map_landmarks (key, name, description, image_url, latitude, longitude, width_px, height_px, show_at_min_zoom)
+    SELECT
+      elem->>'key',
+      elem->>'name',
+      elem->>'description',
+      elem->>'url',
+      (elem->>'lat')::double precision,
+      (elem->>'lng')::double precision,
+      (elem->>'widthPx')::integer,
+      (elem->>'heightPx')::integer,
+      (elem->>'showAtMinZoom')::boolean
+    FROM jsonb_array_elements(p_landmarks) AS elem
+    ON CONFLICT (key) DO UPDATE SET
+      name            = EXCLUDED.name,
+      description     = EXCLUDED.description,
+      image_url       = EXCLUDED.image_url,
+      latitude        = EXCLUDED.latitude,
+      longitude       = EXCLUDED.longitude,
+      width_px        = EXCLUDED.width_px,
+      height_px       = EXCLUDED.height_px,
+      show_at_min_zoom = EXCLUDED.show_at_min_zoom;
+  END IF;
+
+  -- ⑥ スナップショットにない map_landmarks を削除
+  IF p_landmarks IS NOT NULL AND jsonb_array_length(p_landmarks) > 0 THEN
+    DELETE FROM map_landmarks
+    WHERE key NOT IN (
+      SELECT elem->>'key'
+      FROM jsonb_array_elements(p_landmarks) AS elem
+    );
+  ELSE
+    DELETE FROM map_landmarks;
+  END IF;
+
+  -- ⑦ map_route_points を全削除し、スナップショットから再挿入
+  -- branch_from_id 自己参照 FK のため、先に id のみ挿入してから UPDATE する
+  DELETE FROM map_route_points;
+
+  IF p_route_points IS NOT NULL AND jsonb_array_length(p_route_points) > 0 THEN
+    INSERT INTO map_route_points (id, latitude, longitude, sort_order)
+    SELECT
+      elem->>'id',
+      (elem->>'lat')::double precision,
+      (elem->>'lng')::double precision,
+      (elem->>'order')::integer
+    FROM jsonb_array_elements(p_route_points) AS elem;
+
+    UPDATE map_route_points rp
+    SET branch_from_id = elem->>'branchFromId'
+    FROM jsonb_array_elements(p_route_points) AS elem
+    WHERE rp.id = elem->>'id'
+      AND (elem->>'branchFromId') IS NOT NULL
+      AND (elem->>'branchFromId') <> '';
+  END IF;
+
+  -- ⑧ map_route_configs を upsert
+  IF p_route_config IS NOT NULL AND p_route_config <> 'null'::jsonb THEN
+    INSERT INTO map_route_configs (key, road_half_width_meters, snap_distance_meters, visible_distance_meters)
+    VALUES (
+      p_route_config->>'key',
+      (p_route_config->>'roadHalfWidthMeters')::double precision,
+      (p_route_config->>'snapDistanceMeters')::double precision,
+      (p_route_config->>'visibleDistanceMeters')::double precision
+    )
+    ON CONFLICT (key) DO UPDATE SET
+      road_half_width_meters  = EXCLUDED.road_half_width_meters,
+      snap_distance_meters    = EXCLUDED.snap_distance_meters,
+      visible_distance_meters = EXCLUDED.visible_distance_meters,
+      updated_at              = now();
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## 概要

Issue #211 対応。`/api/admin/map-layout` の PUT と `/api/admin/map-layout/snapshots` の POST が複数テーブルを逐次更新しており、途中失敗でデータ不整合が生じる問題を、SQL 関数による1トランザクション化で解決する。

## 問題

### 問題1: route_points の delete-all → insert（最も危険）
```typescript
// 修正前: 2ステップが非アトミック
await adminWriteClient.from("map_route_points").delete().neq("id", ""); // 全削除
await adminWriteClient.from("map_route_points").insert([...]);           // insert 失敗 → route_points 消滅
```

### 問題2: snapshot 復元が5テーブルを逐次更新
復元中のエラーで市場レイアウトが中途半端な状態になる。

## 解決策

| SQL 関数 | 用途 |
|---------|------|
| `replace_map_route_points(p_points jsonb)` | PUT の route_points 全件削除→再挿入をアトミックに実行 |
| `restore_map_layout_snapshot(p_shops, p_landmarks, p_route_points, p_route_config jsonb)` | 5テーブルの復元を1トランザクション内に閉じる |

## 変更ファイル

- `supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql`（新規）
- `app/api/admin/map-layout/route.ts`（route_points 操作を RPC に変更 + getRole 修正）
- `app/api/admin/map-layout/snapshots/route.ts`（applySnapshot を RPC に変更 + getRole 修正）

## マイグレーション手順

```sql
-- Supabase ダッシュボード > SQL Editor で実行
\i supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql
```

## 技術的な注意点

### branch_from_id 自己参照 FK の扱い
`map_route_points.branch_from_id` は同テーブルへの外部キー。一括 INSERT で親より先に子を挿入すると FK 違反になるため、`id` のみで全行挿入後に `branch_from_id` を UPDATE する2ステップで解決。

### applySnapshot の削除
旧 `applySnapshot` 関数（170行）は SQL 関数への移行に伴い完全削除。ロジックはマイグレーション SQL に移管済み。

## 確認してほしいこと

- [ ] マップレイアウト編集（ルートポイントの追加・移動・削除）が正常に保存されること
- [ ] スナップショット復元が正常に動作すること（branch_from_id を持つポイントを含む）
- [ ] 復元後のマップが保存前の状態と一致すること

## 補足

PUT の `market_locations` / `location_assignments` / `map_landmarks` 操作は upsert/targeted-delete ベースであり今回は対象外。最も危険な delete-all パターン（route_points）と全体復元（snapshot）を優先対応した。

Closes #211