### PR TITLE
fix: 環境変数不足時の HTTP ステータスを 200 → 503 に修正

### DIFF
--- a/app/api/analytics/home-visit/route.ts
+++ b/app/api/analytics/home-visit/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: Request) {
         skipped: true,
         reason: "supabase_env_missing",
       },
-      { status: 200 }
+      { status: 503 }
     );
     if (shouldSetVisitorCookie) {
       skippedResponse.cookies.set(VISITOR_COOKIE_NAME, visitorKey, {

--- a/app/api/shops/route.ts
+++ b/app/api/shops/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
-    return NextResponse.json({ shops: [] }, { status: 200 });
+    return NextResponse.json({ shops: [] }, { status: 503 });
   }
 
   const supabase = createClient(supabaseUrl, supabaseKey, {


### PR DESCRIPTION
## 概要

API ルートで環境変数が不足している場合に `status: 200` を返していたため、クライアントの `if (!res.ok)` によるエラーハンドリングが機能しない問題を修正する。環境変数不足は設定エラーであるため `503 Service Unavailable` を返すように変更する。

## 主な変更

- `app/api/analytics/home-visit/route.ts`: 環境変数不足時を 200 → 503 に変更
- `app/api/shops/route.ts`: 環境変数不足時を 200 → 503 に変更

## 変更ファイル

- `app/api/analytics/home-visit/route.ts` — `supabase_env_missing` 時のステータスを 503 に修正
- `app/api/shops/route.ts` — Supabase 環境変数不足時のステータスを 503 に修正

## 確認してほしいこと

- [ ] 環境変数が設定されている通常環境では動作に変化がないこと
- [ ] 環境変数不足の場合にクライアントが `!res.ok` でエラーを検知できること

## 補足

他の `ok: false` を返す箇所（`home-summary`, `coupon-impression`, `shop-interaction` など）は既に適切なステータスコード（503/500 等）を使用していたため変更不要。

Closes #218