### PR TITLE
feat: 図鑑の解放・記念撮影・マップ検索連携

### DIFF
--- a/app/(public)/encyclopedia/camera/page.tsx
+++ b/app/(public)/encyclopedia/camera/page.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
+import { RefreshCw, Download, X, Camera } from "lucide-react";
+import { motion } from "framer-motion";
+
+function CameraPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const itemId = searchParams?.get("item");
+  const item = ENCYCLOPEDIA_ITEMS.find((i) => i.id === itemId);
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  // 起動要求の世代番号。多重起動時に古い取得結果を破棄するために使う
+  const startGenerationRef = useRef(0);
+  const [isPhotoTaken, setIsPhotoTaken] = useState(false);
+  const [capturedImage, setCapturedImage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // 権限拒否などで再要求ボタンを出すかどうか
+  const [isPermissionBlocked, setIsPermissionBlocked] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [facingMode, setFacingMode] = useState<"user" | "environment">("environment");
+
+  const startCamera = useCallback(async () => {
+    // 既存ストリームを停止してから取得し直す（カメラ切り替え時）
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+
+    // ブラウザがカメラAPIに非対応、または非セキュアコンテキスト（http）の場合
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setError("このブラウザではカメラを利用できません。HTTPS環境で最新のブラウザをお使いください。");
+      setIsPermissionBlocked(false);
+      setIsInitializing(false);
+      return;
+    }
+
+    // この呼び出しの世代番号。完了時に最新でなければ結果を破棄する（多重起動防止）
+    const generation = ++startGenerationRef.current;
+
+    setIsInitializing(true);
+    setError(null);
+    setIsPermissionBlocked(false);
+
+    // 指定 facingMode で取得し、カメラ使用中などで開けない場合は制約を緩めて再試行する
+    const requestStream = async () => {
+      try {
+        // getUserMedia の呼び出しがブラウザ標準のカメラ許可ダイアログを表示する
+        return await navigator.mediaDevices.getUserMedia({
+          video: { facingMode },
+          audio: false,
+        });
+      } catch (err) {
+        const name = err instanceof DOMException ? err.name : "";
+        // 指定カメラが使用中/未対応の場合は、制約なしでもう一度試す
+        if (name === "NotReadableError" || name === "OverconstrainedError" || name === "TrackStartError") {
+          return await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+        }
+        throw err;
+      }
+    };
+
+    try {
+      const newStream = await requestStream();
+
+      // 取得中に新しい起動要求が始まっていたら、このストリームは破棄する
+      if (generation !== startGenerationRef.current) {
+        newStream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
+      streamRef.current = newStream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = newStream;
+      }
+      setError(null);
+      setIsPermissionBlocked(false);
+    } catch (err) {
+      // 古い起動要求のエラーは無視する
+      if (generation !== startGenerationRef.current) return;
+      console.error("Camera error:", err);
+      const name = err instanceof DOMException ? err.name : "";
+      if (name === "NotAllowedError" || name === "PermissionDeniedError" || name === "SecurityError") {
+        setError("カメラへのアクセスが許可されていません。撮影するにはカメラの使用を許可してください。");
+        setIsPermissionBlocked(true);
+      } else if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+        setError("カメラが見つかりませんでした。カメラ付きの端末でお試しください。");
+        setIsPermissionBlocked(false);
+      } else if (name === "NotReadableError" || name === "TrackStartError") {
+        setError("カメラを起動できませんでした。他のアプリやタブがカメラを使用していないか確認して、もう一度お試しください。");
+        setIsPermissionBlocked(true);
+      } else {
+        setError("カメラにアクセスできませんでした。ブラウザの設定を確認してください。");
+        setIsPermissionBlocked(true);
+      }
+    } finally {
+      // 最新の起動要求のときだけ初期化中フラグを下ろす
+      if (generation === startGenerationRef.current) {
+        setIsInitializing(false);
+      }
+    }
+  }, [facingMode]);
+
+  useEffect(() => {
+    startCamera();
+    return () => {
+      // 進行中の取得結果を無効化し、ストリームを完全に解放する
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      startGenerationRef.current++;
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, [startCamera]);
+
+  // 「撮り直す」で <video> が再マウントされた際に、保持中のストリームを再アタッチする
+  useEffect(() => {
+    if (!isPhotoTaken && videoRef.current && streamRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+    }
+  }, [isPhotoTaken]);
+
+  const toggleCamera = () => {
+    setFacingMode((prev) => (prev === "user" ? "environment" : "user"));
+  };
+
+  const takePhoto = () => {
+    if (!videoRef.current || !canvasRef.current) return;
+
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    // キャンバスサイズをビデオに合わせる
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
+    // ビデオを描画
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    // フレームと装飾を合成
+    drawFrame(context, canvas.width, canvas.height);
+
+    const dataUrl = canvas.toDataURL("image/webp");
+    setCapturedImage(dataUrl);
+    setIsPhotoTaken(true);
+  };
+
+  const drawFrame = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
+    // 簡易的なフレーム描画
+    const padding = 40;
+
+    // 角の装飾
+    ctx.strokeStyle = "rgba(251, 191, 36, 0.8)"; // amber-400
+    ctx.lineWidth = 15;
+
+    const len = 80;
+    // Top-left
+    ctx.beginPath(); ctx.moveTo(padding, padding + len); ctx.lineTo(padding, padding); ctx.lineTo(padding + len, padding); ctx.stroke();
+    // Top-right
+    ctx.beginPath(); ctx.moveTo(width - padding - len, padding); ctx.lineTo(width - padding, padding); ctx.lineTo(width - padding, padding + len); ctx.stroke();
+    // Bottom-left
+    ctx.beginPath(); ctx.moveTo(padding, height - padding - len); ctx.lineTo(padding, height - padding); ctx.lineTo(padding + len, height - padding); ctx.stroke();
+    // Bottom-right
+    ctx.beginPath(); ctx.moveTo(width - padding - len, height - padding); ctx.lineTo(width - padding, height - padding); ctx.lineTo(width - padding, height - padding - len); ctx.stroke();
+
+    // 日付とロゴ
+    const dateStr = new Date().toLocaleDateString("ja-JP");
+    ctx.fillStyle = "white";
+    ctx.shadowBlur = 10;
+    ctx.shadowColor = "black";
+    ctx.font = "bold 40px sans-serif";
+    ctx.textAlign = "right";
+    ctx.fillText("Kochi Sunday Market", width - 60, height - 60);
+    ctx.font = "30px sans-serif";
+    ctx.fillText(dateStr, width - 60, height - 110);
+
+    // アイテムのスタンプ
+    if (item) {
+      ctx.font = "120px sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText(item.emoji, 120, height - 80);
+      ctx.font = "bold 32px sans-serif";
+      ctx.fillText(item.name, 120, height - 40);
+    }
+  };
+
+  const downloadPhoto = () => {
+    if (!capturedImage) return;
+    const link = document.createElement("a");
+    link.href = capturedImage;
+    link.download = `nicchyo-discovery-${itemId || "photo"}.webp`;
+    link.click();
+  };
+
+  return (
+    <main className="fixed inset-0 z-[10000] bg-black text-white flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between p-6 bg-gradient-to-b from-black/60 to-transparent">
+        <button onClick={() => router.back()} className="rounded-full bg-white/10 p-2 backdrop-blur-md">
+          <X size={24} />
+        </button>
+        <div className="text-center">
+          <h1 className="text-sm font-bold tracking-widest uppercase">
+            {isPhotoTaken ? "完成！" : "記念撮影"}
+          </h1>
+          {item && !isPhotoTaken && <p className="text-xs text-amber-400 mt-0.5">{item.name}と一緒に</p>}
+        </div>
+        <div className="w-10" /> {/* Spacer */}
+      </div>
+
+      {/* Camera View / Captured Image */}
+      <div className="relative flex-1 flex items-center justify-center">
+        {!isPhotoTaken ? (
+          <div className="relative w-full h-full">
+            <video
+              ref={videoRef}
+              autoPlay
+              playsInline
+              className="w-full h-full object-cover"
+            />
+            {/* プレビュー上のフレーム演出 */}
+            <div className="absolute inset-0 pointer-events-none p-10 border-[30px] border-black/10">
+              <div className="w-full h-full border-2 border-white/30 rounded-2xl flex flex-col items-center justify-between p-6">
+                <div className="self-end text-white/50 text-[10px] font-bold tracking-widest">
+                  LIVE PREVIEW
+                </div>
+                {item && (
+                  <div className="self-start flex flex-col items-center gap-1 opacity-80">
+                    <span className="text-6xl">{item.emoji}</span>
+                    <span className="text-xs font-bold text-white shadow-sm">{item.name}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="relative w-full h-full p-4 flex items-center justify-center">
+            <motion.img
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              src={capturedImage!}
+              alt="Captured"
+              className="max-w-full max-h-full rounded-3xl shadow-2xl"
+            />
+          </div>
+        )}
+
+        {/* 起動中（カメラ許可ダイアログの応答待ちを含む） */}
+        {!isPhotoTaken && isInitializing && !error && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-8 text-center bg-slate-900/95">
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-amber-400" />
+            <div>
+              <p className="text-sm font-bold text-white">カメラを起動しています…</p>
+              <p className="mt-1 text-xs text-slate-400">許可を求められたら「許可」を選んでください</p>
+            </div>
+          </div>
+        )}
+
+        {/* エラー・許可拒否時の案内 */}
+        {error && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-8 text-center bg-slate-900">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/15">
+              <Camera className="text-amber-400" size={32} />
+            </div>
+            <p className="mb-2 text-base font-bold text-white">カメラを使えるようにしましょう</p>
+            <p className="mb-6 max-w-xs text-sm leading-relaxed text-slate-300">{error}</p>
+
+            <button
+              onClick={startCamera}
+              disabled={isInitializing}
+              className="mb-3 w-full max-w-xs rounded-2xl bg-amber-500 px-6 py-3.5 text-sm font-bold text-white shadow-lg shadow-amber-500/30 transition active:scale-95 disabled:opacity-60"
+            >
+              {isInitializing ? "起動中…" : "カメラを許可する"}
+            </button>
+
+            {isPermissionBlocked && (
+              <p className="mb-4 max-w-xs text-[11px] leading-relaxed text-slate-500">
+                ボタンを押しても表示されない場合は、ブラウザのアドレスバーの🔒（鍵マーク）からカメラを「許可」に変更し、再度お試しください。
+              </p>
+            )}
+
+            <button
+              onClick={() => router.back()}
+              className="text-xs font-semibold text-slate-400 underline-offset-2 hover:underline"
+            >
+              撮影をやめて戻る
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Footer Controls（エラー・起動中はシャッターを隠す） */}
+      {!(error || (isInitializing && !isPhotoTaken)) && (
+      <div className="absolute bottom-0 left-0 right-0 z-20 p-8 bg-gradient-to-t from-black/80 to-transparent">
+        <div className="flex items-center justify-center gap-8">
+          {!isPhotoTaken ? (
+            <>
+              <button
+                onClick={toggleCamera}
+                className="h-14 w-14 rounded-full bg-white/10 flex items-center justify-center backdrop-blur-md active:scale-90 transition-transform"
+              >
+                <RefreshCw size={24} />
+              </button>
+
+              <button
+                onClick={takePhoto}
+                className="h-20 w-20 rounded-full bg-white p-1 flex items-center justify-center shadow-lg shadow-white/20 active:scale-95 transition-transform"
+              >
+                <div className="h-full w-full rounded-full border-4 border-black/5 flex items-center justify-center">
+                  <div className="h-14 w-14 rounded-full bg-slate-900" />
+                </div>
+              </button>
+
+              <div className="h-14 w-14" /> {/* Placeholder for balance */}
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => setIsPhotoTaken(false)}
+                className="flex-1 rounded-2xl bg-white/10 py-4 text-sm font-bold backdrop-blur-md active:scale-95 transition-transform"
+              >
+                撮り直す
+              </button>
+              <button
+                onClick={downloadPhoto}
+                className="flex-1 flex items-center justify-center gap-2 rounded-2xl bg-amber-500 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/30 active:scale-95 transition-transform"
+              >
+                <Download size={18} />
+                保存する
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      )}
+
+      {/* Hidden Canvas for Processing */}
+      <canvas ref={canvasRef} className="hidden" />
+    </main>
+  );
+}
+
+export default function CameraPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-black" />}>
+      <CameraPageContent />
+    </Suspense>
+  );
+}

