### PR TITLE
feat: 日曜市発見図鑑の基礎（一覧・詳細閲覧）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,4 @@ nicchyo-soft-green: #A0D7A7  （淡い緑）
 
 - `reactStrictMode: false` は意図的（Leaflet互換性のため変更しない）
 - Supabase Storageの画像URLは `*.supabase.co` ドメイン（`next.config.js` の `remotePatterns` に設定済み）
+- `/encyclopedia/scan` ページのみカメラ権限を許可（Permissions-Policy設定あり）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,4 +141,3 @@ nicchyo-soft-green: #A0D7A7  （淡い緑）
 
 - `reactStrictMode: false` は意図的（Leaflet互換性のため変更しない）
 - Supabase Storageの画像URLは `*.supabase.co` ドメイン（`next.config.js` の `remotePatterns` に設定済み）
-- `/encyclopedia/scan` ページのみカメラ権限を許可（Permissions-Policy設定あり）

--- a/app/(public)/encyclopedia/camera/page.tsx
+++ b/app/(public)/encyclopedia/camera/page.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
+import { RefreshCw, Download, X, Camera } from "lucide-react";
+import { motion } from "framer-motion";
+
+function CameraPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const itemId = searchParams?.get("item");
+  const item = ENCYCLOPEDIA_ITEMS.find((i) => i.id === itemId);
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  // 起動要求の世代番号。多重起動時に古い取得結果を破棄するために使う
+  const startGenerationRef = useRef(0);
+  const [isPhotoTaken, setIsPhotoTaken] = useState(false);
+  const [capturedImage, setCapturedImage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // 権限拒否などで再要求ボタンを出すかどうか
+  const [isPermissionBlocked, setIsPermissionBlocked] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [facingMode, setFacingMode] = useState<"user" | "environment">("environment");
+
+  const startCamera = useCallback(async () => {
+    // 既存ストリームを停止してから取得し直す（カメラ切り替え時）
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+
+    // ブラウザがカメラAPIに非対応、または非セキュアコンテキスト（http）の場合
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setError("このブラウザではカメラを利用できません。HTTPS環境で最新のブラウザをお使いください。");
+      setIsPermissionBlocked(false);
+      setIsInitializing(false);
+      return;
+    }
+
+    // この呼び出しの世代番号。完了時に最新でなければ結果を破棄する（多重起動防止）
+    const generation = ++startGenerationRef.current;
+
+    setIsInitializing(true);
+    setError(null);
+    setIsPermissionBlocked(false);
+
+    // 指定 facingMode で取得し、カメラ使用中などで開けない場合は制約を緩めて再試行する
+    const requestStream = async () => {
+      try {
+        // getUserMedia の呼び出しがブラウザ標準のカメラ許可ダイアログを表示する
+        return await navigator.mediaDevices.getUserMedia({
+          video: { facingMode },
+          audio: false,
+        });
+      } catch (err) {
+        const name = err instanceof DOMException ? err.name : "";
+        // 指定カメラが使用中/未対応の場合は、制約なしでもう一度試す
+        if (name === "NotReadableError" || name === "OverconstrainedError" || name === "TrackStartError") {
+          return await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+        }
+        throw err;
+      }
+    };
+
+    try {
+      const newStream = await requestStream();
+
+      // 取得中に新しい起動要求が始まっていたら、このストリームは破棄する
+      if (generation !== startGenerationRef.current) {
+        newStream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
+      streamRef.current = newStream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = newStream;
+      }
+      setError(null);
+      setIsPermissionBlocked(false);
+    } catch (err) {
+      // 古い起動要求のエラーは無視する
+      if (generation !== startGenerationRef.current) return;
+      console.error("Camera error:", err);
+      const name = err instanceof DOMException ? err.name : "";
+      if (name === "NotAllowedError" || name === "PermissionDeniedError" || name === "SecurityError") {
+        setError("カメラへのアクセスが許可されていません。撮影するにはカメラの使用を許可してください。");
+        setIsPermissionBlocked(true);
+      } else if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+        setError("カメラが見つかりませんでした。カメラ付きの端末でお試しください。");
+        setIsPermissionBlocked(false);
+      } else if (name === "NotReadableError" || name === "TrackStartError") {
+        setError("カメラを起動できませんでした。他のアプリやタブがカメラを使用していないか確認して、もう一度お試しください。");
+        setIsPermissionBlocked(true);
+      } else {
+        setError("カメラにアクセスできませんでした。ブラウザの設定を確認してください。");
+        setIsPermissionBlocked(true);
+      }
+    } finally {
+      // 最新の起動要求のときだけ初期化中フラグを下ろす
+      if (generation === startGenerationRef.current) {
+        setIsInitializing(false);
+      }
+    }
+  }, [facingMode]);
+
+  useEffect(() => {
+    startCamera();
+    return () => {
+      // 進行中の取得結果を無効化し、ストリームを完全に解放する
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      startGenerationRef.current++;
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, [startCamera]);
+
+  // 「撮り直す」で <video> が再マウントされた際に、保持中のストリームを再アタッチする
+  useEffect(() => {
+    if (!isPhotoTaken && videoRef.current && streamRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+    }
+  }, [isPhotoTaken]);
+
+  const toggleCamera = () => {
+    setFacingMode((prev) => (prev === "user" ? "environment" : "user"));
+  };
+
+  const takePhoto = () => {
+    if (!videoRef.current || !canvasRef.current) return;
+
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    // キャンバスサイズをビデオに合わせる
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
+    // ビデオを描画
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    // フレームと装飾を合成
+    drawFrame(context, canvas.width, canvas.height);
+
+    const dataUrl = canvas.toDataURL("image/webp");
+    setCapturedImage(dataUrl);
+    setIsPhotoTaken(true);
+  };
+
+  const drawFrame = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
+    // 簡易的なフレーム描画
+    const padding = 40;
+
+    // 角の装飾
+    ctx.strokeStyle = "rgba(251, 191, 36, 0.8)"; // amber-400
+    ctx.lineWidth = 15;
+
+    const len = 80;
+    // Top-left
+    ctx.beginPath(); ctx.moveTo(padding, padding + len); ctx.lineTo(padding, padding); ctx.lineTo(padding + len, padding); ctx.stroke();
+    // Top-right
+    ctx.beginPath(); ctx.moveTo(width - padding - len, padding); ctx.lineTo(width - padding, padding); ctx.lineTo(width - padding, padding + len); ctx.stroke();
+    // Bottom-left
+    ctx.beginPath(); ctx.moveTo(padding, height - padding - len); ctx.lineTo(padding, height - padding); ctx.lineTo(padding + len, height - padding); ctx.stroke();
+    // Bottom-right
+    ctx.beginPath(); ctx.moveTo(width - padding - len, height - padding); ctx.lineTo(width - padding, height - padding); ctx.lineTo(width - padding, height - padding - len); ctx.stroke();
+
+    // 日付とロゴ
+    const dateStr = new Date().toLocaleDateString("ja-JP");
+    ctx.fillStyle = "white";
+    ctx.shadowBlur = 10;
+    ctx.shadowColor = "black";
+    ctx.font = "bold 40px sans-serif";
+    ctx.textAlign = "right";
+    ctx.fillText("Kochi Sunday Market", width - 60, height - 60);
+    ctx.font = "30px sans-serif";
+    ctx.fillText(dateStr, width - 60, height - 110);
+
+    // アイテムのスタンプ
+    if (item) {
+      ctx.font = "120px sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText(item.emoji, 120, height - 80);
+      ctx.font = "bold 32px sans-serif";
+      ctx.fillText(item.name, 120, height - 40);
+    }
+  };
+
+  const downloadPhoto = () => {
+    if (!capturedImage) return;
+    const link = document.createElement("a");
+    link.href = capturedImage;
+    link.download = `nicchyo-discovery-${itemId || "photo"}.webp`;
+    link.click();
+  };
+
+  return (
+    <main className="fixed inset-0 z-[10000] bg-black text-white flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between p-6 bg-gradient-to-b from-black/60 to-transparent">
+        <button onClick={() => router.back()} className="rounded-full bg-white/10 p-2 backdrop-blur-md">
+          <X size={24} />
+        </button>
+        <div className="text-center">
+          <h1 className="text-sm font-bold tracking-widest uppercase">
+            {isPhotoTaken ? "完成！" : "記念撮影"}
+          </h1>
+          {item && !isPhotoTaken && <p className="text-xs text-amber-400 mt-0.5">{item.name}と一緒に</p>}
+        </div>
+        <div className="w-10" /> {/* Spacer */}
+      </div>
+
+      {/* Camera View / Captured Image */}
+      <div className="relative flex-1 flex items-center justify-center">
+        {!isPhotoTaken ? (
+          <div className="relative w-full h-full">
+            <video
+              ref={videoRef}
+              autoPlay
+              playsInline
+              className="w-full h-full object-cover"
+            />
+            {/* プレビュー上のフレーム演出 */}
+            <div className="absolute inset-0 pointer-events-none p-10 border-[30px] border-black/10">
+              <div className="w-full h-full border-2 border-white/30 rounded-2xl flex flex-col items-center justify-between p-6">
+                <div className="self-end text-white/50 text-[10px] font-bold tracking-widest">
+                  LIVE PREVIEW
+                </div>
+                {item && (
+                  <div className="self-start flex flex-col items-center gap-1 opacity-80">
+                    <span className="text-6xl">{item.emoji}</span>
+                    <span className="text-xs font-bold text-white shadow-sm">{item.name}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="relative w-full h-full p-4 flex items-center justify-center">
+            <motion.img
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              src={capturedImage!}
+              alt="Captured"
+              className="max-w-full max-h-full rounded-3xl shadow-2xl"
+            />
+          </div>
+        )}
+
+        {/* 起動中（カメラ許可ダイアログの応答待ちを含む） */}
+        {!isPhotoTaken && isInitializing && !error && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-8 text-center bg-slate-900/95">
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-amber-400" />
+            <div>
+              <p className="text-sm font-bold text-white">カメラを起動しています…</p>
+              <p className="mt-1 text-xs text-slate-400">許可を求められたら「許可」を選んでください</p>
+            </div>
+          </div>
+        )}
+
+        {/* エラー・許可拒否時の案内 */}
+        {error && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-8 text-center bg-slate-900">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/15">
+              <Camera className="text-amber-400" size={32} />
+            </div>
+            <p className="mb-2 text-base font-bold text-white">カメラを使えるようにしましょう</p>
+            <p className="mb-6 max-w-xs text-sm leading-relaxed text-slate-300">{error}</p>
+
+            <button
+              onClick={startCamera}
+              disabled={isInitializing}
+              className="mb-3 w-full max-w-xs rounded-2xl bg-amber-500 px-6 py-3.5 text-sm font-bold text-white shadow-lg shadow-amber-500/30 transition active:scale-95 disabled:opacity-60"
+            >
+              {isInitializing ? "起動中…" : "カメラを許可する"}
+            </button>
+
+            {isPermissionBlocked && (
+              <p className="mb-4 max-w-xs text-[11px] leading-relaxed text-slate-500">
+                ボタンを押しても表示されない場合は、ブラウザのアドレスバーの🔒（鍵マーク）からカメラを「許可」に変更し、再度お試しください。
+              </p>
+            )}
+
+            <button
+              onClick={() => router.back()}
+              className="text-xs font-semibold text-slate-400 underline-offset-2 hover:underline"
+            >
+              撮影をやめて戻る
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Footer Controls（エラー・起動中はシャッターを隠す） */}
+      {!(error || (isInitializing && !isPhotoTaken)) && (
+      <div className="absolute bottom-0 left-0 right-0 z-20 p-8 bg-gradient-to-t from-black/80 to-transparent">
+        <div className="flex items-center justify-center gap-8">
+          {!isPhotoTaken ? (
+            <>
+              <button
+                onClick={toggleCamera}
+                className="h-14 w-14 rounded-full bg-white/10 flex items-center justify-center backdrop-blur-md active:scale-90 transition-transform"
+              >
+                <RefreshCw size={24} />
+              </button>
+
+              <button
+                onClick={takePhoto}
+                className="h-20 w-20 rounded-full bg-white p-1 flex items-center justify-center shadow-lg shadow-white/20 active:scale-95 transition-transform"
+              >
+                <div className="h-full w-full rounded-full border-4 border-black/5 flex items-center justify-center">
+                  <div className="h-14 w-14 rounded-full bg-slate-900" />
+                </div>
+              </button>
+
+              <div className="h-14 w-14" /> {/* Placeholder for balance */}
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => setIsPhotoTaken(false)}
+                className="flex-1 rounded-2xl bg-white/10 py-4 text-sm font-bold backdrop-blur-md active:scale-95 transition-transform"
+              >
+                撮り直す
+              </button>
+              <button
+                onClick={downloadPhoto}
+                className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-amber-500 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/30 active:scale-95 transition-transform"
+              >
+                <Download size={18} />
+                保存する
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      )}
+
+      {/* Hidden Canvas for Processing */}
+      <canvas ref={canvasRef} className="hidden" />
+    </main>
+  );
+}
+
+export default function CameraPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-black" />}>
+      <CameraPageContent />
+    </Suspense>
+  );
+}

