### PR TITLE
fix: anon ロールにマップ表示テーブルの SELECT 権限を付与する

### DIFF
--- a/supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql
+++ b/supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql
@@ -6,3 +6,4 @@ GRANT SELECT ON public.market_locations TO anon;
 GRANT SELECT ON public.location_assignments TO anon;
 GRANT SELECT ON public.categories TO anon;
 GRANT SELECT ON public.products TO anon;
+GRANT SELECT ON public.vendor_contents TO anon;

--- a/supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql
+++ b/supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql
@@ -1,0 +1,8 @@
+-- anon ロールにマップ表示に必要なテーブルの SELECT 権限を付与する
+-- RLS ポリシー（public read）だけでは anon はアクセスできないため明示的に GRANT が必要
+
+GRANT SELECT ON public.vendors TO anon;
+GRANT SELECT ON public.market_locations TO anon;
+GRANT SELECT ON public.location_assignments TO anon;
+GRANT SELECT ON public.categories TO anon;
+GRANT SELECT ON public.products TO anon;


### PR DESCRIPTION
## 概要

ローカル環境で `npx supabase db reset` 後にマップのお店が表示されない問題を修正します。

## 原因

`vendors` 等のテーブルには RLS ポリシー（`public read vendors` = `USING (true)`）が設定されていましたが、`anon` ロールへの `GRANT SELECT` が migration に含まれていませんでした。Supabase では RLS ポリシーだけでなく、テーブルへの権限も明示的に付与する必要があります。

```
permission denied for table vendors
hint: GRANT SELECT ON public.vendors TO anon;
```

## 主な変更

- `supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql` を追加
  - `vendors` / `market_locations` / `location_assignments` / `categories` / `products` に `GRANT SELECT TO anon`

## 変更ファイル

- `supabase/migrations/20260616000000_grant_anon_read_on_public_tables.sql` — 新規追加

## 確認してほしいこと

- [ ] `npx supabase db reset` → `node scripts/seed-local.mjs` → マップにお店が表示されるか

## 補足

本番 Supabase では Supabase ダッシュボード経由でテーブル作成時に自動で GRANT されるため問題は起きていませんでした。ローカルの migration ベースのセットアップでのみ再現する問題です。