--- a/app/(public)/encyclopedia/scan/QrScanner.tsx
+++ b/app/(public)/encyclopedia/scan/QrScanner.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * QRコードスキャナーコンポーネント
+ * html5-qrcode を動的に読み込み、カメラでQRコードを読み取る
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { CameraOff } from "lucide-react";
+
+type Props = {
+  onScan: (value: string) => void;
+  active: boolean;
+};
+
+const SCANNER_ELEMENT_ID = "qr-scanner-region";
+
+export default function QrScanner({ onScan, active }: Props) {
+  const scannerRef = useRef<import("html5-qrcode").Html5QrcodeScanner | null>(null);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    let mounted = true;
+
+    import("html5-qrcode").then(({ Html5QrcodeScanner, Html5QrcodeScanType }) => {
+      if (!mounted) return;
+
+      // 既存インスタンスがあればクリア
+      if (scannerRef.current) {
+        scannerRef.current.clear().catch(() => {});
+        scannerRef.current = null;
+      }
+
+      const scanner = new Html5QrcodeScanner(
+        SCANNER_ELEMENT_ID,
+        {
+          fps: 10,
+          qrbox: { width: 220, height: 220 },
+          supportedScanTypes: [Html5QrcodeScanType.SCAN_TYPE_CAMERA],
+          rememberLastUsedCamera: true,
+          showTorchButtonIfSupported: true,
+        },
+        false
+      );
+
+      scanner.render(
+        (decodedText) => {
+          onScan(decodedText);
+        },
+        () => {
+          // スキャン失敗は都度発生するため無視
+        }
+      );
+
+      scannerRef.current = scanner;
+    }).catch(() => {
+      if (mounted) setCameraError("カメラの初期化に失敗しました");
+    });
+
+    return () => {
+      mounted = false;
+      if (scannerRef.current) {
+        scannerRef.current.clear().catch(() => {});
+        scannerRef.current = null;
+      }
+    };
+  }, [active, onScan]);
+
+  if (cameraError) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-8 text-center">
+        <CameraOff size={36} className="text-red-400" />
+        <p className="text-sm text-red-600">{cameraError}</p>
+        <p className="text-xs text-red-400">
+          ブラウザのカメラ許可を確認してください
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-black">
+      {/* html5-qrcode がここにカメラ映像を描画する */}
+      <div id={SCANNER_ELEMENT_ID} />
+    </div>
+  );
+}

