### PR TITLE
fix: 一括削除に確認フロー追加・監査ログ強化（誤操作防止）

### DIFF
--- a/app/api/admin/shops/bulk/route.ts
+++ b/app/api/admin/shops/bulk/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: Request) {
     const ip = getClientIp(request);
 
     // 監査ログを操作前に記録（削除後に失敗しても痕跡が残るよう）
-    await serviceClient.from("admin_audit_logs").insert({
+    const { error: auditError } = await serviceClient.from("admin_audit_logs").insert({
       actor_id: user.id,
       actor_email: user.email ?? null,
       actor_role: getRole(user),
@@ -98,9 +98,10 @@ export async function POST(request: Request) {
       target_type: "vendor",
       target_id: safeIds.join(","),
       target_name: shopNames.slice(0, 500),
-      details: `${safeIds.length}件を一括${actionLabel}`,
+      details: `${safeIds.length}件の一括${actionLabel}を試みた`,
       ip_address: ip !== "unknown" ? ip : null,
     });
+    if (auditError) console.error("[audit] failed to write audit log", auditError);
 
     const errors: string[] = [];
 

--- a/app/api/admin/shops/bulk/route.ts
+++ b/app/api/admin/shops/bulk/route.ts
@@ -3,14 +3,13 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { createClient as createServerClient } from "@/utils/supabase/server";
 import { requireSameOrigin } from "@/lib/security/requestGuards";
-import { enforceRateLimit } from "@/lib/security/rateLimit";
+import { enforceRateLimit, getClientIp } from "@/lib/security/rateLimit";
 import { getRole, isAdmin } from "@/lib/auth/permissions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 type BulkAction = "suspend" | "restore" | "delete";
-
 
 export async function POST(request: Request) {
   try {
@@ -37,17 +36,29 @@ export async function POST(request: Request) {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (!supabaseUrl || !serviceRoleKey) {
-      return NextResponse.json({ error: "Supabase env missing" }, { status: 500 });
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 
-    const body = (await request.json()) as { action: BulkAction; ids: string[] };
-    const { action, ids } = body;
+    const body = (await request.json()) as {
+      action: BulkAction;
+      ids: string[];
+      confirmText?: string;
+    };
+    const { action, ids, confirmText } = body;
 
     if (!action || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 });
     }
     if (ids.length > 200) {
       return NextResponse.json({ error: "一度に操作できるのは200件までです" }, { status: 400 });
+    }
+
+    // 削除は取り消し不可のため、明示的な確認テキストを必須とする
+    if (action === "delete" && confirmText !== "DELETE") {
+      return NextResponse.json(
+        { error: '削除を実行するには confirmText に "DELETE" を指定してください' },
+        { status: 400 }
+      );
     }
 
     const serviceClient = createServiceClient(supabaseUrl, serviceRoleKey, {
@@ -63,7 +74,7 @@ export async function POST(request: Request) {
     // vendors テーブルに存在するIDのみに絞る（admin等を誤って操作しないため）
     const { data: validVendors, error: vendorFetchError } = await serviceClient
       .from("vendors")
-      .select("id")
+      .select("id, shop_name")
       .in("id", withoutSelf);
     if (vendorFetchError) {
       return NextResponse.json({ error: "Failed to validate vendor IDs" }, { status: 500 });
@@ -73,6 +84,23 @@ export async function POST(request: Request) {
     if (safeIds.length === 0) {
       return NextResponse.json({ error: "対象の出店者が見つかりません" }, { status: 400 });
     }
+
+    const shopNames = validVendors?.map((v: { id: string; shop_name: string | null }) => v.shop_name ?? v.id).join(", ") ?? "";
+    const actionLabel = action === "delete" ? "削除" : action === "suspend" ? "停止" : "復活";
+    const ip = getClientIp(request);
+
+    // 監査ログを操作前に記録（削除後に失敗しても痕跡が残るよう）
+    await serviceClient.from("admin_audit_logs").insert({
+      actor_id: user.id,
+      actor_email: user.email ?? null,
+      actor_role: getRole(user),
+      action: `bulk_${action}`,
+      target_type: "vendor",
+      target_id: safeIds.join(","),
+      target_name: shopNames.slice(0, 500),
+      details: `${safeIds.length}件を一括${actionLabel}`,
+      ip_address: ip !== "unknown" ? ip : null,
+    });
 
     const errors: string[] = [];
 
@@ -98,16 +126,6 @@ export async function POST(request: Request) {
     } else {
       return NextResponse.json({ error: "Unknown action" }, { status: 400 });
     }
-
-    // 監査ログに記録
-    const actionLabel = action === "delete" ? "削除" : action === "suspend" ? "停止" : "復活";
-    await serviceClient.from("admin_audit_logs").insert({
-      actor_id: user.id,
-      action: `bulk_${action}`,
-      target_type: "vendor",
-      target_id: safeIds.join(","),
-      details: `${safeIds.length}件を一括${actionLabel}`,
-    });
 
     if (errors.length > 0) {
       return NextResponse.json(


### PR DESCRIPTION
## 概要

`POST /api/admin/shops/bulk` の `delete` アクションは `admin.deleteUser()` による恒久削除のため、誤操作時の復旧が困難だった。確認フローと監査ログ強化により安全性を高める。

## 主な変更

- **確認フロー追加**: `delete` アクション時にリクエストボディの `confirmText` が `"DELETE"` でない場合は 400 を返す。誤ったリクエストや UI を経由しない直接 POST を防止する
- **監査ログを操作前に記録**: 削除後に監査ログ INSERT が失敗しても痕跡が残るよう、ログ記録をアクション実行前に移動
- **監査ログ項目を拡充**: `actor_email`・`actor_role`・`ip_address`・`target_name`（店舗名）を追加し、事後追跡を容易にする

## 変更ファイル

- `app/api/admin/shops/bulk/route.ts` — 確認フロー・監査ログ強化

## 確認してほしいこと

- [ ] `confirmText: "DELETE"` なしで `action: "delete"` を送ると 400 が返ること
- [ ] `confirmText: "DELETE"` ありの場合は正常に削除が実行されること
- [ ] 監査ログに `actor_email`・`actor_role`・`ip_address`・`target_name` が記録されること
- [ ] suspend・restore は `confirmText` 不要で引き続き動作すること

## 補足

ソフトデリート（`deleted_at` フラグ）は DB マイグレーションとクエリ全体への影響が大きいため、今回は確認フローで対応した。ソフトデリートが必要な場合は別 Issue・別 PR で対応する。

Closes #287