### PR TITLE
fix: abuseDetection の as any を解消し DatabaseWithExtensions を使用

### DIFF
--- a/app/api/grandma/ask/route.ts
+++ b/app/api/grandma/ask/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database.types";
+import type { DatabaseWithExtensions } from "@/types/database.extensions";
 import { buildGrandmaAiSystemPrompt } from "@/app/(public)/map/data/grandmaAiContext";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
 import { enforceRateLimit } from "@/lib/security/rateLimit";
@@ -547,7 +548,7 @@ export async function POST(request: Request) {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (supabaseUrl && serviceRoleKey) {
-      const secClient = createClient<Database>(supabaseUrl, serviceRoleKey);
+      const secClient = createClient<DatabaseWithExtensions>(supabaseUrl, serviceRoleKey);
       // x-real-ip はVercelが設定する信頼できるヘッダー（スプーフィング不可）
       const forwardedIp =
         request.headers.get("x-real-ip") ??

--- a/lib/grandma/abuseDetection.ts
+++ b/lib/grandma/abuseDetection.ts
@@ -1,9 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@/types/database.types";
+import type { DatabaseWithExtensions } from "@/types/database.extensions";
 import { detectAbuse } from "@/lib/security/abuseDetector";
 
 export async function handleAbuseDetection(
-  supabase: SupabaseClient<Database>,
+  supabase: SupabaseClient<DatabaseWithExtensions>,
   ip: string | null,
   text: string,
   visitorKey?: string
@@ -43,8 +43,7 @@ export async function handleAbuseDetection(
         visitor_key: visitorKey ?? null,
         reason: abuse.reason,
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (supabase as any).from("admin_notifications").insert({
+      await supabase.from("admin_notifications").insert({
         type: "ai_abuse",
         title: `AI不正アクセスをブロック（${abuse.type}）`,
         body: `IP: ${ip ?? "不明"} | visitor: ${visitorKey ?? "不明"} | ${abuse.reason} | 内容: ${text.slice(0, 80)}`,


### PR DESCRIPTION
## 概要

`lib/grandma/abuseDetection.ts` で `admin_notifications` テーブルへのアクセスに `as any` キャストを使っていた。既存の `DatabaseWithExtensions` 型（`types/database.extensions.ts`）が `admin_notifications` を含んでいるため、これを使って型安全にアクセスするよう修正する。

## 主な変更

- `lib/grandma/abuseDetection.ts`: `SupabaseClient<Database>` → `SupabaseClient<DatabaseWithExtensions>` に変更、`as any` キャストと eslint-disable コメントを削除
- `app/api/grandma/ask/route.ts`: `secClient` の型を `DatabaseWithExtensions` に変更（`handleAbuseDetection` の引数型に合わせる）

## 変更ファイル

- `lib/grandma/abuseDetection.ts` — 型を修正、`as any` 削除
- `app/api/grandma/ask/route.ts` — `secClient` 生成時の型パラメータを修正

## 確認してほしいこと

- [ ] `npx tsc --noEmit` が通ること
- [ ] `npm run lint` が通ること

## 補足

Issue で指摘されている他の箇所（`admin/notifications/route.ts`・`coupon-impression/route.ts`・`shop-interaction/route.ts`）はすでに `DatabaseWithExtensions` を使用していた。また、`types/database.extensions.ts` にすでに必要なテーブル定義が手動で追加されていた。

Closes #225