--- a/app/(public)/encyclopedia/scan/page.tsx
+++ b/app/(public)/encyclopedia/scan/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useCallback, Suspense } from "react";
+import { useRouter } from "next/navigation";
+import QrScanner from "./QrScanner";
+import { unlockItem } from "@/lib/storage/encyclopedia";
+import { ENCYCLOPEDIA_ITEMS } from "@/data/encyclopediaItems";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Trophy, Sparkles } from "lucide-react";
+import Link from "next/link";
+
+function ScanPageContent() {
+  const router = useRouter();
+  const [unlockedItem, setUnlockedItem] = useState<typeof ENCYCLOPEDIA_ITEMS[0] | null>(null);
+  const [isScanning, setIsScanning] = useState(true);
+
+  const handleScan = useCallback((value: string) => {
+    // QRコードの値が百科事典アイテムの trigger.qrValue と一致するかチェック
+    const item = ENCYCLOPEDIA_ITEMS.find(i => i.trigger.qrValue === value);
+
+    if (item) {
+      const isNew = unlockItem(item.id);
+      if (isNew) {
+        setUnlockedItem(item);
+        setIsScanning(false);
+        // バイブレーション（対応端末のみ）
+        if (typeof window !== 'undefined' && window.navigator.vibrate) {
+          window.navigator.vibrate(200);
+        }
+      } else {
+        // すでに解放済みの場合も、とりあえずそのアイテムを表示するか、トーストを出す
+        // ここではシンプルに図鑑に戻るか、メッセージを出す
+        router.push('/encyclopedia');
+      }
+    }
+  }, [router]);
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-white">
+      <div className="relative flex min-h-screen flex-col items-center justify-center p-6">
+        <Link
+          href="/encyclopedia"
+          className="absolute top-6 right-6 z-20 rounded-full bg-white/10 p-2 backdrop-blur-md"
+        >
+          <X size={24} />
+        </Link>
+
+        {isScanning ? (
+          <div className="w-full max-w-sm space-y-8 text-center">
+            <div className="space-y-2">
+              <h1 className="text-xl font-bold">QRコードをスキャン</h1>
+              <p className="text-sm text-slate-400">店頭のQRコードを読み取ってアイテムをゲット！</p>
+            </div>
+
+            <div className="relative aspect-square overflow-hidden rounded-3xl border-4 border-amber-500/50 bg-black shadow-2xl shadow-amber-500/20">
+              <QrScanner active={isScanning} onScan={handleScan} />
+
+              {/* スキャン枠の演出 */}
+              <div className="absolute inset-0 pointer-events-none border-[40px] border-black/20" />
+              <motion.div
+                animate={{ top: ["10%", "90%", "10%"] }}
+                transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
+                className="absolute left-[10%] right-[10%] h-0.5 bg-amber-400 shadow-[0_0_15px_rgba(251,191,36,0.8)]"
+              />
+            </div>
+
+            <div className="pt-4">
+              <p className="text-xs text-slate-500">
+                カメラへのアクセスを許可してください
+              </p>
+            </div>
+          </div>
+        ) : (
+          <AnimatePresence>
+            {unlockedItem && (
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="flex flex-col items-center text-center"
+              >
+                <div className="relative mb-8">
+                  <motion.div
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
+                    className="absolute inset-0 -m-8 rounded-full bg-gradient-to-tr from-amber-500/0 via-amber-500/40 to-orange-500/0 blur-xl"
+                  />
+                  <div className="relative flex h-32 w-32 items-center justify-center rounded-[2.5rem] bg-white text-6xl shadow-2xl shadow-amber-500/40 ring-4 ring-amber-400">
+                    {unlockedItem.emoji}
+                  </div>
+                  <motion.div
+                    initial={{ y: 20, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    transition={{ delay: 0.3 }}
+                    className="absolute -bottom-4 -right-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-white shadow-lg"
+                  >
+                    <Trophy size={20} />
+                  </motion.div>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-center gap-2 text-amber-400">
+                    <Sparkles size={16} />
+                    <span className="text-xs font-black uppercase tracking-[0.2em]">New Discovery!</span>
+                    <Sparkles size={16} />
+                  </div>
+                  <h2 className="text-3xl font-black">{unlockedItem.name}</h2>
+                  <p className="text-slate-400 max-w-[280px] mx-auto text-sm leading-relaxed">
+                    おめでとう！日曜市の新しい魅力を図鑑に登録しました。
+                  </p>
+                </div>
+
+                <div className="mt-12 flex flex-col gap-3 w-full max-w-[240px]">
+                  <Link
+                    href="/encyclopedia"
+                    className="rounded-2xl bg-amber-500 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/30 transition active:scale-95"
+                  >
+                    図鑑を見る
+                  </Link>
+                  <button
+                    onClick={() => {
+                      setUnlockedItem(null);
+                      setIsScanning(true);
+                    }}
+                    className="rounded-2xl bg-white/10 py-4 text-sm font-bold text-white transition active:scale-95"
+                  >
+                    続けてスキャン
+                  </button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function ScanPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-slate-900" />}>
+      <ScanPageContent />
+    </Suspense>
+  );
+}

--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -25,6 +25,7 @@ import { grandmaEvents } from "./data/grandmaEvents";
 import { recordMarketEnter, recordMarketExit } from "../../../lib/storage/marketStats";
 import { buildSearchIndex } from "../search/lib/searchIndex";
 import { useShopSearch } from "../search/hooks/useShopSearch";
+import { useEncyclopediaUnlock } from "../../../lib/hooks/useEncyclopediaUnlock";
 import { getOrCreateConsultVisitorKey } from "../../../lib/consultVisitorKey";
 import MapCharacterConsult from "./components/MapCharacterConsult";
 
@@ -83,6 +84,8 @@ export default function MapPageClient({
     lng: number;
   } | null>(null);
 
+  useEncyclopediaUnlock(userLocation);
+
   const [isInMarket, setIsInMarket] = useState<boolean | null>(null);
   useEffect(() => {
     if (isInMarket === true) recordMarketEnter();
@@ -123,7 +126,9 @@ export default function MapPageClient({
     ids: number[];
     label: string;
   } | null>(null);
-  const [mapSearchQuery, setMapSearchQuery] = useState('');
+  const [mapSearchQuery, setMapSearchQuery] = useState(
+    () => searchParams?.get("q") ?? '',
+  );
   const [mapSearchCategory, setMapSearchCategory] = useState<string | null>(null);
   const mapSearchIndex = useMemo(() => buildSearchIndex(shops), [shops]);
   const mapSearchResults = useShopSearch({

--- a/lib/hooks/useEncyclopediaUnlock.ts
+++ b/lib/hooks/useEncyclopediaUnlock.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from 'react';
+import { ENCYCLOPEDIA_ITEMS } from '@/data/encyclopediaItems';
+import { unlockItem, getUnlockedItemIds } from '@/lib/storage/encyclopedia';
+import toast from 'react-hot-toast';
+
+export function useEncyclopediaUnlock(userLocation: { lat: number; lng: number } | null) {
+  const lastProcessedLocation = useRef<{ lat: number; lng: number } | null>(null);
+
+  useEffect(() => {
+    if (!userLocation) return;
+
+    // 前回の判定位置から一定距離（例: 10m）動いていない場合は判定をスキップ
+    if (lastProcessedLocation.current) {
+      const dist = calculateDistance(
+        userLocation.lat,
+        userLocation.lng,
+        lastProcessedLocation.current.lat,
+        lastProcessedLocation.current.lng
+      );
+      if (dist < 10) return;
+    }
+
+    lastProcessedLocation.current = userLocation;
+    const unlockedIds = getUnlockedItemIds();
+
+    ENCYCLOPEDIA_ITEMS.forEach((item) => {
+      // すでに解放済み、またはGPSトリガーでない場合はスキップ
+      if (unlockedIds.includes(item.id)) return;
+      if (item.trigger.type !== 'gps' && item.trigger.type !== 'both') return;
+      if (!item.trigger.lat || !item.trigger.lng) return;
+
+      const distance = calculateDistance(
+        userLocation.lat,
+        userLocation.lng,
+        item.trigger.lat,
+        item.trigger.lng
+      );
+
+      if (distance <= (item.trigger.radius || 100)) {
+        const isNew = unlockItem(item.id);
+        if (isNew) {
+          toast.success(`新発見！「${item.name}」を図鑑に登録しました`, {
+            icon: item.emoji,
+            duration: 5000,
+          });
+        }
+      }
+    });
+  }, [userLocation]);
+}
+
+/**
+ * 2点間の距離を計算（メートル）
+ */
+function calculateDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371e3; // 地球の半径 (m)
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lng2 - lng1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,16 @@ const nextConfig = {
           },
         ],
       },
+      {
+        // 図鑑のQRスキャン・記念撮影ページ: カメラを許可
+        source: '/encyclopedia/:path*',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(self)',
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
## 概要
図鑑の付随機能を追加します。PR #295 分割の3本目（最後）。

## 変更内容（6ファイル）
- QRスキャン/GPSによるアイテム解放（scanページ・useEncyclopediaUnlock）
- 記念撮影カメラページ（NotReadableError 対策込み）
- 図鑑からマップ検索バーへ連携（/map?q= で検索実行）
- /encyclopedia 配下にカメラ権限を付与（Permissions-Policy）

## マージ順序
#330（図鑑基礎）の上にスタックしています。マージ順序: #329 → #330 → 本PR。先行PRのマージに伴い base は自動で付け替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)