### PR TITLE
feat: 2本指ピンチズームを有効化する

### DIFF
--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -240,15 +240,18 @@ export function useMapGestures({
     const distanceDelta = distance - gesture.startDistance;
 
     if (gesture.mode === "pending") {
-      if (
-        Math.abs(deltaDeg) < TOUCH_ROTATION_ANGLE_THRESHOLD_DEG &&
-        Math.abs(distanceDelta) < TOUCH_ROTATION_DISTANCE_THRESHOLD_PX
-      ) {
+      const angleExceeded = Math.abs(deltaDeg) >= TOUCH_ROTATION_ANGLE_THRESHOLD_DEG;
+      const distanceExceeded = Math.abs(distanceDelta) >= TOUCH_ROTATION_DISTANCE_THRESHOLD_PX;
+      if (!angleExceeded && !distanceExceeded) {
         return;
       }
 
-      // ピンチズームは無効 — 2本指操作は常に回転として扱う
-      gesture.mode = "rotate";
+      // 回転（角度変化）とズーム（距離変化）のどちらの意図が強いかを、
+      // 各閾値に対する進捗度の大小で判定し、一方のモードにロックする。
+      // 同時に発生したときの誤判定（例: ピンチ中にわずかに回ってしまう）を防ぐ。
+      const angleProgress = Math.abs(deltaDeg) / TOUCH_ROTATION_ANGLE_THRESHOLD_DEG;
+      const distanceProgress = Math.abs(distanceDelta) / TOUCH_ROTATION_DISTANCE_THRESHOLD_PX;
+      gesture.mode = distanceProgress > angleProgress ? "zoom" : "rotate";
 
       debugLog("touch:mode", {
         mode: gesture.mode,


### PR DESCRIPTION
## 概要
マップページで無効化されていた **2本指ピンチズーム** を有効化します。

[Discussion #297](https://github.com/KochiDXClub/nicchyo/discussions/297) のズームスライダー改善（「2本指操作時のみスライダーを表示」）を進めるための前提となるPRです。スライダーの表示制御は別PRで対応します。

## 背景
- 現状、`useMapGestures` は2本指操作を **常に回転** として扱っており、ピンチズームは「回転操作との不具合」を理由に無効化されていました。
- そのため **スマホでズームする手段は右下のスライダーのみ** という状態でした。

## 変更内容
- `pending` モードの判定を見直し、**角度変化（回転）と距離変化（ズーム）の各閾値に対する進捗度** を比較して、回転 / ズームのいずれか一方にモードをロックするようにしました。
- 既存のズーム処理（`scheduleZoom` → `setZoomAround`）はそのまま流用しており、変更は判定ロジック1箇所のみ（+9 / −6行）です。

## 確認事項 / レビュー観点
- 実機（スマホ）で、2本指の **ピンチ＝ズーム** / **ひねり＝回転** が意図どおり切り替わるか
- 過去に問題となった「回転中に意図せずズームしてしまう（逆も同様）」挙動が再発しないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)