### PR TITLE
fix: マジックナンバー・マジック文字列を lib/constants.ts に集約

### DIFF
--- a/app/api/admin/shops/bulk/route.ts
+++ b/app/api/admin/shops/bulk/route.ts
@@ -5,6 +5,7 @@ import { createClient as createServerClient } from "@/utils/supabase/server";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
 import { enforceRateLimit } from "@/lib/security/rateLimit";
 import { getRole, isAdmin } from "@/lib/auth/permissions";
+import { MAX_BULK_OPERATION } from "@/lib/constants";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -46,8 +47,8 @@ export async function POST(request: Request) {
     if (!action || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 });
     }
-    if (ids.length > 200) {
-      return NextResponse.json({ error: "一度に操作できるのは200件までです" }, { status: 400 });
+    if (ids.length > MAX_BULK_OPERATION) {
+      return NextResponse.json({ error: `一度に操作できるのは${MAX_BULK_OPERATION}件までです` }, { status: 400 });
     }
 
     const serviceClient = createServiceClient(supabaseUrl, serviceRoleKey, {

--- a/app/api/admin/users/bulk/route.ts
+++ b/app/api/admin/users/bulk/route.ts
@@ -5,6 +5,7 @@ import { createClient as createServerClient } from "@/utils/supabase/server";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
 import { enforceRateLimit } from "@/lib/security/rateLimit";
 import { getRole, isAdmin } from "@/lib/auth/permissions";
+import { MAX_BULK_OPERATION } from "@/lib/constants";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -39,15 +40,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Supabase env missing" }, { status: 500 });
     }
 
-    const MAX_BULK = 200;
     const body = (await request.json()) as { action: BulkAction; ids: string[] };
     const { action, ids } = body;
 
     if (!action || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 });
     }
