### PR TITLE
fix: .env.example に未記載の環境変数を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=
 # 管理者・サーバーサイドAPIで使用（公開しない）
 SUPABASE_SERVICE_ROLE_KEY=
 
+# サーバーサイド専用 Supabase URL（任意）
+# 未設定時は NEXT_PUBLIC_SUPABASE_URL にフォールバック
+# sync-embeddings・weekly-security-report・reports ページで参照
+SUPABASE_URL=
+
 # ----------------------------------------
 # OpenAI（AI機能に必須）
 # https://platform.openai.com/api-keys
@@ -77,3 +82,11 @@ NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 # 本番環境では設定しないこと
 # ----------------------------------------
 NEXT_PUBLIC_DEV_MARKET_DAY=
+
+# ----------------------------------------
+# Vercel 自動設定変数（手動設定不要）
+# Vercel デプロイ時に自動で注入される。ローカルでは設定しないこと
+# weekly-security-report API でアプリ URL の生成に使用
+# ----------------------------------------
+# VERCEL_PROJECT_PRODUCTION_URL=  # 本番ドメイン（例: nicchyo.jp）
+# VERCEL_URL=                     # デプロイごとのプレビュー URL


### PR DESCRIPTION
## 概要

コード内で参照されているが `.env.example` に記載されていない環境変数を追加する。新規メンバーが環境構築時に設定漏れを起こさないようにする。

## 主な変更

- `SUPABASE_URL` を追加（`sync-embeddings`・`weekly-security-report`・`reports/` で参照。未設定時は `NEXT_PUBLIC_SUPABASE_URL` にフォールバック）
- Vercel 自動設定変数（`VERCEL_PROJECT_PRODUCTION_URL`・`VERCEL_URL`）をコメントで文書化（手動設定不要な旨を明示）

## 変更ファイル

- `.env.example` — 未記載の環境変数を追加・コメントで用途を説明

## 確認してほしいこと

- [ ] `.env.example` に記載の変数名がコード内の参照と一致していること
- [ ] Vercel 自動変数がコメントアウト形式で正しく説明されていること

## 補足

Issue で指摘されていた他の変数（`NEXT_PUBLIC_TURNSTILE_SITE_KEY`・`NEXT_PUBLIC_DEV_MARKET_DAY`・`NEXT_PUBLIC_SITE_URL`・`CRON_SECRET`・`COUPON_QR_SECRET`・`ANTHROPIC_API_KEY`）はすでに `.env.example` に記載済みだった。

Closes #219