### PR TITLE
fix: 管理者 API のエラーレスポンスから内部情報を除去（SUPABASE_SERVICE_ROLE_KEY 等）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,15 @@ NEXT_PUBLIC_SITE_URL=
 NEXT_PUBLIC_APP_URL=
 
 # ----------------------------------------
+# Upstash Redis（任意: 分散レート制限）
+# 複数インスタンス環境（Vercel 等）で正確なレート制限を行う場合に設定する
+# 未設定時はプロセス内 Map にフォールバック（単一インスタンスのみ有効）
+# https://console.upstash.com/ でデータベースを作成し REST API URL/Token を取得
+# ----------------------------------------
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# ----------------------------------------
 # Cloudflare Turnstile（任意: スパム対策）
 # https://dash.cloudflare.com/ でサイトキーを取得
 # 未設定の場合はキャプチャが無効になります

--- a/app/api/admin/audit-logs/route.ts
+++ b/app/api/admin/audit-logs/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-audit-logs-post",
     limit: 60,
     windowMs: 10 * 60 * 1000,

--- a/app/api/admin/content/[id]/route.ts
+++ b/app/api/admin/content/[id]/route.ts
@@ -23,7 +23,7 @@ export async function DELETE(
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-content-id-delete",
     limit: 20,
     windowMs: 10 * 60 * 1000,

--- a/app/api/admin/danger/route.ts
+++ b/app/api/admin/danger/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-danger",
       limit: 8,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/kotodute/[id]/route.ts
+++ b/app/api/admin/kotodute/[id]/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-kotodute-id-patch",
     limit: 30,
     windowMs: 10 * 60 * 1000,
@@ -62,7 +62,7 @@ export async function DELETE(
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-kotodute-id-delete",
     limit: 20,
     windowMs: 10 * 60 * 1000,

--- a/app/api/admin/kotodute/bulk/route.ts
+++ b/app/api/admin/kotodute/bulk/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-kotodute-bulk-post",
     limit: 10,
     windowMs: 10 * 60 * 1000,

--- a/app/api/admin/map-layout/route.ts
+++ b/app/api/admin/map-layout/route.ts
@@ -213,7 +213,7 @@ export async function PUT(request: NextRequest) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-map-layout-put",
       limit: 20,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/map-layout/snapshots/route.ts
+++ b/app/api/admin/map-layout/snapshots/route.ts
@@ -200,7 +200,7 @@ export async function POST(request: NextRequest) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-map-layout-snapshots-post",
       limit: 12,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -47,7 +47,7 @@ export async function PATCH(req: Request) {
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "admin-notifications-patch",
     limit: 30,
     windowMs: 10 * 60 * 1000,

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -144,7 +144,7 @@ export async function PUT(request: NextRequest) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-settings-put",
       limit: 20,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/shops/bulk/route.ts
+++ b/app/api/admin/shops/bulk/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-shops-bulk",
       limit: 10,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/sync-embeddings/route.ts
+++ b/app/api/admin/sync-embeddings/route.ts
@@ -264,7 +264,7 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error("[sync-embeddings]", message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return NextResponse.json({ ok: false, error: "Internal server error" }, { status: 500 });
   }
 }
 
@@ -281,6 +281,6 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error("[sync-embeddings]", message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return NextResponse.json({ ok: false, error: "Internal server error" }, { status: 500 });
   }
 }

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -21,7 +21,7 @@ export async function PATCH(
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-users-id",
       limit: 30,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/users/bulk/route.ts
+++ b/app/api/admin/users/bulk/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "admin-users-bulk",
       limit: 10,
       windowMs: 10 * 60 * 1000,

--- a/app/api/admin/weekly-security-report/route.ts
+++ b/app/api/admin/weekly-security-report/route.ts
@@ -596,7 +596,7 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error("[weekly-security-report]", message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return NextResponse.json({ ok: false, error: "Internal server error" }, { status: 500 });
   }
 }
 
@@ -610,6 +610,6 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error("[weekly-security-report]", message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return NextResponse.json({ ok: false, error: "Internal server error" }, { status: 500 });
   }
 }

--- a/app/api/analytics/coupon-impression/route.ts
+++ b/app/api/analytics/coupon-impression/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "analytics-coupon-impression",
       limit: 30,
       windowMs: 10 * 60 * 1000,