-    if (ids.length > MAX_BULK) {
-      return NextResponse.json({ error: `一度に操作できるのは${MAX_BULK}件までです` }, { status: 400 });
+    if (ids.length > MAX_BULK_OPERATION) {
+      return NextResponse.json({ error: `一度に操作できるのは${MAX_BULK_OPERATION}件までです` }, { status: 400 });
     }
     // 自分自身への操作を除外
     const safeIds = ids.filter((id) => id !== user.id);

--- a/app/api/coupons/issue-initial/route.ts
+++ b/app/api/coupons/issue-initial/route.ts
@@ -6,6 +6,7 @@ import { normalizeCouponIssuance } from "@/lib/coupons/types";
 import type { SupabaseCouponIssuanceRow } from "@/lib/coupons/types";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
 import { enforceRateLimit } from "@/lib/security/rateLimit";
+import { MAX_COUPON_ISSUANCE, JST_MIDNIGHT_UTC_SUFFIX } from "@/lib/constants";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -109,7 +110,7 @@ export async function POST(request: Request) {
     }
 
     // ④ 当日発行上限チェック
-    const maxIssuance = couponSettings?.maxDailyIssuance ?? 300;
+    const maxIssuance = couponSettings?.maxDailyIssuance ?? MAX_COUPON_ISSUANCE;
     const { count: todayCount } = await supabase
       .from("coupon_issuances")
       .select("id", { count: "exact", head: true })
@@ -137,7 +138,7 @@ export async function POST(request: Request) {
     }
 
     // ⑥ 発行（expires_at = market_date の翌日 00:00 JST）
-    const expiresAt = new Date(`${market_date}T15:00:00.000Z`); // JST 翌日0時 = UTC 前日15時
+    const expiresAt = new Date(`${market_date}${JST_MIDNIGHT_UTC_SUFFIX}`);
     expiresAt.setDate(expiresAt.getDate() + 1);
 
     const { data: newCoupon, error: insertError } = await supabase

--- a/app/api/coupons/redeem/route.ts
+++ b/app/api/coupons/redeem/route.ts
@@ -8,6 +8,7 @@ import { normalizeCouponIssuance } from "@/lib/coupons/types";
 import type { SupabaseCouponIssuanceRow } from "@/lib/coupons/types";
 import { isCouponQrTokenValid, parseCouponQrToken } from "@/lib/coupons/qrToken";
 import { todayJstString } from "@/lib/time/jstDate";
+import { MAX_COUPON_ISSUANCE } from "@/lib/constants";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -150,7 +151,7 @@ export async function POST(request: Request) {
 
     // ⑥⑦⑧⑨ クーポン消費・スタンプ付与・次回クーポン発行をアトミックに実行
     // redeem_coupon SQL 関数が1トランザクション内でこれらを完結させる
-    const maxIssuance = couponSettings?.maxDailyIssuance ?? 300;
+    const maxIssuance = couponSettings?.maxDailyIssuance ?? MAX_COUPON_ISSUANCE;
     const nextCouponAmount = couponSettings?.amount ?? 50;
 
     const { data: rpcResult, error: rpcError } = await serviceClient.rpc("redeem_coupon", {

--- a/app/api/map-agent/route.ts
+++ b/app/api/map-agent/route.ts
@@ -5,6 +5,7 @@ import type { Database } from "@/types/database.types";
 import { fetchVendorShopsFromDb } from "@/app/(public)/map/services/shopDb";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
 import { enforceRateLimit } from "@/lib/security/rateLimit";
+import { MARKET_CENTER } from "@/lib/constants";
 
 type Answers = {
   purpose?: string;
@@ -50,7 +51,6 @@ const MapAgentBodySchema = z.object({
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
-const MARKET_CENTER: [number, number] = [33.55915, 133.531];
 
 async function loadShops(): Promise<BaseShop[]> {
   if (!SUPABASE_URL || !SUPABASE_KEY) return [];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,12 @@
+// クーポン1日の最大発行数（coupon_settings.maxDailyIssuance のデフォルト値）
+export const MAX_COUPON_ISSUANCE = 300;
+
+// 管理画面の一括操作で同時に処理できる最大件数
+export const MAX_BULK_OPERATION = 200;
+
+// 日曜市の中心座標（高知城前〜追手筋）
+export const MARKET_CENTER: [number, number] = [33.55915, 133.531];
+
+// JST 翌日 00:00 を UTC で表す時刻サフィックス（ISO 8601）
+// 日本時間は UTC+9 のため、翌日 0:00 JST = 前日 15:00 UTC
+export const JST_MIDNIGHT_UTC_SUFFIX = "T15:00:00.000Z";


### PR DESCRIPTION
## 概要

ビジネスロジックに関わるマジックナンバー・マジック文字列を `lib/constants.ts` に集約する。変更時の修正漏れを防ぎ、値の意図を明確にする。

## 主な変更

- `lib/constants.ts` を新規作成し、`MAX_COUPON_ISSUANCE`・`MAX_BULK_OPERATION`・`MARKET_CENTER`・`JST_MIDNIGHT_UTC_SUFFIX` を定義
- 各ファイルの直書き値を定数参照に置き換え

## 変更ファイル

- `lib/constants.ts` — 定数ファイルを新規作成
- `app/api/coupons/issue-initial/route.ts` — `300` → `MAX_COUPON_ISSUANCE`、`T15:00:00.000Z` → `JST_MIDNIGHT_UTC_SUFFIX`
- `app/api/coupons/redeem/route.ts` — `300` → `MAX_COUPON_ISSUANCE`
- `app/api/admin/users/bulk/route.ts` — ローカル `MAX_BULK = 200` → `MAX_BULK_OPERATION`
- `app/api/admin/shops/bulk/route.ts` — 直書き `200` → `MAX_BULK_OPERATION`
- `app/api/map-agent/route.ts` — ファイルローカルの `MARKET_CENTER` 定義を削除し `lib/constants` から import

## 確認してほしいこと

- [ ] クーポン発行上限（300件）が変わらず機能すること
- [ ] 管理画面の一括操作上限（200件）が変わらず機能すること
- [ ] マップエージェントの中心座標が変わらず機能すること

## 補足

`JST_MIDNIGHT_UTC_SUFFIX` は JST 00:00 = UTC 15:00 という変換ロジックをコメントに明記した。

Closes #226