### PR TITLE
fix: 開発環境の CSP に unsafe-eval を追加して React の eval エラーを解消する

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -42,7 +42,7 @@ export async function middleware(request: NextRequest) {
     "default-src 'self'",
     // 'strict-dynamic': nonce 付きスクリプトが動的にロードするスクリプトにも信頼を伝播
     // 'unsafe-inline': strict-dynamic 非対応の古いブラウザ向けフォールバック
-    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline'`,
+    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline'${process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""}`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data: https://fonts.gstatic.com",


### PR DESCRIPTION
## 概要

ローカル開発環境で発生する `eval() is not supported in this environment` エラーを修正します。

## 原因

`middleware.ts` の `script-src` に `'unsafe-eval'` が含まれていないため、React が開発モードで使用する `eval()`（コールスタック再構築等）がブロックされていました。

## 主な変更

- `middleware.ts`: `NODE_ENV === "development"` の場合のみ `script-src` に `'unsafe-eval'` を追加
- 本番環境では付与しないため、セキュリティへの影響なし

## 変更ファイル

- `middleware.ts` — script-src に開発環境限定の unsafe-eval を追加

## 確認してほしいこと

- [ ] ローカルで `npm run dev` 後にコンソールエラーが出ないか
- [ ] 本番ビルド（`npm run build`）が通るか