### PR TITLE
fix: ViewportHeightUpdater の orientationchange リスナーのメモリリークを解消

### DIFF
--- a/app/components/ViewportHeightUpdater.tsx
+++ b/app/components/ViewportHeightUpdater.tsx
@@ -22,15 +22,13 @@ export default function ViewportHeightUpdater() {
     // リサイズ時に更新
     window.addEventListener('resize', updateVH);
 
-    // iOS Safari: orientationchange にも対応
-    window.addEventListener('orientationchange', () => {
-      // orientationchange後、少し遅延させて実行（iOS Safari対策）
-      setTimeout(updateVH, 100);
-    });
+    // iOS Safari: orientationchange後、少し遅延させて実行
+    const handleOrientationChange = () => setTimeout(updateVH, 100);
+    window.addEventListener('orientationchange', handleOrientationChange);
 
     return () => {
       window.removeEventListener('resize', updateVH);
-      window.removeEventListener('orientationchange', updateVH);
+      window.removeEventListener('orientationchange', handleOrientationChange);
     };
   }, []);
 


### PR DESCRIPTION
## 概要

`orientationchange` イベントリスナーを無名アロー関数で登録し、別の関数参照（`updateVH`）で解除しようとしていたため、コンポーネントの mount/unmount 時にリスナーが蓄積するメモリリークが発生していた。名前付き関数に統一して登録・解除で同じ参照を使うよう修正する。

## 主な変更

- `handleOrientationChange` 名前付き関数を定義し、`addEventListener` / `removeEventListener` で同じ参照を使用

## 変更ファイル

- `app/components/ViewportHeightUpdater.tsx` — orientationchange リスナーのメモリリーク修正

## 確認してほしいこと

- [ ] iOS Safari で画面回転時に `--vh` CSS 変数が正しく更新されること
- [ ] コンポーネントの unmount 後にリスナーが残らないこと

## 補足

`useCallback` を使う実装も可能だが、`useEffect` の依存配列が `[]` のため `handleOrientationChange` は一度だけ定義される。クロージャで参照を共有するシンプルな実装で十分。

Closes #220