### PR TITLE
docs: ローカルセットアップ手順を整備する（LOCAL_SETUP.md 追加・db:seed 追加）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,19 @@ npx supabase start
 
 起動後に表示される `API URL` と `anon key` を `.env.local` に設定してください。
 
-### 6. 開発サーバーの起動
+### 6. 本番データをローカルに流し込む
+
+マップにお店データを表示するため、本番 Supabase のデータをローカルにコピーします。
+
+**事前準備**: `.env.local.production`（本番接続情報）をチームメンバーから入手してプロジェクトルートに置いてください。
+
+```bash
+npm run db:seed
+```
+
+詳細は [docs/LOCAL_SETUP.md](docs/LOCAL_SETUP.md) を参照してください。
+
+### 7. 開発サーバーの起動
 
 ```bash
 npm run dev
@@ -155,6 +167,7 @@ npm run lint         # ESLint
 npm test             # Vitest テスト実行
 npx tsc --noEmit     # 型チェックのみ
 npx supabase start   # Supabase ローカル起動
+npm run db:seed      # 本番データをローカルDBに流し込む
 ```
 
 ---

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,0 +1,88 @@
+# ローカル開発環境セットアップ
+
+マップにお店が表示されない場合、ローカルDBにデータが入っていない可能性があります。
+
+## なぜお店が表示されないのか
+
+マップデータは Supabase（PostgreSQL）から取得しています。ローカル開発では Docker 上で Supabase を起動しますが、**スキーマ（テーブル構造）は自動で作られるものの、データは空の状態**です。
+
+```
+本番Supabase（クラウド）  ←  お店データが入っている
+         ↕ 手動でコピーが必要
+ローカルSupabase（Docker） ←  空の状態で起動する
+```
+
+## 初回セットアップ手順
+
+### 前提
+- Docker Desktop が起動していること
+- `.env.local.production` をチームメンバーから入手済みであること（後述）
+
+```bash
+# 1. ローカルSupabase起動
+npx supabase start
+
+# 2. 本番データをローカルに流し込む
+npm run db:seed
+
+# 3. 開発サーバー起動
+npm run dev
+```
+
+これだけです。
+
+## `.env.local.production` の入手方法
+
+`npm run db:seed` は本番 Supabase への接続に `.env.local.production` を使います。  
+このファイルはセキュリティ上 `.gitignore` されているため、**チームメンバーに共有を依頼してください**。
+
+入手したファイルをプロジェクトルートに置いてください：
+
+```
+nicchyo-platform/
+├── .env.local              ← 自分で作る（cp .env.example .env.local）
+├── .env.local.production   ← チームメンバーから入手する
+└── ...
+```
+
+## 再起動後
+
+PC 再起動後など、Docker を再起動した場合：
+
+```bash
+npx supabase start   # DBデータはDockerボリュームに保持される
+npm run dev
+```
+
+データが消えた場合（`npx supabase db reset` を実行した後など）はステップ2を再実行してください。
+
+## ローカルデータを最新に更新したいとき
+
+本番でお店情報が更新された場合など、ローカルを最新に同期したいときは：
+
+```bash
+npm run db:seed
+```
+
+開発中に「なんか表示がおかしい」と思ったらまずこれを試してください。
+
+## トラブルシューティング
+
+### `npx supabase start` でエラーになる
+→ Docker Desktop が起動しているか確認してください。
+
+### `npm run db:seed` でエラーになる（環境変数）
+→ `.env.local.production` がプロジェクトルートにあるか確認してください。
+
+### `npm run db:seed` でエラーになる（Dockerコンテナ）
+→ `npx supabase start` が完了しているか確認してください。
+
+### それでもお店が表示されない
+ローカルDBにデータが入っているか確認：
+```bash
+# vendors テーブルに300件あればOK
+curl -s "http://127.0.0.1:54321/rest/v1/vendors?limit=1" \
+  -H "apikey: $(grep PUBLISHABLE_DEFAULT_KEY .env.local | cut -d= -f2)"
+```
+
+`[]` が返ってきたらデータが空なので `npm run db:seed` を再実行してください。

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "vitest run --passWithNoTests",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "db:seed": "node scripts/seed-local.mjs",
     "db:seed": "node scripts/seed-local.mjs"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint app/ lib/ components/ types/ utils/ middleware.ts",
     "test": "vitest run --passWithNoTests",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "db:seed": "node scripts/seed-local.mjs",
+    "db:seed": "node scripts/seed-local.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## 概要

他のメンバーがローカル環境を構築できなかった問題を修正します。原因は3点ありました：

1. `docs/LOCAL_SETUP.md` が未コミットでリポジトリに存在しなかった
2. `package.json` に `db:seed` スクリプトが未追加だった
3. `CONTRIBUTING.md` に DB シードのステップと `.env.local.production` の説明がなかった

## 主な変更

- `docs/LOCAL_SETUP.md` を新規追加（`.env.local.production` の入手方法・トラブルシューティング含む）
- `CONTRIBUTING.md` にステップ6（`npm run db:seed`）と `.env.local.production` の説明を追加
- `CONTRIBUTING.md` のコマンド一覧に `npm run db:seed` を追記
- `package.json` に `"db:seed": "node scripts/seed-local.mjs"` を追加

## 変更ファイル

- `docs/LOCAL_SETUP.md` — 新規作成
- `CONTRIBUTING.md` — db:seed ステップ・コマンド追記
- `package.json` — db:seed スクリプト追加

## 確認してほしいこと

- [ ] CONTRIBUTING.md のセットアップ手順がわかりやすいか
- [ ] `.env.local.production` の説明が明確か

## 補足

`.env.local.production` はセキュリティ上 `.gitignore` 済みのため、新メンバーはチームメンバーに共有を依頼する必要があります。その旨を両ファイルに明記しています。