### PR TITLE
fix: JSON-LD script タグの nonce を削除して hydration mismatch を解消する

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import { headers } from "next/headers";
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth/AuthContext";
@@ -70,13 +69,11 @@ const organizationJsonLd = {
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
     <html lang="ja">
       <head>
         <script
           type="application/ld+json"
-          nonce={nonce}
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
       </head>


### PR DESCRIPTION
## 概要

`/map` ページで React hydration mismatch エラーが発生していた。

```
A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.
```

`app/layout.tsx` の JSON-LD `<script>` に `nonce` を付与していたことが原因。

## 原因

`nonce` はリクエストごとに `proxy.ts`（middleware）で生成される。SSR 時にサーバーが `nonce="xxx"` を埋め込むが、クライアントサイドの React はその値を知らないため `nonce=""` として評価し不一致が起きる。

`<script type="application/ld+json">` はブラウザに JavaScript として実行されない純粋な JSON データのため、そもそも CSP の `script-src` 対象外であり nonce は不要。

## 主な変更

- `app/layout.tsx`: JSON-LD script タグから `nonce={nonce}` を削除
- `app/layout.tsx`: 未使用になった `nonce` 変数・`headers` インポートを削除

## 変更ファイル

- `app/layout.tsx`

## 確認してほしいこと

- [ ] `/map` ページを開いて hydration mismatch エラーが出ないこと
- [ ] ビルドが通ること（`npm run build`）
- [ ] 構造化データ（JSON-LD）がページのソースに含まれていること

## 補足

`application/ld+json` は [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) でも「実行されないデータブロック」として分類されており、CSP の適用範囲外。