### PR TITLE
#214 admin API のエラーレスポンスから内部メッセージを除去する

### DIFF
--- a/app/api/admin/audit-logs/route.ts
+++ b/app/api/admin/audit-logs/route.ts
@@ -78,7 +78,10 @@ export async function POST(req: Request) {
     ip_address: ip,
   });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/audit-logs] insert failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ success: true });
 }
 
@@ -102,6 +105,9 @@ export async function GET(req: Request) {
     .order("created_at", { ascending: false })
     .limit(limit);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/audit-logs] select failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ logs: data });
 }

--- a/app/api/admin/content/[id]/route.ts
+++ b/app/api/admin/content/[id]/route.ts
@@ -51,7 +51,8 @@ export async function DELETE(
   const { error } = await dc.from("vendor_contents").delete().eq("id", id);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/content] delete failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
   return NextResponse.json({ success: true });
 }

--- a/app/api/admin/kotodute/[id]/route.ts
+++ b/app/api/admin/kotodute/[id]/route.ts
@@ -56,7 +56,10 @@ export async function PATCH(
   const dc = createAdminClient() ?? supabase;
   const { error } = await dc.from("kotodutes").update({ status: body.status }).eq("id", id);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/kotodute] patch failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ success: true });
 }
 
@@ -86,6 +89,9 @@ export async function DELETE(
   const dc = createAdminClient() ?? supabase;
   const { error } = await dc.from("kotodutes").update({ status: "deleted" }).eq("id", id);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/kotodute] delete failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ success: true });
 }

--- a/app/api/admin/kotodute/bulk/route.ts
+++ b/app/api/admin/kotodute/bulk/route.ts
@@ -52,6 +52,9 @@ export async function POST(req: Request) {
   const dc = createAdminClient() ?? supabase;
   const { error } = await dc.from("kotodutes").update({ status: body.status }).in("id", body.ids);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/kotodute/bulk] update failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ success: true, updated: body.ids.length });
 }

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -43,7 +43,10 @@ export async function GET(_req: Request) {
     .order("created_at", { ascending: false })
     .limit(100);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/notifications] select failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ notifications: data });
 }
 
@@ -74,6 +77,9 @@ export async function PATCH(req: Request) {
     .update({ is_read: true })
     .eq("is_read", false);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[admin/notifications] update failed:", error.message);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
   return NextResponse.json({ success: true });
 }

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -69,7 +69,10 @@ export async function PATCH(
       const { error } = await serviceClient.auth.admin.updateUserById(id, {
         ban_duration: "876000h",
       });
-      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      if (error) {
+        console.error("[admin/users] suspend failed:", error.message);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      }
 
       await serviceClient.from("admin_audit_logs").insert({
         actor_id: user.id,
@@ -82,7 +85,10 @@ export async function PATCH(
       const { error } = await serviceClient.auth.admin.updateUserById(id, {
         ban_duration: "none",
       });
-      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      if (error) {
+        console.error("[admin/users] restore failed:", error.message);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      }
 
       await serviceClient.from("admin_audit_logs").insert({
         actor_id: user.id,
@@ -101,7 +107,10 @@ export async function PATCH(
       const { error } = await serviceClient.auth.admin.updateUserById(id, {
         app_metadata: { role: newRole },
       });
-      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      if (error) {
+        console.error("[admin/users] change_role failed:", error.message);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      }
 
       await serviceClient.from("admin_audit_logs").insert({
         actor_id: user.id,


### PR DESCRIPTION
## 概要

admin 系 API Route で Supabase の `error.message` をそのままクライアントへ返しており、DB スキーマ情報や内部構造が漏洩する可能性があった。詳細はサーバーログ（`console.error`）に残しつつ、外部レスポンスは固定文言に変更した。

## 主な変更

各ファイルの `{ error: error.message }` を `{ error: "Internal server error" }` に変更し、直前に `console.error("[route] operation failed:", error.message)` を追加。

## 変更ファイル

- `app/api/admin/audit-logs/route.ts`（2箇所）
- `app/api/admin/content/[id]/route.ts`（1箇所）
- `app/api/admin/kotodute/[id]/route.ts`（2箇所）
- `app/api/admin/kotodute/bulk/route.ts`（1箇所）
- `app/api/admin/notifications/route.ts`（2箇所）
- `app/api/admin/users/[id]/route.ts`（3箇所）

## 確認してほしいこと

- [ ] エラー時にクライアントへ返るメッセージが固定文言になっているか
- [ ] サーバーログ（`console.error`）に詳細が出力されるか

## 補足

`npm run build` 通過済み。機能ロジックの変更はなし。