### PR TITLE
fix: 純粋表示コンポーネントから不要な "use client" を削除

### DIFF
--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";

--- a/components/admin/AdminPageHeader.tsx
+++ b/components/admin/AdminPageHeader.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ReactNode } from "react";
 
 type AdminPageHeaderProps = {


### PR DESCRIPTION
## 概要

状態・エフェクトを持たない純粋な表示コンポーネントに付いていた `"use client"` を削除し、サーバーコンポーネントとして動作させることでバンドルサイズ削減とサーバー→クライアントブリッジコストを削減する。

## 主な変更

- `components/admin/AdminPageHeader.tsx` から `"use client"` を削除
- `components/EmptyState.tsx` から `"use client"` を削除

## 変更ファイル

- `components/admin/AdminPageHeader.tsx` — 状態・エフェクトなし、サーバーコンポーネントで十分
- `components/EmptyState.tsx` — `cn` と Lucide アイコン描画のみ、状態なし

## 確認してほしいこと

- [ ] 管理画面のヘッダー表示が正常であること
- [ ] `EmptyState` を使っている画面（検索結果なし等）が正常に表示されること

## 補足

`components/admin/MenuCard.tsx` と `components/admin/StatCard.tsx` は Issue 記載の対象だが、すでに `"use client"` がなかったため変更なし。

`EmptyState` の `action` / `secondaryAction` 等の prop にクライアントコンポーネントを渡す場合は、渡す側が `"use client"` を持てばよく、このコンポーネント自体はサーバーコンポーネントのままで問題ない。

Closes #221