### PR TITLE
#215 admin/vendor/moderator ページに force-dynamic を追加する

### DIFF
--- a/app/(public)/admin/analytics/page.tsx
+++ b/app/(public)/admin/analytics/page.tsx
@@ -4,6 +4,8 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { createClient } from "@/utils/supabase/server";
 import { AdminLayout, AdminPageHeader } from "@/components/admin";
 
+export const dynamic = "force-dynamic";
+
 // ---- auth helpers (dashboard と同じパターン) ----
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;

--- a/app/(public)/admin/audit-logs/page.tsx
+++ b/app/(public)/admin/audit-logs/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/AuthContext";

--- a/app/(public)/admin/content/page.tsx
+++ b/app/(public)/admin/content/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/AuthContext";

--- a/app/(public)/admin/coupons/page.tsx
+++ b/app/(public)/admin/coupons/page.tsx
@@ -4,6 +4,8 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { createClient } from "@/utils/supabase/server";
 import { AdminLayout, AdminPageHeader, StatCard } from "@/components/admin";
 
+export const dynamic = "force-dynamic";
+
 function getRole(user: unknown) {
   if (!user || typeof user !== "object") return null;
   const record = user as {

--- a/app/(public)/admin/dashboard/page.tsx
+++ b/app/(public)/admin/dashboard/page.tsx
@@ -5,6 +5,8 @@ import { AdminLayout, AdminPageHeader, StatCard } from "@/components/admin";
 import TrafficChartCard, { type TrafficGranularity, type TrafficPoint } from "@/components/admin/TrafficChartCard";
 import { createClient } from "@/utils/supabase/server";
 
+export const dynamic = "force-dynamic";
+
 type ActivityItem = {
   id: string;
   icon: string;

--- a/app/(public)/admin/events/page.tsx
+++ b/app/(public)/admin/events/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";

--- a/app/(public)/admin/kotodute/page.tsx
+++ b/app/(public)/admin/kotodute/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { ModeratorKotoduteContent } from "@/app/(public)/moderator/kotodute/page";
 
 export default function AdminKotodutePage() {

--- a/app/(public)/admin/map-edit/page.tsx
+++ b/app/(public)/admin/map-edit/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import MapEditClient from "../../map-edit/MapEditClient";
 
 export default function AdminMapEditPage() {

--- a/app/(public)/admin/notifications/page.tsx
+++ b/app/(public)/admin/notifications/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { AdminLayout, AdminPageHeader, EmptyState } from "@/components/admin";
 import { useAdminNotifications } from "@/lib/hooks/useAdminNotifications";
-import { Loader2, Bell, BellOff } from "lucide-react";
+import { Bell } from "lucide-react";
 
 const TYPE_ICONS: Record<string, string> = {
   new_application: "📝",

--- a/app/(public)/admin/page.tsx
+++ b/app/(public)/admin/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export default function AdminPage() {
   redirect("/admin/dashboard");
 }

--- a/app/(public)/admin/settings/page.tsx
+++ b/app/(public)/admin/settings/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";

--- a/app/(public)/admin/shops/page.tsx
+++ b/app/(public)/admin/shops/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React, { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";

--- a/app/(public)/admin/users/page.tsx
+++ b/app/(public)/admin/users/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React, { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import type { UserRole } from "@/lib/auth/types";
 import { exportToCSV, exportToJSON, formatDateForFilename } from "@/lib/admin/exportUtils";
 import { showToast } from "@/lib/admin/toast";
@@ -296,7 +297,7 @@ function AdminUsersContent() {
       } else {
         showToast.error(result.error || "エクスポートに失敗しました");
       }
-    } catch (error) {
+    } catch (_error) {
       showToast.error("エクスポートに失敗しました");
     } finally {
       setIsExporting(false);
@@ -313,7 +314,7 @@ function AdminUsersContent() {
       } else {
         showToast.error(result.error || "エクスポートに失敗しました");
       }
-    } catch (error) {
+    } catch (_error) {
       showToast.error("エクスポートに失敗しました");
     } finally {
       setIsExporting(false);
@@ -751,6 +752,7 @@ function AdminUsersContent() {
                             <div className="flex items-center">
                               <div className="h-10 w-10 flex-shrink-0 rounded-full bg-gray-200 flex items-center justify-center">
                                 {user.avatarUrl ? (
+                                  // eslint-disable-next-line @next/next/no-img-element
                                   <img
                                     src={user.avatarUrl}
                                     alt={user.name}

--- a/app/(public)/moderator/kotodute/page.tsx
+++ b/app/(public)/moderator/kotodute/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";

--- a/app/(public)/moderator/page.tsx
+++ b/app/(public)/moderator/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React, { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useRouter } from "next/navigation";

--- a/app/vendor/account/page.tsx
+++ b/app/vendor/account/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, type FormEvent } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/app/vendor/ai-knowledge/page.tsx
+++ b/app/vendor/ai-knowledge/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";
 import { ArrowLeft, Save, CheckCircle2, Loader2, Sparkles, Info } from "lucide-react";
@@ -81,7 +84,7 @@ export default function AiKnowledgePage() {
 
         <div className="rounded-3xl border border-amber-200 bg-white p-4 shadow-sm">
           <div className="flex items-start gap-3">
-            <img src="/images/obaasan_transparent.png" alt="AIばあちゃん" className="h-14 w-14 flex-shrink-0 opacity-80" />
+            <Image src="/images/obaasan_transparent.png" alt="AIばあちゃん" width={56} height={56} className="flex-shrink-0 opacity-80" />
             <div className="min-w-0">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-600">AI Knowledge</p>
               <h2 className="mt-1 text-2xl font-bold text-slate-900">AIばあちゃんに伝えるお店メモ</h2>

--- a/app/vendor/analytics/ai/page.tsx
+++ b/app/vendor/analytics/ai/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -64,7 +67,7 @@ export default function AiAnalyticsPage() {
             {/* サマリー */}
             <div className="rounded-3xl border border-amber-100 bg-gradient-to-br from-amber-50 to-white p-4 shadow-sm">
               <div className="flex items-center gap-3">
-                <img src="/images/obaasan_transparent.png" alt="AIばあちゃん" className="h-14 w-14 opacity-80" />
+                <Image src="/images/obaasan_transparent.png" alt="AIばあちゃん" width={56} height={56} className="opacity-80" />
                 <div>
                   <p className="text-sm text-slate-500">過去7日間の相談総数</p>
                   <p className="text-4xl font-black text-amber-500">{data.totalCount}<span className="ml-1 text-base font-normal text-slate-500">件</span></p>

--- a/app/vendor/analytics/input/page.tsx
+++ b/app/vendor/analytics/input/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect, type FormEvent } from "react";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";

--- a/app/vendor/analytics/page.tsx
+++ b/app/vendor/analytics/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";

--- a/app/vendor/analytics/products/page.tsx
+++ b/app/vendor/analytics/products/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";

--- a/app/vendor/analytics/time/page.tsx
+++ b/app/vendor/analytics/time/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import NavigationBar from "@/app/components/NavigationBar";

--- a/app/vendor/coupon-settings/page.tsx
+++ b/app/vendor/coupon-settings/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, Save, Loader2, CheckCircle2 } from "lucide-react";

--- a/app/vendor/dashboard/page.tsx
+++ b/app/vendor/dashboard/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export default function VendorDashboardPage() {
   redirect("/my-shop");
 }

--- a/app/vendor/help/page.tsx
+++ b/app/vendor/help/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { ArrowLeft, Megaphone, Store, BarChart2, Sparkles, User, ChevronRight } from "lucide-react";
 import NavigationBar from "@/app/components/NavigationBar";
 
+export const dynamic = "force-dynamic";
+
 const GUIDE_SECTIONS = [
   {
     icon: Megaphone,

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useRef, useEffect, type ChangeEvent, type FormEvent } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/app/vendor/posts/page.tsx
+++ b/app/vendor/posts/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/app/vendor/store/page.tsx
+++ b/app/vendor/store/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect, useRef, type FormEvent } from "react";
 import Link from "next/link";
 import Image from "next/image";


### PR DESCRIPTION
## 概要

ISR キャッシュによる管理データ漏洩を防ぐため、admin・vendor・moderator 配下の全ページに `export const dynamic = "force-dynamic"` を追加した。

## 主な変更

- admin（13ページ）・moderator（2ページ）・vendor（13ページ）計28ファイルに `force-dynamic` を追加
- あわせて既存の ESLint 警告を修正（未使用インポート、catch 変数 `_error`、`<img>` → `<Image>`）

## 変更ファイル

`app/(public)/admin/` 配下 13ページ、`app/(public)/moderator/` 配下 2ページ、`app/vendor/` 配下 13ページ（計28ファイル）

## 確認してほしいこと

- [ ] admin・vendor・moderator の各ページが `ƒ (Dynamic)` としてビルドされているか
- [ ] 既存の画面表示・動作に変化がないか

## 補足

`npm run build` 通過済み。機能ロジックの変更はなし。