### PR TITLE
fix: <button> に type="button" を追加・ESLint ルールで再発防止 (#223)

### DIFF
--- a/app/(public)/admin/audit-logs/page.tsx
+++ b/app/(public)/admin/audit-logs/page.tsx
@@ -206,6 +206,7 @@ export default function AuditLogsPage() {
               const labels = { all: "すべて", today: "今日", week: "7日間", month: "30日間" };
               return (
                 <button
+                  type="button"
                   key={f}
                   onClick={() => setDateFilter(f)}
                   className={`rounded-lg px-3 py-1.5 text-sm font-medium ${
@@ -227,6 +228,7 @@ export default function AuditLogsPage() {
               const activeColors = { all: "bg-slate-700", admin: "bg-red-600", moderator: "bg-purple-600" };
               return (
                 <button
+                  type="button"
                   key={f}
                   onClick={() => setRoleFilter(f)}
                   className={`rounded-lg px-3 py-1.5 text-sm font-medium ${
@@ -254,12 +256,14 @@ export default function AuditLogsPage() {
           {/* エクスポート */}
           <div className="flex gap-2">
             <button
+              type="button"
               onClick={handleExportCSV}
               className="flex items-center gap-1.5 rounded-lg bg-green-700 px-3 py-2 text-sm font-medium text-white hover:bg-green-800"
             >
               <Download size={14} /> CSV
             </button>
             <button
+              type="button"
               onClick={handleExportJSON}
               className="flex items-center gap-1.5 rounded-lg bg-slate-600 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700"
             >

--- a/app/(public)/admin/content/page.tsx
+++ b/app/(public)/admin/content/page.tsx
@@ -158,6 +158,7 @@ export default function AdminContentPage() {
               const activeColors = { all: "bg-gray-700", active: "bg-green-700", expired: "bg-slate-500" };
               return (
                 <button
+                  type="button"
                   key={f}
                   onClick={() => setFilter(f)}
                   className={`rounded-lg px-4 py-2 text-sm font-medium ${
@@ -239,6 +240,7 @@ export default function AdminContentPage() {
 
                 {/* 削除ボタン */}
                 <button
+                  type="button"
                   onClick={() => handleDelete(c.id, c.shop_name)}
                   disabled={deletingId === c.id}
                   className="flex shrink-0 items-center gap-1.5 rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"

--- a/app/(public)/admin/notifications/page.tsx
+++ b/app/(public)/admin/notifications/page.tsx
@@ -70,6 +70,7 @@ export default function NotificationsPage() {
               未読通知が {unreadCount} 件あります
             </span>
             <button
+              type="button"
               onClick={handleMarkAllRead}
               className="rounded-lg bg-orange-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-orange-700"
             >

--- a/app/(public)/admin/shops/page.tsx
+++ b/app/(public)/admin/shops/page.tsx
@@ -296,6 +296,7 @@ function AdminShopsContent() {
           <div className="mb-4 rounded-lg bg-red-50 border border-red-200 p-4 flex items-center justify-between">
             <p className="text-sm text-red-700">{fetchError}</p>
             <button
+              type="button"
               onClick={loadShops}
               className="ml-4 rounded-lg bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700"
             >
@@ -319,18 +320,21 @@ function AdminShopsContent() {
                 <div className="flex flex-wrap gap-2 items-center">
                   <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">ステータス:</span>
                   <button
+                    type="button"
                     onClick={() => setFilter("all")}
                     className={`rounded-lg px-3 py-1.5 text-sm font-medium ${filter === "all" ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                   >
                     すべて ({stats.total})
                   </button>
                   <button
+                    type="button"
                     onClick={() => setFilter("active")}
                     className={`rounded-lg px-3 py-1.5 text-sm font-medium ${filter === "active" ? "bg-green-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                   >
                     稼働中 ({stats.active})
                   </button>
                   <button
+                    type="button"
                     onClick={() => setFilter("suspended")}
                     className={`rounded-lg px-3 py-1.5 text-sm font-medium ${filter === "suspended" ? "bg-red-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                   >
@@ -355,6 +359,7 @@ function AdminShopsContent() {
                 <div className="flex flex-wrap gap-2 items-center pt-2 border-t border-gray-200">
                   <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">カテゴリー:</span>
                   <button
+                    type="button"
                     onClick={() => setCategoryFilter("all")}
                     className={`rounded-lg px-2.5 py-1 text-xs font-medium ${categoryFilter === "all" ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                   >
@@ -362,6 +367,7 @@ function AdminShopsContent() {
                   </button>
                   {uniqueCategories.map((cat) => (
                     <button
+                      type="button"
                       key={cat}
                       onClick={() => setCategoryFilter(cat)}
                       className={`rounded-lg px-2.5 py-1 text-xs font-medium ${categoryFilter === cat ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
@@ -379,7 +385,7 @@ function AdminShopsContent() {
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="flex items-center gap-3">
                     <span className="text-sm font-medium text-blue-900">{selectedShopIds.length}件選択中</span>
-                    <button onClick={() => setSelectedShopIds([])} className="text-sm text-blue-600 hover:text-blue-800">
+                    <button type="button" onClick={() => setSelectedShopIds([])} className="text-sm text-blue-600 hover:text-blue-800">
                       解除
                     </button>
                   </div>
@@ -485,6 +491,7 @@ function AdminShopsContent() {
                                 <td className="px-4 py-3 text-right text-sm whitespace-nowrap">
                                   {shop.status === "active" ? (
                                     <button
+                                      type="button"
                                       onClick={() => handleSingleAction(shop.id, "suspend")}
                                       className="text-orange-600 hover:text-orange-900 mr-3"
                                     >
@@ -492,6 +499,7 @@ function AdminShopsContent() {
                                     </button>
                                   ) : (
                                     <button
+                                      type="button"
                                       onClick={() => handleSingleAction(shop.id, "restore")}
                                       className="text-green-600 hover:text-green-900 mr-3"
                                     >
@@ -499,6 +507,7 @@ function AdminShopsContent() {
                                     </button>
                                   )}
                                   <button
+                                    type="button"
                                     onClick={() => handleSingleAction(shop.id, "delete")}
                                     className="text-red-600 hover:text-red-900"
                                   >
@@ -545,6 +554,7 @@ function AdminShopsContent() {
                       <div className="flex gap-2">
                         {shop.status === "active" ? (
                           <button
+                            type="button"
                             onClick={() => handleSingleAction(shop.id, "suspend")}
                             className="flex-1 rounded-lg border border-orange-300 py-1.5 text-sm text-orange-600 hover:bg-orange-50"
                           >
@@ -552,6 +562,7 @@ function AdminShopsContent() {
                           </button>
                         ) : (
                           <button
+                            type="button"
                             onClick={() => handleSingleAction(shop.id, "restore")}
                             className="flex-1 rounded-lg border border-green-300 py-1.5 text-sm text-green-600 hover:bg-green-50"
                           >
@@ -559,6 +570,7 @@ function AdminShopsContent() {
                           </button>
                         )}
                         <button
+                          type="button"
                           onClick={() => handleSingleAction(shop.id, "delete")}
                           className="flex-1 rounded-lg border border-red-300 py-1.5 text-sm text-red-600 hover:bg-red-50"
                         >
@@ -578,6 +590,7 @@ function AdminShopsContent() {
       <div className="hidden sm:block">
         <Tooltip content="キーボードショートカット (?)">
           <button
+            type="button"
             onClick={() => setShowShortcutHelp(true)}
             className="fixed bottom-8 right-8 w-12 h-12 bg-gray-800 hover:bg-gray-700 text-white rounded-full shadow-lg flex items-center justify-center z-40 transition"
             aria-label="ショートカット一覧"
@@ -595,7 +608,7 @@ function AdminShopsContent() {
           <div className="bg-white rounded-lg p-6 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold text-gray-900">キーボードショートカット</h3>
-              <button onClick={() => setShowShortcutHelp(false)} className="text-gray-400 hover:text-gray-600">
+              <button type="button" onClick={() => setShowShortcutHelp(false)} className="text-gray-400 hover:text-gray-600">
                 <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>

--- a/app/(public)/admin/users/page.tsx
+++ b/app/(public)/admin/users/page.tsx
@@ -462,6 +462,7 @@ function AdminUsersContent() {
               JSON出力
             </LoadingButton>
             <button
+              type="button"
               onClick={handleCreateUser}
               className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
               aria-label="新規ユーザーを追加"
@@ -503,6 +504,7 @@ function AdminUsersContent() {
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex gap-2">
               <button
+                type="button"
                 onClick={() => setFilter("all")}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${
                   filter === "all"
@@ -514,6 +516,7 @@ function AdminUsersContent() {
                 すべて ({stats.total})
               </button>
               <button
+                type="button"
                 onClick={() => setFilter("super_admin")}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${
                   filter === "super_admin"
@@ -525,6 +528,7 @@ function AdminUsersContent() {
                 管理者 ({stats.admins})
               </button>
               <button
+                type="button"
                 onClick={() => setFilter("vendor")}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${
                   filter === "vendor"
@@ -536,6 +540,7 @@ function AdminUsersContent() {
                 出店者 ({stats.vendors})
               </button>
               <button
+                type="button"
                 onClick={() => setFilter("general_user")}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${
                   filter === "general_user"
@@ -547,6 +552,7 @@ function AdminUsersContent() {
                 一般 ({stats.users})
               </button>
               <button
+                type="button"
                 onClick={() => setFilter("suspended")}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${
                   filter === "suspended"
@@ -582,6 +588,7 @@ function AdminUsersContent() {
                   {selectedUserIds.length}人選択中
                 </span>
                 <button
+                  type="button"
                   onClick={() => setSelectedUserIds([])}
                   className="text-sm text-blue-600 hover:text-blue-800"
                   aria-label="選択を解除"
@@ -819,6 +826,7 @@ function AdminUsersContent() {
                           >
                             <Tooltip content="ロール・権限を変更" position="top">
                               <button
+                                type="button"
                                 onClick={() => handleOpenRoleChange(user)}
                                 className="text-purple-600 hover:text-purple-900 mr-3"
                                 aria-label={`${user.name}の権限を変更`}
@@ -829,6 +837,7 @@ function AdminUsersContent() {
                             {user.status === "active" ? (
                               <Tooltip content="ユーザーを停止" position="top">
                                 <button
+                                  type="button"
                                   onClick={() => handleSuspendUser(user)}
                                   className="text-orange-600 hover:text-orange-900"
                                   aria-label={`${user.name}を停止`}
@@ -839,6 +848,7 @@ function AdminUsersContent() {
                             ) : (
                               <Tooltip content="ユーザーを復帰" position="top">
                                 <button
+                                  type="button"
                                   onClick={() => handleRestoreUser(user)}
                                   className="text-green-600 hover:text-green-900"
                                   aria-label={`${user.name}を復帰`}
@@ -913,6 +923,7 @@ function AdminUsersContent() {
             </div>
             <div className="mt-6 flex gap-2">
               <button
+                type="button"
                 onClick={handleRoleChange}
                 className="flex-1 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700"
                 aria-label="ロールを変更"
@@ -920,6 +931,7 @@ function AdminUsersContent() {
                 変更する
               </button>
               <button
+                type="button"
                 onClick={() => setRoleChangeUser(null)}
                 className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
                 aria-label="キャンセル"
@@ -934,6 +946,7 @@ function AdminUsersContent() {
       {/* キーボードショートカットヘルプボタン */}
       <Tooltip content="キーボードショートカット (?)">
         <button
+          type="button"
           onClick={() => setShowShortcutHelp(true)}
           className="fixed bottom-8 right-8 w-12 h-12 bg-gray-800 hover:bg-gray-700 text-white rounded-full shadow-lg flex items-center justify-center z-40 transition"
           aria-label="キーボードショートカット一覧を表示"
@@ -951,6 +964,7 @@ function AdminUsersContent() {
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold text-gray-900">キーボードショートカット</h3>
               <button
+                type="button"
                 onClick={() => setShowShortcutHelp(false)}
                 className="text-gray-400 hover:text-gray-600"
                 aria-label="閉じる"

--- a/app/(public)/contact/ContactForm.tsx
+++ b/app/(public)/contact/ContactForm.tsx
@@ -85,6 +85,7 @@ export default function ContactForm() {
           内容を確認の上、担当者よりご連絡させていただきます。
         </p>
         <button
+          type="button"
           onClick={() => setIsSubmitted(false)}
           className="mt-4 text-sm font-medium text-amber-600 hover:text-amber-700 underline underline-offset-4"
         >

--- a/app/(public)/faq/FaqClient.tsx
+++ b/app/(public)/faq/FaqClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { Search, ChevronDown, ChevronUp, MessageCircle } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FAQ_DATA, FAQ_CATEGORIES, type FaqCategory } from "./data";
+import { FAQ_DATA, FAQ_CATEGORIES } from "./data";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import EmptyState from "@/components/EmptyState";
@@ -58,6 +58,7 @@ export default function FaqClient() {
             const isSelected = selectedCategory === cat.id;
             return (
               <button
+                type="button"
                 key={cat.id}
                 onClick={() => setSelectedCategory(cat.id)}
                 className={cn(
@@ -89,6 +90,7 @@ export default function FaqClient() {
                 className="overflow-hidden rounded-2xl border border-orange-100 bg-white/90 shadow-sm transition-shadow hover:shadow-md"
               >
                 <button
+                  type="button"
                   onClick={() => toggleItem(item.id)}
                   className="flex w-full items-start justify-between gap-4 p-5 text-left"
                 >
@@ -131,6 +133,7 @@ export default function FaqClient() {
                 description="キーワードを変更するか、AIチャットボットにお気軽にご相談ください。"
                 action={
                   <button
+                    type="button"
                     onClick={() => {
                       setSearchQuery("");
                       setSelectedCategory("all");

--- a/app/(public)/map/components/FirstVisitGuide.tsx
+++ b/app/(public)/map/components/FirstVisitGuide.tsx
@@ -93,6 +93,7 @@ export default function FirstVisitGuide() {
           <div className="mt-8 flex justify-center gap-3">
              {step < 2 ? (
                <button
+                 type="button"
                  onClick={handleNext}
                  className="w-full rounded-xl bg-amber-500 py-3 text-base font-bold text-white shadow-md transition hover:bg-amber-600 active:scale-95"
                >
@@ -100,6 +101,7 @@ export default function FirstVisitGuide() {
                </button>
              ) : (
                <button
+                 type="button"
                  onClick={handleComplete}
                  className="w-full rounded-xl bg-amber-500 py-3 text-base font-bold text-white shadow-md transition hover:bg-amber-600 active:scale-95"
                >

--- a/app/(public)/map/components/GrandmaGuide.tsx
+++ b/app/(public)/map/components/GrandmaGuide.tsx
@@ -103,6 +103,7 @@ export default function GrandmaGuide() {
         {menuButton}
         {menuPanel}
         <button
+          type="button"
         onClick={handleToggle}
         className="fixed top-20 right-4 z-[2000] group animate-slide-in-right"
         aria-label="ガイドを開く"
@@ -141,6 +142,7 @@ export default function GrandmaGuide() {
       <div className="relative bg-white rounded-2xl shadow-2xl max-w-sm border-4 border-amber-600 overflow-hidden">
         {/* 閉じるボタン */}
         <button
+          type="button"
           onClick={handleToggle}
           className="absolute top-3 right-3 z-10 bg-white hover:bg-gray-100 rounded-full p-1.5 shadow-md transition-all hover:scale-110"
           aria-label="折りたたむ"
@@ -217,6 +219,7 @@ export default function GrandmaGuide() {
 
           <div className="mt-4 pt-4 border-t border-amber-200">
             <button
+              type="button"
               onClick={handleToggle}
               className="w-full bg-gradient-to-r from-amber-500 to-orange-500 text-white py-3 rounded-lg font-bold text-sm hover:from-amber-600 hover:to-orange-600 transition-all shadow-md hover:shadow-lg active:scale-95"
             >

--- a/app/(public)/moderator/kotodute/page.tsx
+++ b/app/(public)/moderator/kotodute/page.tsx
@@ -241,7 +241,7 @@ export function ModeratorKotoduteContent() {
               { f: "hidden" as const, label: `非公開 (${stats.hidden})`, active: "bg-orange-600" },
               { f: "deleted" as const, label: `削除済み (${stats.deleted})`, active: "bg-gray-600" },
             ]).map(({ f, label, active }) => (
-              <button key={f} onClick={() => setFilter(f)}
+              <button type="button" key={f} onClick={() => setFilter(f)}
                 className={`rounded-lg px-4 py-2 text-sm font-medium ${filter === f ? `${active} text-white` : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                 {label}
               </button>
@@ -257,12 +257,12 @@ export function ModeratorKotoduteContent() {
           {uniqueShops.length > 0 && (
             <div className="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
               <span className="text-xs font-medium text-slate-500 uppercase">店舗:</span>
-              <button onClick={() => setShopFilter("all")}
+              <button type="button" onClick={() => setShopFilter("all")}
                 className={`rounded-lg px-3 py-1.5 text-sm font-medium ${shopFilter === "all" ? "bg-gray-700 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
                 すべて
               </button>
               {uniqueShops.map((s) => (
-                <button key={s} onClick={() => setShopFilter(s)}
+                <button type="button" key={s} onClick={() => setShopFilter(s)}
                   className={`rounded-lg px-3 py-1.5 text-sm font-medium ${shopFilter === s ? "bg-gray-700 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
                   {s}
                 </button>
@@ -276,7 +276,7 @@ export function ModeratorKotoduteContent() {
           <div className="mb-4 flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
             <div className="flex items-center gap-4">
               <span className="text-sm font-medium text-slate-800">{selectedIds.length}件選択中</span>
-              <button onClick={() => setSelectedIds([])} className="text-sm text-slate-500 hover:text-slate-700">選択解除</button>
+              <button type="button" onClick={() => setSelectedIds([])} className="text-sm text-slate-500 hover:text-slate-700">選択解除</button>
             </div>
             <div className="flex gap-2">
               <LoadingButton onClick={() => handleBulkUpdate("published", "公開")} isLoading={actionLoading} loadingText="処理中..."
@@ -337,11 +337,11 @@ export function ModeratorKotoduteContent() {
                 <div className="mt-4 flex flex-wrap gap-2 border-t border-slate-100 pt-4">
                   {k.status === "published" && (
                     <>
-                      <button onClick={() => updateStatus([k.id], "hidden", "非公開")} disabled={actionLoading}
+                      <button type="button" onClick={() => updateStatus([k.id], "hidden", "非公開")} disabled={actionLoading}
                         className="rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:opacity-50">
                         🔒 非公開
                       </button>
-                      <button onClick={() => updateStatus([k.id], "deleted", "削除")} disabled={actionLoading}
+                      <button type="button" onClick={() => updateStatus([k.id], "deleted", "削除")} disabled={actionLoading}
                         className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50">
                         🗑️ 削除
                       </button>
@@ -349,18 +349,18 @@ export function ModeratorKotoduteContent() {
                   )}
                   {k.status === "hidden" && (
                     <>
-                      <button onClick={() => updateStatus([k.id], "published", "公開")} disabled={actionLoading}
+                      <button type="button" onClick={() => updateStatus([k.id], "published", "公開")} disabled={actionLoading}
                         className="rounded-lg bg-green-700 px-4 py-2 text-sm font-medium text-white hover:bg-green-800 disabled:opacity-50">
                         ✓ 公開
                       </button>
-                      <button onClick={() => updateStatus([k.id], "deleted", "削除")} disabled={actionLoading}
+                      <button type="button" onClick={() => updateStatus([k.id], "deleted", "削除")} disabled={actionLoading}
                         className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50">
                         🗑️ 削除
                       </button>
                     </>
                   )}
                   {k.status === "deleted" && (
-                    <button onClick={() => updateStatus([k.id], "published", "公開（復元）")} disabled={actionLoading}
+                    <button type="button" onClick={() => updateStatus([k.id], "published", "公開（復元）")} disabled={actionLoading}
                       className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
                       ↺ 復元
                     </button>

--- a/app/(public)/moderator/page.tsx
+++ b/app/(public)/moderator/page.tsx
@@ -180,6 +180,7 @@ function ModeratorDashboardContent() {
           <div className="mb-6 rounded-lg bg-red-50 border border-red-200 p-4 flex items-center justify-between">
             <p className="text-sm text-red-700">{dataError}</p>
             <button
+              type="button"
               onClick={loadStats}
               className="ml-4 rounded-lg bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700"
             >

--- a/app/(public)/posts/PostsClient.tsx
+++ b/app/(public)/posts/PostsClient.tsx
@@ -56,7 +56,7 @@ export default function PostsClient() {
               rows={3}
             />
             <div className="mt-2 flex justify-end">
-              <button className="bg-amber-600 text-white px-6 py-2 rounded-full text-sm font-bold shadow-sm hover:bg-amber-500 transition-colors active:scale-95">
+              <button type="button" className="bg-amber-600 text-white px-6 py-2 rounded-full text-sm font-bold shadow-sm hover:bg-amber-500 transition-colors active:scale-95">
                 投稿する
               </button>
             </div>
@@ -97,6 +97,7 @@ export default function PostsClient() {
                   あなたの発見が、誰かの「行きたい！」につながります。
                 </p>
                 <button
+                  type="button"
                   onClick={handleFocus}
                   className="inline-flex items-center gap-2 rounded-full bg-amber-600 px-8 py-3 text-sm font-bold text-white shadow-lg shadow-amber-200/50 transition hover:bg-amber-500 hover:shadow-xl active:scale-95"
                 >

--- a/app/(public)/search/components/SearchDiscovery.tsx
+++ b/app/(public)/search/components/SearchDiscovery.tsx
@@ -85,6 +85,7 @@ export default function SearchDiscovery({
         <div className="flex flex-wrap gap-2">
           {visibleCategories.map((cat) => (
             <button
+              type="button"
               key={cat}
               onClick={() => onCategorySelect(cat)}
               className="rounded-full border border-amber-100 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm transition hover:border-amber-300 hover:bg-amber-50 active:scale-95"

--- a/app/about/AboutStory.tsx
+++ b/app/about/AboutStory.tsx
@@ -154,6 +154,7 @@ export default function AboutStory() {
       <div className="fixed bottom-0 left-0 right-0 border-t border-amber-100 bg-white/90 px-6 py-6 backdrop-blur-sm safe-bottom">
         <div className="mx-auto flex max-w-md items-center justify-between gap-4">
           <button
+            type="button"
             onClick={prevSlide}
             disabled={currentIndex === 0}
             className={`flex h-12 w-12 items-center justify-center rounded-full transition ${
@@ -171,6 +172,7 @@ export default function AboutStory() {
           </span>
 
           <button
+            type="button"
             onClick={nextSlide}
             disabled={currentIndex === aboutSlides.length - 1}
             className={`flex h-14 flex-1 items-center justify-center gap-2 rounded-full font-bold shadow-md transition active:scale-95 ${

--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -8,6 +8,7 @@
 
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
@@ -53,6 +54,7 @@ export default function HamburgerMenu() {
     <>
       {/* ハンバーガーボタン（固定位置・オーバーレイ） */}
       <button
+        type="button"
         onClick={toggleMenu}
         className={`hamburger-button fixed top-4 right-4 z-[10002] flex h-12 w-12 items-center justify-center rounded-lg bg-white/90 text-gray-700 shadow-md transition hover:bg-white hover:shadow-lg ${
           isMenuOpen ? "is-open" : "is-closed"
@@ -101,7 +103,7 @@ export default function HamburgerMenu() {
               <Link href={permissions.isVendor ? "/vendor/account" : "/my-profile"} onClick={closeMenu} className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-amber-500 text-white text-xl font-bold">
                   {user.avatarUrl ? (
-                    <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                    <Image src={user.avatarUrl} alt={user.name} width={48} height={48} className="h-full w-full object-cover" />
                   ) : (
                     user.name.charAt(0)
                   )}
@@ -495,6 +497,7 @@ export default function HamburgerMenu() {
 
                   <li>
                     <button
+                      type="button"
                       onClick={handleLogout}
                       className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-gray-700 transition hover:bg-red-50 hover:text-red-600"
                     >

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -216,6 +216,7 @@ function NavigationBarInner({
                   </div>
                 ) : (
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/login")}
                     className="mb-4 flex w-full items-center gap-4 rounded-2xl border-2 border-dashed border-amber-200 bg-amber-50/50 px-4 py-4 text-left transition active:scale-[0.98] active:bg-amber-50"
                   >
@@ -240,6 +241,7 @@ function NavigationBarInner({
                   <div className="mb-3 h-[76px] animate-pulse rounded-2xl bg-gray-100" />
                 ) : couponLoadError ? (
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/coupons")}
                     className="mb-3 flex w-full items-center gap-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 text-left transition active:scale-[0.98]"
                   >
@@ -259,6 +261,7 @@ function NavigationBarInner({
                 ) : activeCoupon && isMarketDay ? (
                   /* 今すぐ使えるクーポン */
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/coupons")}
                     className="mb-3 flex w-full items-center gap-4 rounded-2xl bg-green-500 px-4 py-4 text-left shadow-sm transition hover:bg-green-600 active:scale-[0.98]"
                   >
@@ -285,6 +288,7 @@ function NavigationBarInner({
                 ) : isMarketDay ? (
                   /* 開催日・クーポン未保有 */
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/coupons")}
                     className="mb-3 flex w-full items-center gap-4 rounded-2xl border-2 border-dashed border-green-200 bg-green-50/50 px-4 py-4 text-left transition active:scale-[0.98]"
                   >
@@ -304,6 +308,7 @@ function NavigationBarInner({
                 ) : (
                   /* 非開催日・または取得失敗：通常メニュー項目 */
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/coupons")}
                     className="mb-3 flex w-full items-center gap-3 rounded-2xl border border-green-100 bg-green-50 px-4 py-3.5 text-left transition active:scale-[0.98]"
                   >
@@ -317,6 +322,7 @@ function NavigationBarInner({
 
                 {/* ─ プライマリ：バッグ ─ */}
                 <button
+                  type="button"
                   onClick={() => handleMenuItemClick("/bag")}
                   className={`mb-4 flex w-full items-center gap-3 rounded-2xl px-4 py-3.5 text-left transition active:scale-[0.98] ${
                     bagItems.length > 0
@@ -367,6 +373,7 @@ function NavigationBarInner({
                 {/* ─ 補足：テキストリンク ─ */}
                 <div className="mb-4 flex flex-wrap gap-x-5 gap-y-2 px-1">
                   <button
+                    type="button"
                     onClick={() => handleMenuItemClick("/recipes")}
                     className="text-[13px] text-slate-400 transition hover:text-slate-600"
                   >
@@ -383,6 +390,7 @@ function NavigationBarInner({
                     <div className="overflow-hidden rounded-2xl border border-amber-100 bg-white shadow-sm">
                       {vendorMenuItems.map((item, i) => (
                         <button
+                          type="button"
                           key={item.href}
                           onClick={() => handleMenuItemClick(item.href)}
                           className={`flex w-full items-center gap-4 px-4 py-[14px] text-left transition active:bg-amber-50 ${i !== 0 ? "border-t border-gray-100" : ""}`}
@@ -405,6 +413,7 @@ function NavigationBarInner({
                     <div className="overflow-hidden rounded-2xl border border-red-100 bg-white shadow-sm">
                       {adminMenuItems.map((item, i) => (
                         <button
+                          type="button"
                           key={item.href}
                           onClick={() => handleMenuItemClick(item.href)}
                           className={`flex w-full items-center gap-4 px-4 py-[14px] text-left transition active:bg-red-50 ${i !== 0 ? "border-t border-gray-100" : ""}`}
@@ -423,6 +432,7 @@ function NavigationBarInner({
                 {/* ─ ログアウト ─ */}
                 {isLoggedIn && (
                   <button
+                    type="button"
                     onClick={handleLogout}
                     className="flex w-full items-center justify-center gap-2.5 rounded-2xl border border-gray-200 bg-white py-[14px] text-[14px] font-semibold text-gray-500 shadow-sm transition active:bg-gray-50 active:scale-[0.98]"
                   >
@@ -476,6 +486,7 @@ function NavigationBarInner({
             {/* 中央：メニューボタン */}
             <div className="flex flex-1 items-center justify-center">
               <button
+                type="button"
                 onClick={() => setMenuOpen((v) => !v)}
                 className="flex flex-col items-center gap-1 transition-all duration-200 active:scale-95"
               >
@@ -519,6 +530,7 @@ function NavigationBarInner({
           /* ── サブページ：もどるバー ── */
           <div className="mx-auto flex h-14 max-w-lg items-center px-4">
             <button
+              type="button"
               onClick={() => router.push("/map")}
               className="flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-gray-600 transition active:scale-95 hover:bg-gray-100"
             >

--- a/app/vendor/post/new/page.tsx
+++ b/app/vendor/post/new/page.tsx
@@ -78,12 +78,12 @@ function PostCard({ post, onRepost, onEditRepost }: { post: Post; onRepost: (pos
         </div>
       </div>
       <div className="mt-3 flex gap-2 border-t border-slate-100 pt-3">
-        <button onClick={() => onRepost(post)}
+        <button type="button" onClick={() => onRepost(post)}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-amber-200 bg-amber-50 py-2 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
         >
           <RotateCcw size={13} />そのまま再投稿
         </button>
-        <button onClick={() => onEditRepost(post)}
+        <button type="button" onClick={() => onEditRepost(post)}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-slate-200 bg-slate-50 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
         >
           <Pencil size={13} />編集して再投稿
@@ -256,6 +256,7 @@ export default function VendorPostNewPage() {
               出店者メニューへ
             </Link>
             <button
+              type="button"
               onClick={() => { setIsSubmitted(false); setText(""); setImageFile(null); setImagePreview(null); setExpirationPreset("today"); setCustomDateTime(""); }}
               className="text-sm font-medium text-slate-500 hover:text-slate-700 hover:underline"
             >
@@ -285,12 +286,14 @@ export default function VendorPostNewPage() {
         {/* タブバー */}
         <div className="mx-auto mt-3 flex max-w-2xl gap-1 rounded-2xl border border-slate-200 bg-slate-100 p-1.5">
           <button
+            type="button"
             onClick={() => setActiveTab("new")}
             className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-semibold transition ${activeTab === "new" ? "bg-white text-amber-600 shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
           >
             <PlusCircle size={13} />新規投稿
           </button>
           <button
+            type="button"
             onClick={() => setActiveTab("history")}
             className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-semibold transition ${activeTab === "history" ? "bg-white text-amber-600 shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
           >
@@ -455,7 +458,7 @@ export default function VendorPostNewPage() {
 
           <div className="mb-4 flex gap-1.5 rounded-3xl border border-slate-200 bg-white p-1.5 shadow-sm">
             {FILTER_TABS.map((tab) => (
-              <button key={tab.key} onClick={() => setFilterTab(tab.key)}
+              <button type="button" key={tab.key} onClick={() => setFilterTab(tab.key)}
                 className={`flex flex-1 items-center justify-center gap-1.5 rounded-2xl py-3 text-sm font-semibold transition ${filterTab === tab.key ? "bg-amber-500 text-white shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
               >
                 {tab.label}
@@ -490,7 +493,7 @@ export default function VendorPostNewPage() {
           <div className="flex items-center gap-2 rounded-2xl bg-emerald-600 px-5 py-3 shadow-lg">
             <CheckCircle2 size={16} className="text-white" />
             <span className="text-sm font-semibold text-white">再投稿しました！</span>
-            <button onClick={() => setShowRepostToast(false)} className="ml-2 text-emerald-200 hover:text-white">
+            <button type="button" onClick={() => setShowRepostToast(false)} className="ml-2 text-emerald-200 hover:text-white">
               <XCircle size={14} />
             </button>
           </div>

--- a/app/vendor/posts/page.tsx
+++ b/app/vendor/posts/page.tsx
@@ -64,12 +64,12 @@ function PostCard({ post, onRepost, onEditRepost }: { post: Post; onRepost: (pos
         </div>
       </div>
       <div className="mt-3 flex flex-col gap-2 border-t border-slate-100 pt-3 sm:flex-row">
-        <button onClick={() => onRepost(post)}
+        <button type="button" onClick={() => onRepost(post)}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-2xl border border-amber-200 bg-amber-50 py-3 text-sm font-semibold text-amber-700 transition hover:bg-amber-100"
         >
           <RotateCcw size={13} />そのまま再投稿
         </button>
-        <button onClick={() => onEditRepost(post)}
+        <button type="button" onClick={() => onEditRepost(post)}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
         >
           <Pencil size={13} />編集して再投稿
@@ -85,7 +85,7 @@ function RepostSuccessToast({ onClose }: { onClose: () => void }) {
       <div className="flex items-center gap-2 rounded-2xl bg-emerald-600 px-5 py-3 shadow-lg">
         <CheckCircle2 size={16} className="text-white" />
         <span className="text-sm font-semibold text-white">再投稿しました！</span>
-        <button onClick={onClose} className="ml-2 text-emerald-200 hover:text-white"><XCircle size={14} /></button>
+        <button type="button" onClick={onClose} className="ml-2 text-emerald-200 hover:text-white"><XCircle size={14} /></button>
       </div>
     </div>
   );
@@ -171,7 +171,7 @@ export default function VendorPostsPage() {
 
         <div className="mb-4 flex gap-1.5 rounded-3xl border border-slate-200 bg-white p-1.5 shadow-sm">
           {TABS.map((tab) => (
-            <button key={tab.key} onClick={() => setActiveTab(tab.key)}
+            <button type="button" key={tab.key} onClick={() => setActiveTab(tab.key)}
               className={`flex flex-1 items-center justify-center gap-1.5 rounded-2xl py-3 text-sm font-semibold transition ${activeTab === tab.key ? "bg-amber-500 text-white shadow-sm" : "text-slate-500 hover:text-slate-700"}`}
             >
               {tab.label}

--- a/components/admin/EmptyState.tsx
+++ b/components/admin/EmptyState.tsx
@@ -25,6 +25,7 @@ export const EmptyState = React.memo(function EmptyState({
       {description && <p className="text-sm text-gray-600 mb-4 text-center max-w-md">{description}</p>}
       {action && (
         <button
+          type="button"
           onClick={action.onClick}
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
         >

--- a/components/admin/ErrorBoundary.tsx
+++ b/components/admin/ErrorBoundary.tsx
@@ -46,6 +46,7 @@ export class ErrorBoundary extends React.Component<
               申し訳ございません。予期しないエラーが発生しました。
             </p>
             <button
+              type="button"
               onClick={() => window.location.reload()}
               className="rounded-lg bg-blue-600 px-6 py-2 text-white font-medium hover:bg-blue-700"
             >

--- a/components/admin/LoadingButton.tsx
+++ b/components/admin/LoadingButton.tsx
@@ -16,6 +16,7 @@ export const LoadingButton = React.memo(function LoadingButton({
 }: LoadingButtonProps) {
   return (
     <button
+      type="button"
       {...props}
       disabled={isLoading || disabled}
       className={`${className} ${isLoading || disabled ? "opacity-50 cursor-not-allowed" : ""}`}

--- a/components/admin/desktop/DataDensityToggle.tsx
+++ b/components/admin/desktop/DataDensityToggle.tsx
@@ -50,6 +50,7 @@ export const DataDensityToggle = React.memo(function DataDensityToggle({
         {(Object.entries(DENSITY_CONFIG) as [DataDensity, typeof DENSITY_CONFIG[DataDensity]][]).map(
           ([key, config]) => (
             <button
+              type="button"
               key={key}
               onClick={() => onChange(key)}
               className={`px-3 py-1 text-xs font-medium rounded transition ${

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -27,6 +27,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
+        // eslint-disable-next-line react/button-has-type
         type={type}
         className={cn(
           "inline-flex items-center justify-center rounded-xl border text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const coreWebVitals = require("eslint-config-next/core-web-vitals");
 const typescript = require("eslint-config-next/typescript");
+const reactPlugin = require("eslint-plugin-react");
 
 // React Compiler のルールを無効化（このプロジェクトは React Compiler を使用しない）
 const reactCompilerRulesOff = {
@@ -28,8 +29,10 @@ const config = [
   ...coreWebVitals,
   ...typescript,
   {
+    plugins: { react: reactPlugin },
     rules: {
       ...reactCompilerRulesOff,
+      "react/button-has-type": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {


### PR DESCRIPTION
## 概要
フォーム内で `type` 未指定の `<button>` がデフォルトの `type="submit"` として動作し、意図せずフォーム送信を引き起こす問題を修正（Issue #223）。

## 主な変更
- プロジェクト全体の `<button>` に `type="button"` を追加（24ファイル）
- `eslint.config.mjs` に `react/button-has-type: error` を追加して今後の混入を防止
- `components/ui/button.tsx` の汎用 Button コンポーネントは `type` を prop で受け取るため `eslint-disable` コメントで除外（デフォルト値は `"button"`）

## 変更ファイル
- `eslint.config.mjs` — `react/button-has-type: error` ルールを追加・`eslint-plugin-react` を明示インポート
- `components/ui/button.tsx` — eslint-disable コメント追加（prop 経由で type を受け取る正当なケース）
- `app/(public)/admin/**`, `app/components/**`, `app/vendor/**`, `components/admin/**` など計23ファイル — `type="button"` 追加

## 確認してほしいこと
- [ ] フォーム内のボタンが誤って submit しなくなっているか確認
- [ ] 新しいボタンを追加した際に ESLint が `type` 未指定をエラーで検出するか確認

## 補足
`app/(public)/faq/FaqClient.tsx` の未使用 `FaqCategory` インポートと `app/components/HamburgerMenu.tsx` の `<img>` → `<Image>` 対応も同時に修正（pre-commit hook の `--max-warnings 0` 制約による）。

Closes #223