--- a/app/(public)/encyclopedia/camera/page.tsx
+++ b/app/(public)/encyclopedia/camera/page.tsx
@@ -197,14 +197,16 @@ function CameraPageContent() {
     const link = document.createElement("a");
     link.href = capturedImage;
     link.download = `nicchyo-discovery-${itemId || "photo"}.webp`;
+    document.body.appendChild(link);
     link.click();
+    link.remove();
   };
 
   return (
     <main className="fixed inset-0 z-[10000] bg-black text-white flex flex-col overflow-hidden">
       {/* Header */}
       <div className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between p-6 bg-gradient-to-b from-black/60 to-transparent">
-        <button onClick={() => router.back()} className="rounded-full bg-white/10 p-2 backdrop-blur-md">
+        <button type="button" onClick={() => router.back()} className="rounded-full bg-white/10 p-2 backdrop-blur-md">
           <X size={24} />
         </button>
         <div className="text-center">
@@ -274,6 +276,7 @@ function CameraPageContent() {
             <p className="mb-6 max-w-xs text-sm leading-relaxed text-slate-300">{error}</p>
 
             <button
+              type="button"
               onClick={startCamera}
               disabled={isInitializing}
               className="mb-3 w-full max-w-xs rounded-2xl bg-amber-500 px-6 py-3.5 text-sm font-bold text-white shadow-lg shadow-amber-500/30 transition active:scale-95 disabled:opacity-60"
@@ -288,6 +291,7 @@ function CameraPageContent() {
             )}
 
             <button
+              type="button"
               onClick={() => router.back()}
               className="text-xs font-semibold text-slate-400 underline-offset-2 hover:underline"
             >
@@ -304,6 +308,7 @@ function CameraPageContent() {
           {!isPhotoTaken ? (
             <>
               <button
+                type="button"
                 onClick={toggleCamera}
                 className="h-14 w-14 rounded-full bg-white/10 flex items-center justify-center backdrop-blur-md active:scale-90 transition-transform"
               >
@@ -311,6 +316,7 @@ function CameraPageContent() {
               </button>
 
               <button
+                type="button"
                 onClick={takePhoto}
                 className="h-20 w-20 rounded-full bg-white p-1 flex items-center justify-center shadow-lg shadow-white/20 active:scale-95 transition-transform"
               >
@@ -324,12 +330,14 @@ function CameraPageContent() {
           ) : (
             <>
               <button
+                type="button"
                 onClick={() => setIsPhotoTaken(false)}
                 className="flex-1 rounded-2xl bg-white/10 py-4 text-sm font-bold backdrop-blur-md active:scale-95 transition-transform"
               >
                 撮り直す
               </button>
               <button
+                type="button"
                 onClick={downloadPhoto}
                 className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-amber-500 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/30 active:scale-95 transition-transform"
               >

--- a/app/(public)/encyclopedia/camera/page.tsx
+++ b/app/(public)/encyclopedia/camera/page.tsx
@@ -148,7 +148,7 @@ function CameraPageContent() {
     // フレームと装飾を合成
     drawFrame(context, canvas.width, canvas.height);
 
-    const dataUrl = canvas.toDataURL("image/webp");
+    const dataUrl = canvas.toDataURL("image/jpeg");
     setCapturedImage(dataUrl);
     setIsPhotoTaken(true);
   };

--- a/app/(public)/encyclopedia/camera/page.tsx
+++ b/app/(public)/encyclopedia/camera/page.tsx
@@ -196,7 +196,7 @@ function CameraPageContent() {
     if (!capturedImage) return;
     const link = document.createElement("a");
     link.href = capturedImage;
-    link.download = `nicchyo-discovery-${itemId || "photo"}.webp`;
+    link.download = `nicchyo-discovery-${itemId || "photo"}.jpg`;
     document.body.appendChild(link);
     link.click();
     link.remove();

--- a/app/(public)/encyclopedia/page.tsx
+++ b/app/(public)/encyclopedia/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { ENCYCLOPEDIA_ITEMS, type EncyclopediaItem } from "@/data/encyclopediaItems";
+import { useEncyclopedia } from "@/lib/storage/encyclopedia";
+import NavigationBar from "@/app/components/NavigationBar";
+import { Camera, QrCode, MapPin, Trophy, Star, Share2 } from "lucide-react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+
+const CATEGORY_LABELS: Record<EncyclopediaItem["category"], string> = {
+  food: "グルメ",
+  craft: "工芸品",
+  seasonal: "季節限定",
+};
+
+const RARITY_STARS: Record<EncyclopediaItem["rarity"], number> = {
+  normal: 1,
+  rare: 2,
+  super_rare: 3,
+};
+
+export default function EncyclopediaPage() {
+  const { unlockedIds } = useEncyclopedia();
+  const [selectedItem, setSelectedItem] = useState<EncyclopediaItem | null>(null);
+
+  const stats = {
+    total: ENCYCLOPEDIA_ITEMS.length,
+    unlocked: unlockedIds.length,
+    percent: Math.round((unlockedIds.length / ENCYCLOPEDIA_ITEMS.length) * 100),
+  };
+
+  return (
+    <main className="min-h-screen bg-slate-50 pb-28">
+      {/* Header */}
+      <div className="bg-white px-4 pt-8 pb-6 shadow-sm ring-1 ring-slate-200">
+        <div className="mx-auto max-w-lg">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900">日曜市発見図鑑</h1>
+              <p className="mt-1 text-sm text-slate-500">日曜市の魅力を集める冒険に出よう</p>
+            </div>
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-50 ring-1 ring-amber-100">
+              <Trophy className="h-7 w-7 text-amber-500" />
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between text-xs font-bold uppercase tracking-wider text-slate-400">
+              <span>コレクションの進捗</span>
+              <span className="text-amber-600">{stats.unlocked} / {stats.total}</span>
+            </div>
+            <div className="mt-2 h-2.5 overflow-hidden rounded-full bg-slate-100 ring-1 ring-slate-200">
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${stats.percent}%` }}
+                className="h-full bg-gradient-to-r from-amber-400 to-orange-500"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-lg px-4 pt-6">
+        {/* Grid */}
+        <div className="grid grid-cols-2 gap-4">
+          {ENCYCLOPEDIA_ITEMS.map((item) => {
+            const isUnlocked = unlockedIds.includes(item.id);
+            return (
+              <motion.button
+                key={item.id}
+                whileTap={{ scale: 0.96 }}
+                onClick={() => setSelectedItem(item)}
+                className={`relative flex flex-col items-center gap-3 rounded-3xl p-5 text-center transition-all ${
+                  isUnlocked
+                    ? "bg-white shadow-sm ring-1 ring-slate-200 hover:shadow-md"
+                    : "bg-slate-50 ring-1 ring-dashed ring-slate-300"
+                }`}
+              >
+                {/* カテゴリーバッジ */}
+                <span className="absolute left-3 top-3 rounded-full bg-slate-100 px-2 py-0.5 text-[9px] font-bold tracking-wide text-slate-500">
+                  {CATEGORY_LABELS[item.category]}
+                </span>
+
+                {/* 未開放時の取得方法アイコン */}
+                {!isUnlocked && (
+                  <span className="absolute right-3 top-3 text-slate-400">
+                    {item.trigger.type === "qr" ? (
+                      <QrCode className="h-4 w-4" />
+                    ) : (
+                      <MapPin className="h-4 w-4" />
+                    )}
+                  </span>
+                )}
+
+                {/* エンブレム */}
+                <div
+                  className={`mt-3 flex h-16 w-16 items-center justify-center rounded-2xl text-4xl ${
+                    isUnlocked ? "bg-amber-50 ring-1 ring-amber-100" : "bg-slate-100"
+                  }`}
+                >
+                  <span className={isUnlocked ? "" : "opacity-25 [filter:grayscale(1)_brightness(0)]"}>
+                    {item.emoji}
+                  </span>
+                </div>
+
+                {/* 名前 */}
+                <p className={`text-sm font-bold ${isUnlocked ? "text-slate-900" : "text-slate-400"}`}>
+                  {item.name}
+                </p>
+
+                {/* レアリティ */}
+                <div className="flex justify-center gap-0.5">
+                  {Array.from({ length: RARITY_STARS[item.rarity] }).map((_, i) => (
+                    <Star
+                      key={i}
+                      className={`h-3 w-3 ${
+                        isUnlocked ? "fill-amber-400 text-amber-400" : "fill-slate-200 text-slate-200"
+                      }`}
+                    />
+                  ))}
+                </div>
+              </motion.button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Item Detail Modal */}
+      <AnimatePresence>
+        {selectedItem && (
+          <div className="fixed inset-0 z-[10000] flex items-end justify-center p-4 sm:items-center">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setSelectedItem(null)}
+              className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"
+            />
+            <motion.div
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              className="relative w-full max-w-lg overflow-hidden rounded-[2.5rem] bg-white shadow-2xl"
+            >
+              {(() => {
+                const isUnlocked = unlockedIds.includes(selectedItem.id);
+                return (
+                  <div className="p-8">
+                    <div className="flex justify-between items-start mb-6">
+                      <div className={`flex h-20 w-20 items-center justify-center rounded-3xl text-5xl shadow-inner ${
+                        isUnlocked ? "bg-amber-50" : "bg-slate-100"
+                      }`}>
+                        <span className={isUnlocked ? "" : "opacity-30 [filter:grayscale(1)_brightness(0)]"}>
+                          {selectedItem.emoji}
+                        </span>
+                      </div>
+                      <div className="text-right">
+                        <span className="inline-block rounded-full bg-slate-100 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-slate-500">
+                          {CATEGORY_LABELS[selectedItem.category]}
+                        </span>
+                        <h2 className="mt-2 text-2xl font-black text-slate-900">{selectedItem.name}</h2>
+                      </div>
+                    </div>
+
+                    <div className="space-y-6">
+                      <div>
+                        <h3 className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">解説</h3>
+                        <p className="text-slate-600 leading-relaxed">{selectedItem.description}</p>
+                      </div>
+
+                      <Link
+                        href={`/map?q=${encodeURIComponent(selectedItem.name)}`}
+                        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-nicchyo-primary py-4 text-sm font-bold text-white shadow-lg active:scale-[0.98] transition-transform"
+                      >
+                        <MapPin size={18} />
+                        販売しているお店をチェック
+                      </Link>
+
+                      {isUnlocked && (
+                        <div className="flex gap-2">
+                          <Link
+                            href={`/encyclopedia/camera?item=${selectedItem.id}`}
+                            className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-slate-900 py-4 text-sm font-bold text-white shadow-lg active:scale-[0.98] transition-transform"
+                          >
+                            <Camera size={18} />
+                            記念撮影をする
+                          </Link>
+                          <button className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 active:scale-[0.98] transition-transform">
+                            <Share2 size={20} />
+                          </button>
+                        </div>
+                      )}
+
+                      <button
+                        onClick={() => setSelectedItem(null)}
+                        className="w-full rounded-2xl bg-slate-100 py-4 text-sm font-bold text-slate-600 active:scale-[0.98] transition-transform"
+                      >
+                        閉じる
+                      </button>
+                    </div>
+                  </div>
+                );
+              })()}
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+
+      <NavigationBar />
+    </main>
+  );
+}

--- a/app/(public)/encyclopedia/page.tsx
+++ b/app/(public)/encyclopedia/page.tsx
@@ -186,13 +186,14 @@ export default function EncyclopediaPage() {
                             <Camera size={18} />
                             記念撮影をする
                           </Link>
-                          <button className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 active:scale-[0.98] transition-transform">
+                          <button type="button" disabled aria-label="シェア（準備中）" className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-400 opacity-50 transition-transform">
                             <Share2 size={20} />
                           </button>
                         </div>
                       )}
 
                       <button
+                        type="button"
                         onClick={() => setSelectedItem(null)}
                         className="w-full rounded-2xl bg-slate-100 py-4 text-sm font-bold text-slate-600 active:scale-[0.98] transition-transform"
                       >

--- a/app/(public)/encyclopedia/scan/QrScanner.tsx
+++ b/app/(public)/encyclopedia/scan/QrScanner.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * QRコードスキャナーコンポーネント
+ * html5-qrcode を動的に読み込み、カメラでQRコードを読み取る
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { CameraOff } from "lucide-react";
+
+type Props = {
+  onScan: (value: string) => void;
+  active: boolean;
+};
+
+const SCANNER_ELEMENT_ID = "qr-scanner-region";
+
+export default function QrScanner({ onScan, active }: Props) {
+  const scannerRef = useRef<import("html5-qrcode").Html5QrcodeScanner | null>(null);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    let mounted = true;
+
+    import("html5-qrcode").then(({ Html5QrcodeScanner, Html5QrcodeScanType }) => {
+      if (!mounted) return;
+
+      // 既存インスタンスがあればクリア
+      if (scannerRef.current) {
+        scannerRef.current.clear().catch(() => {});
+        scannerRef.current = null;
+      }
+
+      const scanner = new Html5QrcodeScanner(
+        SCANNER_ELEMENT_ID,
+        {
+          fps: 10,
+          qrbox: { width: 220, height: 220 },
+          supportedScanTypes: [Html5QrcodeScanType.SCAN_TYPE_CAMERA],
+          rememberLastUsedCamera: true,
+          showTorchButtonIfSupported: true,
+        },
+        false
+      );
+
+      scanner.render(
+        (decodedText) => {
+          onScan(decodedText);
+        },
+        () => {
+          // スキャン失敗は都度発生するため無視
+        }
+      );
+
+      scannerRef.current = scanner;
+    }).catch(() => {
+      if (mounted) setCameraError("カメラの初期化に失敗しました");
+    });
+
+    return () => {
+      mounted = false;
+      if (scannerRef.current) {
+        scannerRef.current.clear().catch(() => {});
+        scannerRef.current = null;
+      }
+    };
+  }, [active, onScan]);
+
+  if (cameraError) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-8 text-center">
+        <CameraOff size={36} className="text-red-400" />
+        <p className="text-sm text-red-600">{cameraError}</p>
+        <p className="text-xs text-red-400">
+          ブラウザのカメラ許可を確認してください
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-black">
+      {/* html5-qrcode がここにカメラ映像を描画する */}
+      <div id={SCANNER_ELEMENT_ID} />
+    </div>
+  );
+}

--- a/app/(public)/encyclopedia/scan/page.tsx
+++ b/app/(public)/encyclopedia/scan/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import QrScanner from "./QrScanner";
 import { unlockItem } from "@/lib/storage/encyclopedia";
+import toast from "react-hot-toast";
 import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Trophy, Sparkles } from "lucide-react";
@@ -28,8 +29,7 @@ function ScanPageContent() {
           window.navigator.vibrate(200);
         }
       } else {
-        // すでに解放済みの場合も、とりあえずそのアイテムを表示するか、トーストを出す
-        // ここではシンプルに図鑑に戻るか、メッセージを出す
+        toast(`「${item.name}」はすでに発見済みです`, { icon: item.emoji });
         router.push('/encyclopedia');
       }
     }
@@ -117,6 +117,7 @@ function ScanPageContent() {
                     図鑑を見る
                   </Link>
                   <button
+                    type="button"
                     onClick={() => {
                       setUnlockedItem(null);
                       setIsScanning(true);

--- a/app/(public)/encyclopedia/scan/page.tsx
+++ b/app/(public)/encyclopedia/scan/page.tsx
@@ -5,14 +5,14 @@ import { useRouter } from "next/navigation";
 import QrScanner from "./QrScanner";
 import { unlockItem } from "@/lib/storage/encyclopedia";
 import toast from "react-hot-toast";
-import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
+import { ENCYCLOPEDIA_ITEMS, EncyclopediaItem } from "@/data/encyclopediaItems";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Trophy, Sparkles } from "lucide-react";
 import Link from "next/link";
 
 function ScanPageContent() {
   const router = useRouter();
-  const [unlockedItem, setUnlockedItem] = useState<typeof ENCYCLOPEDIA_ITEMS[0] | null>(null);
+  const [unlockedItem, setUnlockedItem] = useState<EncyclopediaItem | null>(null);
   const [isScanning, setIsScanning] = useState(true);
 
   const handleScan = useCallback((value: string) => {

--- a/app/(public)/encyclopedia/scan/page.tsx
+++ b/app/(public)/encyclopedia/scan/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useCallback, Suspense } from "react";
+import { useRouter } from "next/navigation";
+import QrScanner from "./QrScanner";
+import { unlockItem } from "@/lib/storage/encyclopedia";
+import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Trophy, Sparkles } from "lucide-react";
+import Link from "next/link";
+
+function ScanPageContent() {
+  const router = useRouter();
+  const [unlockedItem, setUnlockedItem] = useState<typeof ENCYCLOPEDIA_ITEMS[0] | null>(null);
+  const [isScanning, setIsScanning] = useState(true);
+
+  const handleScan = useCallback((value: string) => {
+    // QRコードの値が百科事典アイテムの trigger.qrValue と一致するかチェック
+    const item = ENCYCLOPEDIA_ITEMS.find(i => i.trigger.qrValue === value);
+
+    if (item) {
+      const isNew = unlockItem(item.id);
+      if (isNew) {
+        setUnlockedItem(item);
+        setIsScanning(false);
+        // バイブレーション（対応端末のみ）
+        if (typeof window !== 'undefined' && window.navigator.vibrate) {
+          window.navigator.vibrate(200);
+        }
+      } else {
+        // すでに解放済みの場合も、とりあえずそのアイテムを表示するか、トーストを出す
+        // ここではシンプルに図鑑に戻るか、メッセージを出す
+        router.push('/encyclopedia');
+      }
+    }
+  }, [router]);
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-white">
+      <div className="relative flex min-h-screen flex-col items-center justify-center p-6">
+        <Link
+          href="/encyclopedia"
+          className="absolute top-6 right-6 z-20 rounded-full bg-white/10 p-2 backdrop-blur-md"
+        >
+          <X size={24} />
+        </Link>
+
+        {isScanning ? (
+          <div className="w-full max-w-sm space-y-8 text-center">
+            <div className="space-y-2">
+              <h1 className="text-xl font-bold">QRコードをスキャン</h1>
+              <p className="text-sm text-slate-400">店頭のQRコードを読み取ってアイテムをゲット！</p>
+            </div>
+
+            <div className="relative aspect-square overflow-hidden rounded-3xl border-4 border-amber-500/50 bg-black shadow-2xl shadow-amber-500/20">
+              <QrScanner active={isScanning} onScan={handleScan} />
+
+              {/* スキャン枠の演出 */}
+              <div className="absolute inset-0 pointer-events-none border-[40px] border-black/20" />
+              <motion.div
+                animate={{ top: ["10%", "90%", "10%"] }}
+                transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
+                className="absolute left-[10%] right-[10%] h-0.5 bg-amber-400 shadow-[0_0_15px_rgba(251,191,36,0.8)]"
+              />
+            </div>
+
+            <div className="pt-4">
+              <p className="text-xs text-slate-500">
+                カメラへのアクセスを許可してください
+              </p>
+            </div>
+          </div>
+        ) : (
+          <AnimatePresence>
+            {unlockedItem && (
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="flex flex-col items-center text-center"
+              >
+                <div className="relative mb-8">
+                  <motion.div
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
+                    className="absolute inset-0 -m-8 rounded-full bg-gradient-to-tr from-amber-500/0 via-amber-500/40 to-orange-500/0 blur-xl"
+                  />
+                  <div className="relative flex h-32 w-32 items-center justify-center rounded-[2.5rem] bg-white text-6xl shadow-2xl shadow-amber-500/40 ring-4 ring-amber-400">
+                    {unlockedItem.emoji}
+                  </div>
+                  <motion.div
+                    initial={{ y: 20, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    transition={{ delay: 0.3 }}
+                    className="absolute -bottom-4 -right-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white shadow-lg"
+                  >
+                    <Trophy size={20} />
+                  </motion.div>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-center gap-2 text-amber-400">
+                    <Sparkles size={16} />
+                    <span className="text-xs font-black uppercase tracking-[0.2em]">New Discovery!</span>
+                    <Sparkles size={16} />
+                  </div>
+                  <h2 className="text-3xl font-black">{unlockedItem.name}</h2>
+                  <p className="text-slate-400 max-w-[280px] mx-auto text-sm leading-relaxed">
+                    おめでとう！日曜市の新しい魅力を図鑑に登録しました。
+                  </p>
+                </div>
+
+                <div className="mt-12 flex flex-col gap-3 w-full max-w-[240px]">
+                  <Link
+                    href="/encyclopedia"
+                    className="rounded-2xl bg-amber-500 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/30 transition active:scale-95"
+                  >
+                    図鑑を見る
+                  </Link>
+                  <button
+                    onClick={() => {
+                      setUnlockedItem(null);
+                      setIsScanning(true);
+                    }}
+                    className="rounded-2xl bg-white/10 py-4 text-sm font-bold text-white transition active:scale-95"
+                  >
+                    続けてスキャン
+                  </button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function ScanPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-slate-900" />}>
+      <ScanPageContent />
+    </Suspense>
+  );
+}

--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -25,6 +25,7 @@ import { grandmaEvents } from "./data/grandmaEvents";
 import { recordMarketEnter, recordMarketExit } from "../../../lib/storage/marketStats";
 import { buildSearchIndex } from "../search/lib/searchIndex";
 import { useShopSearch } from "../search/hooks/useShopSearch";
+import { useEncyclopediaUnlock } from "../../../lib/hooks/useEncyclopediaUnlock";
 import { getOrCreateConsultVisitorKey } from "../../../lib/consultVisitorKey";
 import MapCharacterConsult from "./components/MapCharacterConsult";
 
@@ -83,6 +84,8 @@ export default function MapPageClient({
     lng: number;
   } | null>(null);
 
+  useEncyclopediaUnlock(userLocation);
+
   const [isInMarket, setIsInMarket] = useState<boolean | null>(null);
   useEffect(() => {
     if (isInMarket === true) recordMarketEnter();
@@ -123,7 +126,9 @@ export default function MapPageClient({
     ids: number[];
     label: string;
   } | null>(null);
-  const [mapSearchQuery, setMapSearchQuery] = useState('');
+  const [mapSearchQuery, setMapSearchQuery] = useState(
+    () => searchParams?.get("q") ?? '',
+  );
   const [mapSearchCategory, setMapSearchCategory] = useState<string | null>(null);
   const mapSearchIndex = useMemo(() => buildSearchIndex(shops), [shops]);
   const mapSearchResults = useShopSearch({

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -12,11 +12,12 @@ import { useBag } from "@/lib/storage/BagContext";
 type NavItem = {
   name: string;
   href: string;
-  icon: "search" | "chat" | "admin";
+  icon: "search" | "chat" | "admin" | "book";
 };
 
 const baseNavItems: NavItem[] = [
   { name: "相談", href: "/map", icon: "chat" },
+  { name: "図鑑", href: "/encyclopedia", icon: "book" },
 ];
 
 // ─── セカンダリメニュー項目（2列グリッド） ────────────────────────────────────
@@ -488,6 +489,16 @@ function NavIcon({ name, className }: NavIconProps) {
             strokeLinecap="round"
             strokeLinejoin="round"
             d="M4.5 6.75A2.25 2.25 0 0 1 6.75 4.5h10.5A2.25 2.25 0 0 1 19.5 6.75v6A2.25 2.25 0 0 1 17.25 15H9l-3.75 3v-3H6.75A2.25 2.25 0 0 1 4.5 12.75v-6Z"
+          />
+        </svg>
+      );
+    case "book":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18c-2.305 0-4.408.867-6 2.292m0-14.25v14.25"
           />
         </svg>
       );

--- a/data/encyclopediaItems.ts
+++ b/data/encyclopediaItems.ts
@@ -1,0 +1,121 @@
+export type Rarity = 'normal' | 'rare' | 'super_rare';
+
+export type EncyclopediaItem = {
+  id: string;
+  name: string;
+  emoji: string;
+  description: string;
+  rarity: Rarity;
+  hint: string;
+  category: 'food' | 'craft' | 'seasonal';
+  locationName?: string;
+  // 簡易的な判定用
+  trigger: {
+    type: 'qr' | 'gps' | 'both';
+    qrValue?: string;
+    lat?: number;
+    lng?: number;
+    radius?: number; // meters
+  };
+};
+
+export const ENCYCLOPEDIA_ITEMS: EncyclopediaItem[] = [
+  {
+    id: 'imoten',
+    name: 'いも天',
+    emoji: '🍠',
+    description: '日曜市といえばこれ！ホクホクのさつまいもを厚めの衣で揚げた、行列必至の名物です。外はカリッと、中はしっとり甘い。',
+    rarity: 'normal',
+    hint: '大橋通り周辺の香ばしい匂いをたどってみて。',
+    category: 'food',
+    locationName: '大橋通り周辺',
+    trigger: {
+      type: 'gps',
+      lat: 33.559,
+      lng: 133.535,
+      radius: 100
+    }
+  },
+  {
+    id: 'inakazushi',
+    name: '田舎寿司',
+    emoji: '🍣',
+    description: 'りゅうきゅう（蓮芋）や筍、椎茸など、山の幸をふんだんに使った高知の伝統的なお寿司。柚子の酢がきいた酢飯が特徴です。',
+    rarity: 'normal',
+    hint: 'お惣菜がたくさん並んでいるお店を探して。',
+    category: 'food',
+    trigger: {
+      type: 'qr',
+      qrValue: 'item_inakazushi'
+    }
+  },
+  {
+    id: 'hiyashiame',
+    name: 'ひやしあめ',
+    emoji: '🥤',
+    description: '生姜のきいた甘い飲み物。夏は氷でキリッと、冬は温めても美味しい、日曜市の定番ドリンクです。',
+    rarity: 'normal',
+    hint: '「ひやしあめ」の旗が立っているお店があるよ。',
+    category: 'food',
+    trigger: {
+      type: 'qr',
+      qrValue: 'item_hiyashiame'
+    }
+  },
+  {
+    id: 'tosahamono',
+    name: '土佐刃物',
+    emoji: '🔪',
+    description: '400年以上の歴史を持つ、高知の伝統工芸品。切れ味抜群で丈夫な包丁や鎌は、全国の料理人や農家に愛されています。',
+    rarity: 'normal',
+    hint: '鉄を叩く音が聞こえてくるかも？',
+    category: 'craft',
+    trigger: {
+      type: 'qr',
+      qrValue: 'item_tosahamono'
+    }
+  },
+  {
+    id: 'niitakanashi',
+    name: '新高梨',
+    emoji: '🍐',
+    description: '「梨の王様」と呼ばれる、高知発祥の巨大な梨。香りが高く、非常にジューシー。秋の日曜市を代表する味覚です。',
+    rarity: 'rare',
+    hint: '秋（9月〜10月）の時期にしか現れないよ。',
+    category: 'seasonal',
+    trigger: {
+      type: 'gps',
+      lat: 33.560,
+      lng: 133.533,
+      radius: 200
+    }
+  },
+  {
+    id: 'konatsu',
+    name: '小夏',
+    emoji: '🍋',
+    description: '初夏を告げる高知の柑橘。白い甘皮と一緒に食べるのが特徴で、爽やかな甘酸っぱさが口いっぱいに広がります。',
+    rarity: 'rare',
+    hint: '春から夏にかけて、黄色い果実が並ぶ頃に探してみて。',
+    category: 'seasonal',
+    trigger: {
+      type: 'qr',
+      qrValue: 'item_konatsu'
+    }
+  },
+  {
+    id: 'sansai',
+    name: '幻の山菜',
+    emoji: '🌿',
+    description: '朝一番にしか並ばない、地元の通だけが知っている希少な山菜。売り切れ御免のスーパーレアアイテムです。',
+    rarity: 'super_rare',
+    hint: '日曜日の朝、一番早い時間帯に探してみよう。',
+    category: 'food',
+    trigger: {
+      type: 'gps',
+      lat: 33.562,
+      lng: 133.530,
+      radius: 50
+    }
+  }
+];

--- a/lib/hooks/useEncyclopediaUnlock.ts
+++ b/lib/hooks/useEncyclopediaUnlock.ts
@@ -23,11 +23,11 @@ export function useEncyclopediaUnlock(userLocation: { lat: number; lng: number }
     }
 
     lastProcessedLocation.current = userLocation;
-    const unlockedIds = getUnlockedItemIds();
+    const unlockedIdSet = new Set(getUnlockedItemIds());
 
     ENCYCLOPEDIA_ITEMS.forEach((item) => {
       // すでに解放済み、またはGPSトリガーでない場合はスキップ
-      if (unlockedIds.includes(item.id)) return;
+      if (unlockedIdSet.has(item.id)) return;
       if (item.trigger.type !== 'gps' && item.trigger.type !== 'both') return;
       if (!item.trigger.lat || !item.trigger.lng) return;
 

--- a/lib/hooks/useEncyclopediaUnlock.ts
+++ b/lib/hooks/useEncyclopediaUnlock.ts
@@ -29,7 +29,7 @@ export function useEncyclopediaUnlock(userLocation: { lat: number; lng: number }
       // すでに解放済み、またはGPSトリガーでない場合はスキップ
       if (unlockedIdSet.has(item.id)) return;
       if (item.trigger.type !== 'gps' && item.trigger.type !== 'both') return;
-      if (!item.trigger.lat || !item.trigger.lng) return;
+      if (item.trigger.lat === undefined || item.trigger.lng === undefined) return;
 
       const distance = calculateDistance(
         userLocation.lat,

--- a/lib/hooks/useEncyclopediaUnlock.ts
+++ b/lib/hooks/useEncyclopediaUnlock.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from 'react';
+import { ENCYCLOPEDIA_ITEMS } from '@/data/encyclopediaItems';
+import { unlockItem, getUnlockedItemIds } from '@/lib/storage/encyclopedia';
+import toast from 'react-hot-toast';
+
+export function useEncyclopediaUnlock(userLocation: { lat: number; lng: number } | null) {
+  const lastProcessedLocation = useRef<{ lat: number; lng: number } | null>(null);
+
+  useEffect(() => {
+    if (!userLocation) return;
+
+    // 前回の判定位置から一定距離（例: 10m）動いていない場合は判定をスキップ
+    if (lastProcessedLocation.current) {
+      const dist = calculateDistance(
+        userLocation.lat,
+        userLocation.lng,
+        lastProcessedLocation.current.lat,
+        lastProcessedLocation.current.lng
+      );
+      if (dist < 10) return;
+    }
+
+    lastProcessedLocation.current = userLocation;
+    const unlockedIds = getUnlockedItemIds();
+
+    ENCYCLOPEDIA_ITEMS.forEach((item) => {
+      // すでに解放済み、またはGPSトリガーでない場合はスキップ
+      if (unlockedIds.includes(item.id)) return;
+      if (item.trigger.type !== 'gps' && item.trigger.type !== 'both') return;
+      if (!item.trigger.lat || !item.trigger.lng) return;
+
+      const distance = calculateDistance(
+        userLocation.lat,
+        userLocation.lng,
+        item.trigger.lat,
+        item.trigger.lng
+      );
+
+      if (distance <= (item.trigger.radius || 100)) {
+        const isNew = unlockItem(item.id);
+        if (isNew) {
+          toast.success(`新発見！「${item.name}」を図鑑に登録しました`, {
+            icon: item.emoji,
+            duration: 5000,
+          });
+        }
+      }
+    });
+  }, [userLocation]);
+}
+
+/**
+ * 2点間の距離を計算（メートル）
+ */
+function calculateDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371e3; // 地球の半径 (m)
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lng2 - lng1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}

--- a/lib/storage/encyclopedia.ts
+++ b/lib/storage/encyclopedia.ts
@@ -4,9 +4,8 @@ import { useEffect, useState, useCallback } from 'react';
 
 const STORAGE_KEY = 'nicchyo-encyclopedia-unlocked';
 
-// デモ用: 動作確認のため、常に1コレクションを解放済みとして扱う。
-// 本番運用時はこの配列を空にする（#335）。
-const DEMO_UNLOCKED_IDS = ['imoten'];
+// デモ用: 動作確認のため、常に1コレクションを解放済みとして扱う（#335）。
+const DEMO_UNLOCKED_IDS = process.env.NODE_ENV === 'development' ? ['imoten'] : [];
 
 export function getUnlockedItemIds(): string[] {
   if (typeof window === 'undefined') return [];

--- a/lib/storage/encyclopedia.ts
+++ b/lib/storage/encyclopedia.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'nicchyo-encyclopedia-unlocked';
+
+// デモ用: 動作確認のため、常に1コレクションを解放済みとして扱う。
+// 本番運用時はこの配列を空にする。
+const DEMO_UNLOCKED_IDS = ['imoten'];
+
+export function getUnlockedItemIds(): string[] {
+  if (typeof window === 'undefined') return [];
+  const raw = localStorage.getItem(STORAGE_KEY);
+  let stored: string[] = [];
+  if (raw) {
+    try {
+      stored = JSON.parse(raw);
+    } catch {
+      stored = [];
+    }
+  }
+  return Array.from(new Set([...DEMO_UNLOCKED_IDS, ...stored]));
+}
+
+export function unlockItem(id: string): boolean {
+  if (typeof window === 'undefined') return false;
+  const current = getUnlockedItemIds();
+  if (current.includes(id)) return false;
+
+  const next = [...current, id];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  window.dispatchEvent(new Event('nicchyo-encyclopedia-updated'));
+  return true;
+}
+
+export function useEncyclopedia() {
+  const [unlockedIds, setUnlockedIds] = useState<string[]>([]);
+
+  const refresh = useCallback(() => {
+    setUnlockedIds(getUnlockedItemIds());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    window.addEventListener('nicchyo-encyclopedia-updated', refresh);
+    return () => window.removeEventListener('nicchyo-encyclopedia-updated', refresh);
+  }, [refresh]);
+
+  return { unlockedIds, refresh };
+}

--- a/lib/storage/encyclopedia.ts
+++ b/lib/storage/encyclopedia.ts
@@ -5,7 +5,7 @@ import { useEffect, useState, useCallback } from 'react';
 const STORAGE_KEY = 'nicchyo-encyclopedia-unlocked';
 
 // デモ用: 動作確認のため、常に1コレクションを解放済みとして扱う。
-// 本番運用時はこの配列を空にする。
+// 本番運用時はこの配列を空にする（#335）。
 const DEMO_UNLOCKED_IDS = ['imoten'];
 
 export function getUnlockedItemIds(): string[] {
@@ -34,7 +34,7 @@ export function unlockItem(id: string): boolean {
 }
 
 export function useEncyclopedia() {
-  const [unlockedIds, setUnlockedIds] = useState<string[]>([]);
+  const [unlockedIds, setUnlockedIds] = useState<string[]>(() => getUnlockedItemIds());
 
   const refresh = useCallback(() => {
     setUnlockedIds(getUnlockedItemIds());

--- a/next.config.js
+++ b/next.config.js
@@ -72,14 +72,14 @@ const nextConfig = {
         ],
       },
       {
-        // 図鑑のQRスキャン・記念撮影ページ: カメラを許可
-        source: '/encyclopedia/:path*',
-        headers: [
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(self)',
-          },
-        ],
+        // 図鑑のQRスキャンページ: カメラを許可
+        source: '/encyclopedia/scan',
+        headers: [{ key: 'Permissions-Policy', value: 'camera=(self)' }],
+      },
+      {
+        // 図鑑の記念撮影ページ: カメラを許可
+        source: '/encyclopedia/camera',
+        headers: [{ key: 'Permissions-Policy', value: 'camera=(self)' }],
       },
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,16 @@ const nextConfig = {
           },
         ],
       },
+      {
+        // 図鑑のQRスキャン・記念撮影ページ: カメラを許可
+        source: '/encyclopedia/:path*',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(self)',
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
## 概要
日曜市発見図鑑の「基礎」部分（コレクション一覧の閲覧）を追加します。PR #295 分割の2本目。

## 変更内容（5ファイル）
- 図鑑ページ（一覧グリッド＋詳細モーダル）
- 図鑑アイテムのマスターデータ
- 解放状態のローカルストレージ
- ナビゲーションに「図鑑」エントリ追加

## マージ順序
このPRは #329（クーポン削除）の上にスタックしています。base を `feature/remove-coupons` にしているため、**#329 をマージ後に develop へ自動で付け替わります**。マージ順序: #329 → 本PR → 図鑑付随PR。

## 補足
- 「記念撮影」「販売店チェック（マップ検索）」などのリンク先は後続の図鑑付随PRで追加されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)