### PR TITLE
fix: signup ページの二重 setError 呼び出しを修正

### DIFF
--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -66,7 +66,6 @@ export default function SignupPage() {
     setIsSubmitting(false);
 
     if (signUpError || !data.user) {
-      setError(signUpError?.message ?? "登録に失敗しました。");
       setError(signUpError?.message ?? "アカウントを作成できませんでした。");
       return;
     }


### PR DESCRIPTION
## 概要

`app/(public)/signup/page.tsx` でサインアップ失敗時に `setError` が2行連続で呼ばれており、前者が後者で常に上書きされていた。コピペミスと思われるため、後者1行に統一する。

## 主な変更

- 無効な1行目の `setError("登録に失敗しました。")` を削除

## 変更ファイル

- `app/(public)/signup/page.tsx` — 重複した `setError` 呼び出しを削除

## 確認してほしいこと

- [ ] サインアップ失敗時にエラーメッセージが「アカウントを作成できませんでした。」と表示されること
- [ ] サインアップ成功時は /map にリダイレクトされること

Closes #227