### PR TITLE
fix: kotodute ノートの localStorage 読み込み時に入力検証を追加（Code scanning #2 #3）

### DIFF
--- a/app/kotodute/KotoduteClient.tsx
+++ b/app/kotodute/KotoduteClient.tsx
@@ -184,8 +184,9 @@ export default function KotoduteClient() {
             <div className="mt-3 space-y-2">
               {filteredNotes.map((note) => {
                 const isAll = note.shopId === "all";
-                const label = isAll ? "日曜市全体" : findShopName(shops, note.shopId as number);
-                const targetHref = isAll ? "/map" : `/map?shop=${note.shopId}`;
+                const shopIdNum = typeof note.shopId === "number" && note.shopId > 0 ? note.shopId : null;
+                const label = shopIdNum ? findShopName(shops, shopIdNum) : "日曜市全体";
+                const targetHref = shopIdNum ? `/map?shop=${shopIdNum}` : "/map";
 
                 return (
                   <Link

--- a/app/kotodute/KotoduteClient.tsx
+++ b/app/kotodute/KotoduteClient.tsx
@@ -183,8 +183,8 @@ export default function KotoduteClient() {
           ) : (
             <div className="mt-3 space-y-2">
               {filteredNotes.map((note) => {
-                const isAll = note.shopId === "all";
                 const shopIdNum = typeof note.shopId === "number" && note.shopId > 0 ? note.shopId : null;
+                const isAll = shopIdNum === null;
                 const label = shopIdNum ? findShopName(shops, shopIdNum) : "日曜市全体";
                 const targetHref = shopIdNum ? `/map?shop=${shopIdNum}` : "/map";
 
@@ -205,7 +205,7 @@ export default function KotoduteClient() {
                             isAll ? "bg-slate-900 text-white" : "bg-amber-600 text-white"
                           }`}
                         >
-                          {isAll ? "#all" : `#${note.shopId}`}
+                          {isAll ? "#all" : `#${shopIdNum}`}
                         </span>
                         <span className="text-sm text-gray-700">{label}</span>
                       </div>

--- a/lib/kotoduteStorage.test.ts
+++ b/lib/kotoduteStorage.test.ts
@@ -60,6 +60,75 @@ describe('kotoduteStorage', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(validData[0]);
     });
+
+    it('coerces invalid shopId (string) to "all"', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { id: 'n1', shopId: '123', text: 'hello', createdAt: 1000 },
+      ]));
+      const result = loadKotodute();
+      expect(result).toHaveLength(1);
+      expect(result[0].shopId).toBe('all');
+    });
+
+    it('coerces negative shopId to "all"', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { id: 'n1', shopId: -5, text: 'hello', createdAt: 1000 },
+      ]));
+      const result = loadKotodute();
+      expect(result[0].shopId).toBe('all');
+    });
+
+    it('coerces fractional shopId to "all"', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { id: 'n1', shopId: 1.5, text: 'hello', createdAt: 1000 },
+      ]));
+      const result = loadKotodute();
+      expect(result[0].shopId).toBe('all');
+    });
+
+    it('drops notes missing id', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { shopId: 1, text: 'no id', createdAt: 1000 },
+        { id: 'valid', shopId: 1, text: 'ok', createdAt: 1000 },
+      ]));
+      const result = loadKotodute();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('valid');
+    });
+
+    it('drops notes missing text', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { id: 'n1', shopId: 1, createdAt: 1000 },
+        { id: 'n2', shopId: 1, text: 'ok', createdAt: 1000 },
+      ]));
+      const result = loadKotodute();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('n2');
+    });
+
+    it('keeps valid notes and drops invalid ones from mixed array', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { id: 'good-1', shopId: 10, text: 'ok', createdAt: 1000 },
+        { shopId: 10, text: 'missing id', createdAt: 1000 },
+        { id: 'good-2', shopId: 'all', text: 'also ok', createdAt: 2000 },
+        null,
+        42,
+      ]));
+      const result = loadKotodute();
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('good-1');
+      expect(result[1].id).toBe('good-2');
+    });
+
+    it('falls back to seed when all notes are invalid', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { shopId: 1, text: 'no id', createdAt: 1000 },
+        { id: 'n2', text: 'no createdAt' },
+      ]));
+      const result = loadKotodute();
+      expect(result).toHaveLength(3);
+      expect(result[0].id).toBe('seed-1');
+    });
   });
 
   describe('saveKotodute', () => {

--- a/lib/kotoduteStorage.ts
+++ b/lib/kotoduteStorage.ts
@@ -51,7 +51,7 @@ function sanitizeNote(raw: unknown): KotoduteNote | null {
         : "all";
 
   const authorEmoji =
-    typeof r.authorEmoji === "string" && /^\p{Emoji}/u.test(r.authorEmoji)
+    typeof r.authorEmoji === "string" && /^\p{Extended_Pictographic}/u.test(r.authorEmoji)
       ? r.authorEmoji
       : undefined;
 

--- a/lib/kotoduteStorage.ts
+++ b/lib/kotoduteStorage.ts
@@ -32,12 +32,39 @@ const seed: KotoduteNote[] = [
   },
 ];
 
+function sanitizeNote(raw: unknown): KotoduteNote | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+
+  const id = typeof r.id === "string" && r.id ? r.id : null;
+  const text = typeof r.text === "string" ? r.text : null;
+  const createdAt = typeof r.createdAt === "number" && isFinite(r.createdAt) ? r.createdAt : null;
+  if (!id || !text || createdAt === null) return null;
+
+  // shopId は number(正整数) か "all" のみ許可
+  const rawShopId = r.shopId;
+  const shopId: number | "all" =
+    rawShopId === "all"
+      ? "all"
+      : typeof rawShopId === "number" && Number.isInteger(rawShopId) && rawShopId > 0
+        ? rawShopId
+        : "all";
+
+  const authorEmoji =
+    typeof r.authorEmoji === "string" && /^\p{Emoji}/u.test(r.authorEmoji)
+      ? r.authorEmoji
+      : undefined;
+
+  return { id, shopId, text, createdAt, authorEmoji };
+}
+
 export function loadKotodute(): KotoduteNote[] {
   if (typeof window === "undefined") return seed;
   const raw = localStorage.getItem(STORAGE_KEY);
-  const parsed = safeJsonParse<KotoduteNote[]>(raw, []);
+  const parsed = safeJsonParse<unknown[]>(raw, []);
   if (!Array.isArray(parsed) || parsed.length === 0) return seed;
-  return parsed;
+  const notes = parsed.map(sanitizeNote).filter((n): n is KotoduteNote => n !== null);
+  return notes.length > 0 ? notes : seed;
 }
 
 export function saveKotodute(notes: KotoduteNote[]) {


### PR DESCRIPTION
## 概要

GitHub Code scanning アラート #2・#3（`js/xss-through-dom`）を解消する。

CodeQL は localStorage から読み込んだ `note.id`・`note.shopId` が DOM 属性（`key`・`href`）に
流入する経路を XSS リスクとして検出していた。

- `loadKotodute()` で localStorage データを読み込む際に `sanitizeNote()` で検証し、
  `shopId` は正整数か `"all"` のみ、`id` は非空文字列のみを許可する
- `KotoduteClient.tsx` の `targetHref` 構築前に `typeof note.shopId === "number"` で
  型を明示的に確認し、数値以外は `/map` にフォールバックする

## 主な変更

- `lib/kotoduteStorage.ts` — `sanitizeNote()` を追加して localStorage データを検証
- `app/kotodute/KotoduteClient.tsx` — `targetHref` 構築前に明示的数値チェックを追加

## 変更ファイル

- `lib/kotoduteStorage.ts` — `sanitizeNote()` 追加、`loadKotodute()` で使用
- `app/kotodute/KotoduteClient.tsx` — `shopIdNum` で型ガードを明示

## 確認してほしいこと

- [ ] ことづて一覧が正常に表示されること
- [ ] お店リンクが `/map?shop=<数値>` 形式で遷移すること
- [ ] 全体あての投稿が `/map` へ遷移すること
- [ ] Code scanning アラート #2・#3 がクローズされること

## 補足

`sanitizeNote()` は localStorage の改ざんに対する防御であり、React の標準 JSX レンダリングは
元から HTML エスケープ済みのため、実際の XSS リスクは低い。CodeQL の静的解析上の指摘を解消するための明示的な対策。

Closes #2
Closes #3 (code-scanning)