### PR TITLE
fix: lint 対象に utils/ と middleware.ts を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app/ lib/ components/ types/",
+    "lint": "eslint app/ lib/ components/ types/ utils/ middleware.ts",
     "test": "vitest run --passWithNoTests",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev"


### PR DESCRIPTION
## 概要

`package.json` の lint スクリプトが `app/ lib/ components/ types/` のみを対象にしており、セキュリティ上重要な `utils/supabase/` と `middleware.ts` が lint されていなかった。対象ディレクトリを拡張して、これらのファイルを lint 対象に含める。

## 主な変更

- `package.json` の lint スクリプトに `utils/` と `middleware.ts` を追加

## 変更ファイル

- `package.json` — lint 対象ディレクトリを拡張

## 確認してほしいこと

- [ ] `npm run lint` が既存の警告数と同じレベルで通ること（エラーが増えないこと）
- [ ] `utils/supabase/` と `middleware.ts` が lint 対象に含まれること

## 補足

`utils/` と `middleware.ts` を追加した結果、既存の警告数（34件）に変化はなく、新たなエラーも発生しなかった。`scripts/` は `.js`/`.mjs` ファイルのみでプロジェクトの TypeScript/Next.js ESLint ルールとの相性が悪いため対象外とした。

Closes #224