### PR TITLE
fix: middleware CSP nonce を Next.js 推奨実装に修正 (#256)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
+import { headers } from "next/headers";
 import type { Metadata, Viewport } from "next";
-import Script from "next/script";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth/AuthContext";
 import { MenuProvider } from "@/lib/ui/MenuContext";
@@ -53,8 +53,6 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
-const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://nicchyo.jp";
 
 const organizationJsonLd = {
@@ -71,12 +69,14 @@ const organizationJsonLd = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
     <html lang="ja">
       <head>
         <script
           type="application/ld+json"
+          nonce={nonce}
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
       </head>

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,7 +40,9 @@ export async function middleware(request: NextRequest) {
 
   const csp = [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}'`,
+    // 'strict-dynamic': nonce 付きスクリプトが動的にロードするスクリプトにも信頼を伝播
+    // 'unsafe-inline': strict-dynamic 非対応の古いブラウザ向けフォールバック
+    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline'`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data: https://fonts.gstatic.com",


### PR DESCRIPTION
## 概要
`middleware.ts` の CSP `script-src` に `'nonce-${nonce}'` のみが指定されており、Next.js がアプリケーション起動時に動的ロードするチャンクスクリプトが信頼されずブロックされる可能性があった（Issue #256）。

## 主な変更
- `middleware.ts`: `script-src` に `'strict-dynamic'` と `'unsafe-inline'` を追加
  - `'strict-dynamic'`: nonce 付きスクリプトが動的にロードするスクリプト（Next.js チャンク）にも信頼を伝播
  - `'unsafe-inline'`: `'strict-dynamic'` 非対応の古いブラウザ向けフォールバック（CSP3 対応ブラウザでは無視される）
- `app/layout.tsx`: async 化し `headers()` でノンスを取得、JSON-LD インラインスクリプトに `nonce` 属性を付与
- `app/layout.tsx`: 未使用の `GA_ID` 変数と `Script` import を削除

## 変更ファイル
- `middleware.ts` — CSP `script-src` を `'nonce-...' 'strict-dynamic' 'unsafe-inline'` に更新
- `app/layout.tsx` — async 化・nonce 取得・JSON-LD script タグへ nonce 付与

## 確認してほしいこと
- [ ] ブラウザの DevTools → Network → Response Headers で `content-security-policy` が正しく設定されているか確認
- [ ] ブラウザの DevTools → Console で CSP 違反エラーが出ていないか確認
- [ ] ページのハイドレーションが正常に動作しているか確認

## 補足
Next.js 公式ドキュメント（[Content Security Policy](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy)）に従った実装。`x-nonce` ヘッダーを middleware で設定することで Next.js が自動的に生成するインラインスクリプトにもノンスを付与する。

Closes #256