### PR TITLE
fix: abuseDetection.ts の ip=null 時に文字列リテラルが入るバグを修正

### DIFF
--- a/lib/grandma/abuseDetection.ts
+++ b/lib/grandma/abuseDetection.ts
@@ -8,8 +8,6 @@ export async function handleAbuseDetection(
   text: string,
   visitorKey?: string
 ): Promise<"blocked" | "ok"> {
-  const blockIpValue = ip ?? "__visitor_key__";
-
   // Check blocklist in parallel for IP and visitor_key
   if (ip || visitorKey) {
     const [ipResult, visitorResult] = await Promise.all([
@@ -39,7 +37,7 @@ export async function handleAbuseDetection(
     });
     if (shouldBlock && (ip || visitorKey)) {
       await supabase.from("ai_abuse_blocks").insert({
-        ip_address: blockIpValue,
+        ip_address: ip ?? null,
         visitor_key: visitorKey ?? null,
         reason: abuse.reason,
       });

--- a/supabase/migrations/20260613000000_make_ip_address_nullable_in_abuse_blocks.sql
+++ b/supabase/migrations/20260613000000_make_ip_address_nullable_in_abuse_blocks.sql
@@ -1,0 +1,4 @@
+-- ip が取得できない環境（リバースプロキシ設定等）では null になるため、
+-- NOT NULL 制約を外して visitor_key のみでのブロックに対応する
+ALTER TABLE ai_abuse_blocks
+  ALTER COLUMN ip_address DROP NOT NULL;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -80,7 +80,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
-          ip_address: string
+          ip_address: string | null
           is_active: boolean
           reason: string
           visitor_key: string | null
@@ -88,7 +88,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
-          ip_address: string
+          ip_address?: string | null
           is_active?: boolean
           reason: string
           visitor_key?: string | null
@@ -96,7 +96,7 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
-          ip_address?: string
+          ip_address?: string | null
           is_active?: boolean
           reason?: string
           visitor_key?: string | null


### PR DESCRIPTION
## 概要

`lib/grandma/abuseDetection.ts` で `ip` が `null` の場合に `ip_address` カラムへ `"__visitor_key__"` というリテラル文字列が格納されてしまうバグを修正する。

## 主な変更

- `blockIpValue = ip ?? "__visitor_key__"` のフォールバック変数を削除し、INSERT 時に `ip ?? null` を直接指定
- `ai_abuse_blocks.ip_address` の `NOT NULL` 制約を外すマイグレーションを追加
- `types/database.types.ts` の `ip_address` 型を `string | null` に更新

## 変更ファイル

- `lib/grandma/abuseDetection.ts` — バグの原因となっていた `blockIpValue` フォールバックを除去
- `supabase/migrations/20260613000000_make_ip_address_nullable_in_abuse_blocks.sql` — `ip_address NOT NULL` 制約の解除
- `types/database.types.ts` — `ai_abuse_blocks` の Row/Insert/Update 型を null 許容に修正

## 確認してほしいこと

- [ ] IP が取得できない環境でのブロック登録が `ip_address: null` で保存されること
- [ ] `visitor_key` のみでブロックチェックが機能すること
- [ ] 既存のIPブロック済みレコードに影響がないこと

## 補足

DB スキーマ変更（マイグレーション）が含まれるため、本番反映時に `supabase db push` または Supabase ダッシュボードからマイグレーション適用が必要。

Closes #258