### PR TITLE
fix: AuthContext の getSession() を getUser() に変更・cleanup race condition 解消

### DIFF
--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -93,7 +93,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!supabase) return;
 
       // getSession() はサーバー検証なし。getUser() でサーバーサイド検証を行う
-      const { data } = await supabase.auth.getUser();
+      const { data, error } = await supabase.auth.getUser();
+      if (error) {
+        console.error("[AuthContext] getUser failed:", error.message);
+      }
       if (!active) return;
       if (data.user) {
         setUser(mapSupabaseUser(data.user));
@@ -104,8 +107,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       setIsLoading(false);
 
-      const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
         if (!active) return;
+        // INITIAL_SESSION は getUser() で処理済みのためスキップ（未検証ローカルトークンによる上書きを防ぐ）
+        if (event === "INITIAL_SESSION") return;
         if (session?.user) {
           setUser(mapSupabaseUser(session.user));
           setIsLoggedIn(true);

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -77,6 +77,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let active = true;
+    let unsubscribe: (() => void) | null = null;
 
     const init = async () => {
       if (!supabaseRef.current) {
@@ -91,10 +92,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const supabase = supabaseRef.current;
       if (!supabase) return;
 
-      const { data } = await supabase.auth.getSession();
+      // getSession() はサーバー検証なし。getUser() でサーバーサイド検証を行う
+      const { data } = await supabase.auth.getUser();
       if (!active) return;
-      if (data.session?.user) {
-        setUser(mapSupabaseUser(data.session.user));
+      if (data.user) {
+        setUser(mapSupabaseUser(data.user));
         setIsLoggedIn(true);
       } else {
         setUser(null);
@@ -102,7 +104,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       setIsLoading(false);
 
-      const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
         if (!active) return;
         if (session?.user) {
           setUser(mapSupabaseUser(session.user));
@@ -113,17 +115,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       });
 
-      return () => {
-        subscription.subscription.unsubscribe();
-      };
+      unsubscribe = () => sub.subscription.unsubscribe();
+      // cleanup が先に走っていた場合は即座に解除する
+      if (!active) unsubscribe();
     };
 
-    const cleanupPromise = init();
+    init();
     return () => {
       active = false;
-      if (cleanupPromise && typeof cleanupPromise.then === "function") {
-        cleanupPromise.then((cleanup) => cleanup?.());
-      }
+      unsubscribe?.();
     };
   }, []);
 


### PR DESCRIPTION
## 概要

`lib/auth/AuthContext.tsx` で Supabase のガイドライン違反（`getSession()` 使用）と cleanup の race condition を修正する。

## 主な変更

- `getSession()` → `getUser()` に変更（サーバーサイドでのセッション検証を行うようにする）
- subscription を `unsubscribe` クロージャ変数で管理し、cleanup を同期的に実行できるようにする
- `cleanupPromise.then(...)` による非同期 cleanup パターンを廃止し、race condition を解消

## 変更ファイル

- `lib/auth/AuthContext.tsx` — getUser() 対応と cleanup ロジック修正

## 確認してほしいこと

- [ ] ログイン・ログアウトが正常に動作すること
- [ ] ページリロード時に認証状態が復元されること
- [ ] 未ログイン時に認証保護ページへのアクセスが正しくリダイレクトされること

## 補足

`getSession()` は JWT の cookie をデコードするだけでサーバー検証を行わないため、セッションの有効期限切れや無効化が反映されない。`getUser()` はサーバーに問い合わせるため、より安全。

Closes #217