### PR TITLE
fix(ver1.3): PR #278 レビュー指摘の対応（Cookie・SQL権限・バリデーション）

### DIFF
--- a/app/api/grandma/ask/route.ts
+++ b/app/api/grandma/ask/route.ts
@@ -138,7 +138,9 @@ async function parseRequest(request: Request): Promise<ParsedRequest> {
   } else {
     const parsed = AskJsonBodySchema.safeParse(await request.json());
     if (!parsed.success) {
-      throw new Error(`Invalid request body: ${parsed.error.issues[0].message}`);
+      const err = new Error(parsed.error.issues[0].message);
+      (err as Error & { statusCode: number }).statusCode = 400;
+      throw err;
     }
     const payload = parsed.data;
     text = payload.text ?? "";
@@ -513,6 +515,15 @@ export async function POST(request: Request) {
     });
     if (rateLimited) return rateLimited;
 
+    let parsedReq: ParsedRequest;
+    try {
+      parsedReq = await parseRequest(request);
+    } catch (e) {
+      if (e instanceof Error && (e as Error & { statusCode?: number }).statusCode === 400) {
+        return NextResponse.json({ error: e.message }, { status: 400 });
+      }
+      throw e;
+    }
     const {
       text,
       location,
@@ -524,7 +535,7 @@ export async function POST(request: Request) {
       preferredCharacterId,
       visitorKey,
       stream,
-    } = await parseRequest(request);
+    } = parsedReq;
     const question = text || (imageDataUrl ? "画像について教えて" : "");
     if (!question) {
       return NextResponse.json({ reply: "質問を入力してね。" }, { status: 400 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,13 +17,21 @@ export async function middleware(request: NextRequest) {
   if (pathname.startsWith("/admin") || pathname.startsWith("/moderator")) {
     const allowed = appRole === "super_admin" || appRole === "admin" || appRole === "moderator";
     if (!user || !allowed) {
-      return NextResponse.redirect(new URL("/", request.url));
+      const redirectRes = NextResponse.redirect(new URL("/", request.url));
+      supabaseResponse.cookies.getAll().forEach(({ name, value }) => {
+        redirectRes.cookies.set(name, value);
+      });
+      return redirectRes;
     }
   }
 
   if (pathname.startsWith("/my-shop")) {
     if (!user || appRole !== "vendor") {
-      return NextResponse.redirect(new URL("/", request.url));
+      const redirectRes = NextResponse.redirect(new URL("/", request.url));
+      supabaseResponse.cookies.getAll().forEach(({ name, value }) => {
+        redirectRes.cookies.set(name, value);
+      });
+      return redirectRes;
     }
   }
 

--- a/supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql
+++ b/supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql
@@ -177,3 +177,11 @@ BEGIN
   END IF;
 END;
 $$;
+
+-- service_role のみ実行可能。anon・authenticated からは直接呼び出せないようにする。
+-- redeem_coupon と同様に SECURITY DEFINER 関数の権限を明示的に制限する。
+GRANT EXECUTE ON FUNCTION replace_map_route_points(jsonb) TO service_role;
+REVOKE EXECUTE ON FUNCTION replace_map_route_points(jsonb) FROM anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION restore_map_layout_snapshot(jsonb, jsonb, jsonb, jsonb) TO service_role;
+REVOKE EXECUTE ON FUNCTION restore_map_layout_snapshot(jsonb, jsonb, jsonb, jsonb) FROM anon, authenticated;


### PR DESCRIPTION
## 概要

PR #278（ver1.3 develop→main）に対するレビュー指摘のうち、コード修正が必要な3件に対応します。

---

## 修正内容

### 1. middleware: リダイレクト時に Supabase 更新済み Cookie を引き継ぐ

**指摘箇所**: `middleware.ts` line 21（Copilot）

`/admin`・`/moderator`・`/my-shop` へのアクセス拒否時、`NextResponse.redirect()` を返す前に `supabaseResponse.cookies` をコピーしていなかった。`getUser()` でセッションリフレッシュが発生した場合、更新された `Set-Cookie` がブラウザに届かず認証が失われる可能性があった。

```ts
// 修正前
return NextResponse.redirect(new URL("/", request.url));

// 修正後
const redirectRes = NextResponse.redirect(new URL("/", request.url));
supabaseResponse.cookies.getAll().forEach(({ name, value }) => {
  redirectRes.cookies.set(name, value);
});
return redirectRes;
```

---

### 2. migration: map-layout SQL 関数に REVOKE/GRANT を追加

**指摘箇所**: `supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql` line 16（Copilot）

`replace_map_route_points` と `restore_map_layout_snapshot` は `SECURITY DEFINER` だったが、`REVOKE/GRANT` が未設定で `PUBLIC`（`anon`/`authenticated` を含む）から実行可能な状態だった。`redeem_coupon` 関数と同等の権限設計に統一する。

```sql
GRANT EXECUTE ON FUNCTION replace_map_route_points(jsonb) TO service_role;
REVOKE EXECUTE ON FUNCTION replace_map_route_points(jsonb) FROM anon, authenticated;

GRANT EXECUTE ON FUNCTION restore_map_layout_snapshot(jsonb, jsonb, jsonb, jsonb) TO service_role;
REVOKE EXECUTE ON FUNCTION restore_map_layout_snapshot(jsonb, jsonb, jsonb, jsonb) FROM anon, authenticated;
```

---

### 3. grandma/ask: Zod バリデーション失敗を 500 から 400 に修正

**指摘箇所**: `app/api/grandma/ask/route.ts` line 142（Copilot）

JSON リクエストボディが `AskJsonBodySchema` に適合しない場合、`throw new Error()` で例外が外側の `try/catch` に捕捉されて 500 が返っていた。`parseRequest` 関数から `statusCode=400` 付きのエラーを throw し、POST ハンドラー側で補足して 400 Bad Request を返すよう修正する。

---

## 変更ファイル

- `middleware.ts`
- `supabase/migrations/20260515000001_create_map_layout_transaction_functions.sql`
- `app/api/grandma/ask/route.ts`

## 関連

- PR #278 のレビュー: https://github.com/KochiDXClub/nicchyo/pull/278