### PR TITLE
権限判定ロジックを permissions.ts に集約してリファクタ (#212)

### DIFF
--- a/app/(public)/admin/analytics/page.tsx
+++ b/app/(public)/admin/analytics/page.tsx
@@ -7,11 +7,6 @@ import { getRole, isAdmin } from "@/lib/auth/permissions";
 
 export const dynamic = "force-dynamic";
 
-// ---- auth helpers ----
-function isAdminAnalyticsRole(role: string | null | undefined) {
-  return role === "admin" || role === "super_admin";
-}
-
 function createAdminReadClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -113,7 +108,7 @@ export default async function AdminAnalyticsPage() {
   const vendorCats = (vendorCatsResult.data ?? []) as unknown as VendorCatRow[];
 
   // 管理者アクセスを除外
-  const userRows = pageRows.filter((r) => !isAdminAnalyticsRole(r.user_role));
+  const userRows = pageRows.filter((r) => !isAdmin(r.user_role));
 
   // ---- アクセス統計 ----
   function uniqueVisitors(rows: typeof userRows, fromDate: string) {

--- a/app/(public)/admin/dashboard/page.tsx
+++ b/app/(public)/admin/dashboard/page.tsx
@@ -106,8 +106,6 @@ function formatMinutes(value: number) {
   return `${value.toFixed(1)}分`;
 }
 
-
-
 function buildVisitorDailyDurationMap(rows: PageAnalyticsRow[]) {
   const byDate = new Map<string, Map<string, number>>();
 

--- a/app/(public)/admin/dashboard/page.tsx
+++ b/app/(public)/admin/dashboard/page.tsx
@@ -106,16 +106,14 @@ function formatMinutes(value: number) {
   return `${value.toFixed(1)}分`;
 }
 
-function isAdminAnalyticsRole(role: string | null | undefined) {
-  return role === "admin" || role === "super_admin";
-}
+
 
 function buildVisitorDailyDurationMap(rows: PageAnalyticsRow[]) {
   const byDate = new Map<string, Map<string, number>>();
 
   for (const row of rows) {
     if (!row.visit_date || !row.visitor_key) continue;
-    if (isAdminAnalyticsRole(row.user_role)) continue;
+    if (isAdmin(row.user_role)) continue;
     const duration = typeof row.duration_seconds === "number" ? row.duration_seconds : 0;
     const visitorMap = byDate.get(row.visit_date) ?? new Map<string, number>();
     visitorMap.set(row.visitor_key, (visitorMap.get(row.visitor_key) ?? 0) + duration);
@@ -358,7 +356,7 @@ export default async function AdminDashboardPage() {
   const allTrafficRows: DailyUniqueRow[] = Array.from(
     new Map(
       periodPageAnalytics
-        .filter((row) => !isAdminAnalyticsRole(row.user_role))
+        .filter((row) => !isAdmin(row.user_role))
         .map((row) => [`${row.visit_date}:${row.visitor_key}`, { visit_date: row.visit_date, visitor_key: row.visitor_key }])
     ).values()
   );
@@ -424,7 +422,7 @@ export default async function AdminDashboardPage() {
   const webAverageStayMinutes =
     allVisitorTotals.length > 0 ? weeklyDurationTotal / allVisitorTotals.length / 60 : 0;
 
-  const nonAdminPageAnalytics = latestDayPageAnalytics.filter((row) => !isAdminAnalyticsRole(row.user_role));
+  const nonAdminPageAnalytics = latestDayPageAnalytics.filter((row) => !isAdmin(row.user_role));
   const todayUrlMap = new Map<string, Map<string, number>>();
   for (const row of nonAdminPageAnalytics) {
     const path = row.path || "/";

--- a/app/(public)/admin/layout.tsx
+++ b/app/(public)/admin/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
+import { getRole, isModerator } from "@/lib/auth/permissions";
 import type { ReactNode } from "react";
 
 export default async function AdminLayout({ children }: { children: ReactNode }) {
@@ -8,10 +9,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   const supabase = createClient(cookieStore);
   const { data: { user } } = await supabase.auth.getUser();
 
-  const role = (user?.app_metadata as { role?: string } | undefined)?.role;
-  const isAllowed = role === "super_admin" || role === "admin" || role === "moderator";
-
-  if (!user || !isAllowed) {
+  if (!user || !isModerator(getRole(user))) {
     redirect("/");
   }
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { createClient as createServerClient } from "@/utils/supabase/server";
-import { getRole, isAdmin } from "@/lib/auth/permissions";
+import { getRole, isAdmin, normalizeRole } from "@/lib/auth/permissions";
 import type { UserRole } from "@/lib/auth/types";
 
 export const runtime = "nodejs";
@@ -26,13 +26,6 @@ type AdminUserRecord = {
   lastLogin: string;
   status: "active" | "suspended";
 };
-
-function normalizeRole(value?: string | null): UserRole {
-  if (value === "admin" || value === "super_admin") return "super_admin";
-  if (value === "moderator") return "moderator";
-  if (value === "vendor") return "vendor";
-  return "general_user";
-}
 
 function formatDate(value?: string | null) {
   if (!value) return "-";

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
+import type { UserRole } from "./types";
 
 /** app_metadata.role から文字列ロールを取り出す（unknown 型の user 対応） */
 export function getRole(user: unknown): string | null {
@@ -21,6 +22,14 @@ export function isModerator(role: string | null): boolean {
 /** vendor ロールかどうかを判定する */
 export function isVendor(role: string | null): boolean {
   return role === "vendor";
+}
+
+/** app_metadata の生ロール文字列を UserRole 型に正規化する */
+export function normalizeRole(value?: string | null): UserRole {
+  if (value === "admin" || value === "super_admin") return "super_admin";
+  if (value === "moderator") return "moderator";
+  if (value === "vendor") return "vendor";
+  return "general_user";
 }
 
 /** vendor ロール以外を 403 で弾く（API Route 用ガード） */


### PR DESCRIPTION
## 概要

`isAdminAnalyticsRole`・`normalizeRole` などの権限判定ロジックが複数ファイルに重複実装されていた問題を解消。`lib/auth/permissions.ts` に一元集約し、乖離を防ぐ。

## 主な変更

- `lib/auth/permissions.ts` に `normalizeRole` を追加
- `app/(public)/admin/layout.tsx` のインライン role チェックを `isModerator(getRole(user))` に置き換え
- `admin/analytics/page.tsx` のローカル `isAdminAnalyticsRole` を削除 → `isAdmin` を直接使用
- `admin/dashboard/page.tsx` の同上（3箇所）
- `app/api/admin/users/route.ts` のローカル `normalizeRole` を削除 → `permissions.ts` から import

## 変更ファイル

- `lib/auth/permissions.ts` — `normalizeRole` を追加
- `app/(public)/admin/layout.tsx` — インライン role チェックを permissions 関数に統一
- `app/(public)/admin/analytics/page.tsx` — ローカル関数を削除、`isAdmin` を直接使用
- `app/(public)/admin/dashboard/page.tsx` — 同上（3箇所）
- `app/api/admin/users/route.ts` — ローカル `normalizeRole` を削除

## 確認してほしいこと

- [ ] 管理者ページへのアクセス制御が正常に機能するか（admin / super_admin / moderator がアクセス可、それ以外はリダイレクト）
- [ ] アナリティクスページの訪問者集計からadminユーザーが除外されているか
- [ ] ユーザー管理ページのロール表示が正常か

## 補足

動作の変更なし。既存のロジックを集約しただけのリファクタです。

Closes #212