### PR TITLE
fix: <img> タグを next/image に置き換え、プロフィール画像の空 alt を修正

### DIFF
--- a/app/(public)/my-profile/page.tsx
+++ b/app/(public)/my-profile/page.tsx
@@ -1,6 +1,7 @@
 ﻿"use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import NavigationBar from "../../components/NavigationBar";
 import { useAuth } from "../../../lib/auth/AuthContext";
@@ -118,7 +119,7 @@ export default function MyProfilePage() {
           <div className="flex flex-col items-start gap-6 md:flex-row md:items-center md:gap-8">
             <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-amber-500 text-2xl font-bold text-white shadow-sm">
               {avatarUrl ? (
-                <img src={avatarUrl} alt="プロフィール画像" className="h-full w-full object-cover" />
+                <Image src={avatarUrl} alt="プロフィール画像" width={80} height={80} className="h-full w-full object-cover" />
               ) : (
                 user.name.charAt(0)
               )}

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -8,6 +8,7 @@
 
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
@@ -101,7 +102,7 @@ export default function HamburgerMenu() {
               <Link href={permissions.isVendor ? "/vendor/account" : "/my-profile"} onClick={closeMenu} className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-amber-500 text-white text-xl font-bold">
                   {user.avatarUrl ? (
-                    <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                    <Image src={user.avatarUrl} alt={user.name} width={48} height={48} className="h-full w-full object-cover" />
                   ) : (
                     user.name.charAt(0)
                   )}


### PR DESCRIPTION
## 概要

ネイティブ `<img>` タグを `next/image` の `<Image>` コンポーネントに置き換え、Next.js の画像最適化（WebP/AVIF 変換・遅延読み込み）を有効にする。あわせて意味のあるプロフィール画像の `alt=""` を適切なテキストに修正する。

## 主な変更

- `HamburgerMenu.tsx`: プロフィールアバターを `<Image>` に変換、`alt=""` → `alt={user.name}` に修正
- `my-profile/page.tsx`: プロフィールアバターを `<Image>` に変換（`alt` は既に適切だった）

## 変更ファイル

- `app/components/HamburgerMenu.tsx` — `<img>` → `<Image width={48} height={48}>` に変換、空 alt 修正
- `app/(public)/my-profile/page.tsx` — `<img>` → `<Image width={80} height={80}>` に変換

## 確認してほしいこと

- [ ] ハンバーガーメニューのプロフィールアバターが正常に表示されること
- [ ] マイプロフィールページのアバターが正常に表示されること

## 補足

Issue 記載の他のファイルについて：

- `ShopDetailBanner.tsx`・`BagCards.tsx`・`vendor/analytics/ai/page.tsx`・`vendor/ai-knowledge/page.tsx`・`admin/content/page.tsx` はすでに `<Image>` を使用していた
- `vendor/post/new/page.tsx`（354・431行）は `imagePreview` がブラウザ生成の blob URL のため `<Image>` では処理できない。`eslint-disable-next-line` コメントが既にあり意図的な判断
- `MapView.tsx:1147` は Leaflet マーカーの HTML テンプレート文字列内のため `<Image>` 使用不可
- `MapView.tsx:384` は `eslint-disable-next-line` があり現時点では変更せず

Closes #222