### PR TITLE
#213 CSV エクスポートの数式インジェクション対策を追加する

### DIFF
--- a/lib/admin/exportUtils.ts
+++ b/lib/admin/exportUtils.ts
@@ -73,12 +73,12 @@ export function exportToJSON<T>(data: T[], filename: string): { success: boolean
  */
 function escapeCSV(value: string): string {
   const dangerous = /^[=+\-@\t\r]/.test(value);
-  const escaped = value.replace(/"/g, '""');
-  const quoted =
-    escaped.includes(",") || escaped.includes("\n") || escaped.includes('"')
-      ? `"${escaped}"`
-      : escaped;
-  return dangerous ? `'${quoted}` : quoted;
+  const sanitized = dangerous ? `'${value}` : value;
+  const escaped = sanitized.replace(/"/g, '""');
+  if (escaped.includes(",") || escaped.includes("\n") || escaped.includes('"')) {
+    return `"${escaped}"`;
+  }
+  return escaped;
 }
 
 /**

--- a/lib/admin/exportUtils.ts
+++ b/lib/admin/exportUtils.ts
@@ -44,7 +44,7 @@ export function exportToCSV<T extends Record<string, unknown>>(
   try {
     downloadBlob(blob, filename);
     return { success: true };
-  } catch (error) {
+  } catch (_error) {
     return { success: false, error: "エクスポートに失敗しました" };
   }
 }
@@ -62,20 +62,23 @@ export function exportToJSON<T>(data: T[], filename: string): { success: boolean
     const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
     downloadBlob(blob, filename);
     return { success: true };
-  } catch (error) {
+  } catch (_error) {
     return { success: false, error: "エクスポートに失敗しました" };
   }
 }
 
 /**
  * CSV用エスケープ処理
+ * =, +, -, @, \t, \r で始まる値にシングルクォートを前置してCSVインジェクションを防ぐ
  */
 function escapeCSV(value: string): string {
-  // カンマ、改行、ダブルクォートを含む場合はダブルクォートで囲む
-  if (value.includes(",") || value.includes("\n") || value.includes('"')) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
+  const dangerous = /^[=+\-@\t\r]/.test(value);
+  const escaped = value.replace(/"/g, '""');
+  const quoted =
+    escaped.includes(",") || escaped.includes("\n") || escaped.includes('"')
+      ? `"${escaped}"`
+      : escaped;
+  return dangerous ? `'${quoted}` : quoted;
 }
 
 /**


### PR DESCRIPTION
## 概要

`lib/admin/exportUtils.ts` の `escapeCSV` が `=`, `+`, `-`, `@`, `\t`, `\r` で始まる値を素通りさせており、管理者が CSV をダウンロードして Excel / Numbers で開くと数式として実行される CSV インジェクションに脆弱だった。

## 主な変更

- `lib/admin/exportUtils.ts` — `escapeCSV` にシングルクォート前置処理を追加

**変更前**
```typescript
function escapeCSV(value: string): string {
  if (value.includes(",") || value.includes("\n") || value.includes('"')) {
    return `"${value.replace(/"/g, '""')}"`;
  }
  return value; // =cmd|'/c calc'!A0 がそのまま通る
}
```

**変更後**
```typescript
function escapeCSV(value: string): string {
  const dangerous = /^[=+\-@\t\r]/.test(value);
  const escaped = value.replace(/"/g, '""');
  const quoted =
    escaped.includes(",") || escaped.includes("\n") || escaped.includes('"')
      ? `"${escaped}"`
      : escaped;
  return dangerous ? `'${quoted}` : quoted;
}
```

## 変更ファイル

- `lib/admin/exportUtils.ts`

## 確認してほしいこと

- [ ] 通常のデータ（日本語・数値）が正常にエクスポートされるか
- [ ] `=SUM(1+1)` を含む値がシングルクォート付きで出力されるか

## 補足

`npm run build` 通過済み。影響範囲は管理者向け CSV ダウンロード機能のみ。