### PR TITLE
fix: CI ワークフローに GITHUB_TOKEN の最小権限を明示（Code scanning #1）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [develop, main]
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint / Type Check / Test / Build


### PR DESCRIPTION
## 概要

GitHub Code scanning アラート #1「Workflow does not contain permissions」を解消する。`GITHUB_TOKEN` のパーミッションが未指定だと不要な書き込み権限が暗黙的に付与されるため、`permissions: contents: read` を明示した。

## 主な変更

- `.github/workflows/ci.yml` にワークフローレベルの `permissions` ブロックを追加

## 変更ファイル

- `.github/workflows/ci.yml` — `permissions: contents: read` を追加

## 確認してほしいこと

- [ ] CI が引き続き正常に通ること（checkout・npm ci・lint・build 等に影響なし）
- [ ] Code scanning アラート #1 がクローズされること

## 補足

CI ジョブはコードの読み取り・ビルドのみを行うため、`contents: read` の最小権限で十分。