### PR TITLE
refactor: admin/layout.tsx と middleware.ts のロールチェックを isModerator() に統一

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/middleware";
+import { getRole, isModerator } from "@/lib/auth/permissions";
 
 export async function middleware(request: NextRequest) {
   const { supabase, getResponse } = createClient(request);
@@ -12,10 +13,10 @@ export async function middleware(request: NextRequest) {
 
   // パスベースのアクセス制御
   const pathname = request.nextUrl.pathname;
-  const appRole = (user?.app_metadata as { role?: string } | undefined)?.role ?? null;
+  const appRole = getRole(user);
 
   if (pathname.startsWith("/admin") || pathname.startsWith("/moderator")) {
-    const allowed = appRole === "super_admin" || appRole === "admin" || appRole === "moderator";
+    const allowed = isModerator(appRole);
     if (!user || !allowed) {
       const redirectRes = NextResponse.redirect(new URL("/", request.url));
       supabaseResponse.cookies.getAll().forEach(({ name, value }) => {


### PR DESCRIPTION
## 概要

Issue #280 で指摘された、`admin/layout.tsx` と `middleware.ts` でのインラインロールチェックを、`lib/auth/permissions.ts` の `isModerator()` / `getRole()` に統一する。

## 主な変更

- `app/(public)/admin/layout.tsx`: インラインの role 比較を `getRole()` + `isModerator()` に置換
- `middleware.ts`: 同様に `getRole()` + `isModerator()` に置換

## 変更ファイル

- `app/(public)/admin/layout.tsx` — ロールチェックを permissions.ts に委譲
- `middleware.ts` — ロールチェックを permissions.ts に委譲

## 確認してほしいこと

- [ ] `/admin` および `/moderator` パスへの権限チェックが正常に動作すること
- [ ] moderator / admin / super_admin ユーザーがアクセス可能なこと
- [ ] それ以外のユーザーがトップにリダイレクトされること

## 補足

`isModerator()` の実装: `role === "moderator" || isAdmin(role)`（`isAdmin` = `"admin" || "super_admin"`）。動作は変わらない。

Closes #280