### PR TITLE
fix: /vendor/* パスを middleware のアクセス制御に追加する

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  if (pathname.startsWith("/my-shop")) {
+  if (pathname.startsWith("/my-shop") || pathname.startsWith("/vendor")) {
     if (!user || appRole !== "vendor") {
       const redirectRes = NextResponse.redirect(new URL("/", request.url));
       supabaseResponse.cookies.getAll().forEach(({ name, value }) => {


### PR DESCRIPTION
## 概要

Issue #281 で議論された `/vendor/*` パスの middleware ガード設計について、`/my-shop` と同じ二重防衛パターンを採用して追加する。

現状では `app/vendor/layout.tsx` によるクライアントサイドガードのみだったため、サーバーサイドで認可前にページコンテンツが生成される可能性があった。

## 主な変更

- `/vendor/*` へのアクセスを `vendor` ロール未保有ユーザーから middleware でリダイレクト
- `/my-shop` の条件と同じ `appRole !== "vendor"` チェックで統一

## 変更ファイル

- `middleware.ts` — `/my-shop` のガード条件に `/vendor` を追加（1行変更）

## 確認してほしいこと

- [ ] vendor ロールのアカウントで `/vendor/dashboard` にアクセスできるか
- [ ] 未ログイン状態で `/vendor/dashboard` にアクセスするとトップ（`/`）にリダイレクトされるか
- [ ] vendor 以外のロール（admin など）で `/vendor/*` にアクセスするとリダイレクトされるか

## 補足

`app/vendor/layout.tsx` のクライアントサイドガードはそのまま残し、middleware と合わせた二重防衛構成とした（`/my-shop` と同じ設計）。

Closes #281