--- a/app/api/analytics/home-summary/route.ts
+++ b/app/api/analytics/home-summary/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
   const originCheck = requireSameOrigin(request);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(request, {
+  const rateLimited = await enforceRateLimit(request, {
     bucket: "analytics-home-summary",
     limit: 60,
     windowMs: 60 * 1000,

--- a/app/api/analytics/shop-interaction/route.ts
+++ b/app/api/analytics/shop-interaction/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "analytics-shop-interaction",
       limit: 60,
       windowMs: 10 * 60 * 1000,

--- a/app/api/coupons/issue-initial/route.ts
+++ b/app/api/coupons/issue-initial/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "coupons-issue-initial",
       limit: 10,
       windowMs: 10 * 60 * 1000,

--- a/app/api/coupons/my/route.ts
+++ b/app/api/coupons/my/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "coupons-my",
       limit: 30,
       windowMs: 10 * 60 * 1000,

--- a/app/api/coupons/qr-token/route.ts
+++ b/app/api/coupons/qr-token/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "coupons-qr-token",
       limit: 30,
       windowMs: 10 * 60 * 1000,

--- a/app/api/grandma/ask/route.ts
+++ b/app/api/grandma/ask/route.ts
@@ -508,7 +508,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "grandma-ask",
       limit: 30,
       windowMs: 10 * 60 * 1000,

--- a/app/api/grandma/shop-chat/route.ts
+++ b/app/api/grandma/shop-chat/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
   const originCheck = requireSameOrigin(req);
   if (!originCheck.ok) return originCheck.response;
 
-  const rateLimited = enforceRateLimit(req, {
+  const rateLimited = await enforceRateLimit(req, {
     bucket: "grandma-shop-chat",
     limit: 20,
     windowMs: 10 * 60 * 1000,

--- a/app/api/map-agent/route.ts
+++ b/app/api/map-agent/route.ts
@@ -298,7 +298,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "map-agent",
       limit: 15,
       windowMs: 10 * 60 * 1000,

--- a/app/api/vendor/knowledge/route.ts
+++ b/app/api/vendor/knowledge/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
     const originCheck = requireSameOrigin(request);
     if (!originCheck.ok) return originCheck.response;
 
-    const rateLimited = enforceRateLimit(request, {
+    const rateLimited = await enforceRateLimit(request, {
       bucket: "vendor-knowledge-post",
       limit: 12,
       windowMs: 10 * 60 * 1000,

--- a/lib/security/rateLimit.test.ts
+++ b/lib/security/rateLimit.test.ts
@@ -35,19 +35,16 @@ describe('rateLimit', () => {
     const defaultOptions = {
       bucket: 'test-bucket',
       limit: 2,
-      windowMs: 1000, // 1 second
+      windowMs: 1000,
     };
 
-    it('allows requests within limit', () => {
+    it('allows requests within limit', async () => {
       const req = new Request('http://localhost', {
         headers: { 'x-real-ip': '1.1.1.1' }
       });
 
-      const res1 = enforceRateLimit(req, defaultOptions);
-      expect(res1).toBeNull();
-
-      const res2 = enforceRateLimit(req, defaultOptions);
-      expect(res2).toBeNull();
+      expect(await enforceRateLimit(req, defaultOptions)).toBeNull();
+      expect(await enforceRateLimit(req, defaultOptions)).toBeNull();
     });
 
     it('blocks requests over limit and returns 429 response', async () => {
@@ -55,9 +52,9 @@ describe('rateLimit', () => {
         headers: { 'x-real-ip': '2.2.2.2' }
       });
 
-      enforceRateLimit(req, defaultOptions);
-      enforceRateLimit(req, defaultOptions);
-      const res = enforceRateLimit(req, defaultOptions);
+      await enforceRateLimit(req, defaultOptions);
+      await enforceRateLimit(req, defaultOptions);
+      const res = await enforceRateLimit(req, defaultOptions);
 
       expect(res).not.toBeNull();
       expect(res?.status).toBe(429);
@@ -67,22 +64,19 @@ describe('rateLimit', () => {
       expect(body.error).toBe('Too Many Requests');
     });
 
-    it('resets limit after windowMs', () => {
+    it('resets limit after windowMs', async () => {
       const req = new Request('http://localhost', {
         headers: { 'x-real-ip': '3.3.3.3' }
       });
 
-      enforceRateLimit(req, defaultOptions);
-      enforceRateLimit(req, defaultOptions);
+      await enforceRateLimit(req, defaultOptions);
+      await enforceRateLimit(req, defaultOptions);
 
-      const resBlocked = enforceRateLimit(req, defaultOptions);
-      expect(resBlocked).not.toBeNull();
+      expect(await enforceRateLimit(req, defaultOptions)).not.toBeNull();
 
-      // Advance time by 1.1 seconds
       vi.advanceTimersByTime(1100);
 
-      const resAllowed = enforceRateLimit(req, defaultOptions);
-      expect(resAllowed).toBeNull();
+      expect(await enforceRateLimit(req, defaultOptions)).toBeNull();
     });
 
     it('supports custom messages', async () => {
@@ -91,40 +85,34 @@ describe('rateLimit', () => {
       });
       const options = { ...defaultOptions, message: 'Custom error message' };
 
-      enforceRateLimit(req, options);
-      enforceRateLimit(req, options);
-      const res = enforceRateLimit(req, options);
+      await enforceRateLimit(req, options);
+      await enforceRateLimit(req, options);
+      const res = await enforceRateLimit(req, options);
 
       const body = await res?.json();
       expect(body.message).toBe('Custom error message');
     });
   });
-});
 
   describe('cleanupIfNeeded', () => {
-    it('cleans up old entries when MAX_BUCKETS is exceeded', () => {
+    it('cleans up old entries when MAX_BUCKETS is exceeded', async () => {
       const defaultOptions = {
         bucket: 'test-bucket-cleanup',
         limit: 10,
         windowMs: 1000,
       };
 
-      // Fill up to MAX_BUCKETS (20000)
       for (let i = 0; i < 20001; i++) {
         const req = new Request('http://localhost', {
           headers: { 'x-real-ip': `ip-${i}` }
         });
-        enforceRateLimit(req, defaultOptions);
+        await enforceRateLimit(req, defaultOptions);
       }
 
-      // 20001 triggers cleanup, deleting 3000 oldest
-      // Expected size: 20001 - 3000 = 17001
-
-      // Unfortunately we can't easily assert on RATE_LIMIT_STORE size directly
-      // since it's not exported. But we can verify it doesn't throw.
-      expect(() => {
+      await expect(async () => {
         const lastReq = new Request('http://localhost', { headers: { 'x-real-ip': 'ip-final' } });
-        enforceRateLimit(lastReq, defaultOptions);
+        await enforceRateLimit(lastReq, defaultOptions);
       }).not.toThrow();
     });
   });
+});

--- a/lib/security/rateLimit.ts
+++ b/lib/security/rateLimit.ts
@@ -13,6 +13,10 @@ type RateLimitOptions = {
   message?: string;
 };
 
+// ── in-memory fallback（単一プロセス内のみ有効） ───────────────────────────
+// UPSTASH_REDIS_REST_URL が未設定の場合に使用する。
+// Vercel 等の複数インスタンス環境では各インスタンスが独立したカウンターを持つため、
+// 本番で確実なレート制限を行うには Upstash Redis 環境変数の設定が必要。
 const RATE_LIMIT_STORE = new Map<string, RateLimitEntry>();
 const MAX_BUCKETS = 20000;
 
@@ -24,6 +28,77 @@ function cleanupIfNeeded() {
   oldest.forEach(([key]) => RATE_LIMIT_STORE.delete(key));
 }
 
+function inMemoryRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+  message: string
+): NextResponse | null {
+  const now = Date.now();
+  const current = RATE_LIMIT_STORE.get(key);
+
+  if (!current || now > current.resetAt) {
+    RATE_LIMIT_STORE.set(key, { count: 1, resetAt: now + windowMs });
+    cleanupIfNeeded();
+    return null;
+  }
+
+  if (current.count >= limit) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+    return NextResponse.json(
+      { error: "Too Many Requests", message },
+      { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
+    );
+  }
+
+  current.count += 1;
+  return null;
+}
+
+// ── Upstash Redis ──────────────────────────────────────────────────────────
+// UPSTASH_REDIS_REST_URL と UPSTASH_REDIS_REST_TOKEN が設定されている場合に使用する。
+// 複数インスタンス間で共有されるため、水平スケール環境でも正確なレート制限が機能する。
+let upstashRatelimit:
+  | ((key: string, limit: number, windowMs: number) => Promise<{ success: boolean; reset: number }>)
+  | null = null;
+
+if (
+  process.env.UPSTASH_REDIS_REST_URL &&
+  process.env.UPSTASH_REDIS_REST_TOKEN
+) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Redis } = require("@upstash/redis") as typeof import("@upstash/redis");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Ratelimit } = require("@upstash/ratelimit") as typeof import("@upstash/ratelimit");
+
+  const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  });
+
+  // windowMs ごとに bucket キャッシュを作る（異なる windowMs は別インスタンス）
+  const limiterCache = new Map<string, InstanceType<typeof Ratelimit>>();
+
+  upstashRatelimit = async (key, limit, windowMs) => {
+    const cacheKey = `${limit}:${windowMs}`;
+    if (!limiterCache.has(cacheKey)) {
+      limiterCache.set(
+        cacheKey,
+        new Ratelimit({
+          redis,
+          limiter: Ratelimit.slidingWindow(limit, `${windowMs} ms`),
+          prefix: "nicchyo:rl",
+        })
+      );
+    }
+    const limiter = limiterCache.get(cacheKey)!;
+    const result = await limiter.limit(key);
+    return { success: result.success, reset: result.reset };
+  };
+}
+
+// ── 公開 API ───────────────────────────────────────────────────────────────
+
 export function getClientIp(request: Request): string {
   const realIp = request.headers.get("x-real-ip");
   if (realIp) return realIp;
@@ -34,37 +109,23 @@ export function getClientIp(request: Request): string {
   return forwardedFor.split(",")[0]?.trim() || "unknown";
 }
 
-export function enforceRateLimit(
+export async function enforceRateLimit(
   request: Request,
   { bucket, limit, windowMs, keySuffix, message }: RateLimitOptions
-) {
+): Promise<NextResponse | null> {
   const ip = getClientIp(request);
   const key = [bucket, ip, keySuffix ?? ""].join(":");
-  const now = Date.now();
+  const defaultMessage = message ?? "リクエストが多すぎます。しばらくしてからお試しください。";
 
-  const current = RATE_LIMIT_STORE.get(key);
-  if (!current || now > current.resetAt) {
-    RATE_LIMIT_STORE.set(key, { count: 1, resetAt: now + windowMs });
-    cleanupIfNeeded();
-    return null;
-  }
-
-  if (current.count >= limit) {
-    const retryAfterSeconds = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+  if (upstashRatelimit) {
+    const { success, reset } = await upstashRatelimit(key, limit, windowMs);
+    if (success) return null;
+    const retryAfterSeconds = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
     return NextResponse.json(
-      {
-        error: "Too Many Requests",
-        message: message ?? "リクエストが多すぎます。しばらくしてからお試しください。",
-      },
-      {
-        status: 429,
-        headers: {
-          "Retry-After": String(retryAfterSeconds),
-        },
-      }
+      { error: "Too Many Requests", message: defaultMessage },
+      { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
     );
   }
 
-  current.count += 1;
-  return null;
+  return inMemoryRateLimit(key, limit, windowMs, defaultMessage);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-virtual": "^3.13.23",
         "@types/leaflet.markercluster": "^1.5.6",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "axios": "^1.15.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -3681,6 +3683,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.6",
@@ -12042,6 +12077,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-virtual": "^3.13.23",
     "@types/leaflet.markercluster": "^1.5.6",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "axios": "^1.15.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## 概要

### Issue #285 — レート制限の分散対応（Upstash Redis）

Vercel 等の水平スケール環境ではサーバーレス関数がプロセスをまたぐため、インメモリのレート制限が機能しない。`@upstash/ratelimit`（スライディングウィンドウ方式）を導入し、環境変数 `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` が設定されていれば Redis バックエンドを使用し、未設定の場合は既存のインメモリ実装にフォールバックするよう変更した。

`enforceRateLimit` を async 関数に変更したため、全 API Route（23 ファイル）の呼び出し元に `await` を追加した。

### Issue #286 — 管理者 API のエラーレスポンスから内部情報を除去

`sync-embeddings` と `weekly-security-report` の catch ブロックで `err.message` をそのまま HTTP レスポンスボディに返していた。`"SUPABASE_SERVICE_ROLE_KEY is missing."` 等のサーバー構成情報がクライアントに漏洩していたため、レスポンスを汎用メッセージ `"Internal server error"` に変更した。

## 主な変更

- `lib/security/rateLimit.ts` — Upstash Redis スライディングウィンドウ対応、`enforceRateLimit` を async 化
- `lib/security/rateLimit.test.ts` — 非同期化に伴うテスト修正
- 全 API Route 23 ファイル — `await enforceRateLimit(...)` に変更
- `package.json` — `@upstash/redis`・`@upstash/ratelimit` 追加
- `.env.example` — `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` 追加
- `app/api/admin/sync-embeddings/route.ts` — エラーレスポンスを汎用化（#286）
- `app/api/admin/weekly-security-report/route.ts` — エラーレスポンスを汎用化（#286）

## 変更ファイル

- `lib/security/rateLimit.ts` — Upstash Redis 対応（インメモリフォールバック付き）
- `lib/security/rateLimit.test.ts` — async テスト対応
- `app/api/**` (23 files) — `await enforceRateLimit` 対応
- `package.json` / `package-lock.json` — Upstash 依存追加
- `.env.example` — Upstash 環境変数追加

## 確認してほしいこと

- [ ] `UPSTASH_REDIS_REST_URL` 未設定時にインメモリフォールバックが動作すること
- [ ] `UPSTASH_REDIS_REST_URL` 設定時に Redis ベースのレート制限が動作すること
- [ ] 既存のレート制限テスト（`lib/security/rateLimit.test.ts`）がすべて通ること
- [ ] `/api/admin/sync-embeddings` がエラー時に `{ ok: false, error: "Internal server error" }` を返すこと
- [ ] サーバーログには詳細なエラーメッセージが出力されること

## 補足

Upstash Redis を利用しない場合（ローカル開発・単一インスタンス環境）は、環境変数を設定しないだけで従来通りのインメモリ動作になる。

Closes #285
Closes #286