### PR TITLE
refactor: TOUCH_ROTATION_DISTANCE_THRESHOLD_PX を TOUCH_PINCH_DISTANCE_THRESHOLD_PX にリネーム

### DIFF
--- a/app/(public)/map-edit/MapLayoutEditor.tsx
+++ b/app/(public)/map-edit/MapLayoutEditor.tsx
@@ -65,7 +65,7 @@ function ClickCapture({ onClick }: { onClick: (lat: number, lng: number) => void
 }
 
 const TOUCH_ROTATION_ANGLE_THRESHOLD_DEG = 4;
-const TOUCH_ROTATION_DISTANCE_THRESHOLD_PX = 8;
+const TOUCH_PINCH_DISTANCE_THRESHOLD_PX = 8;
 const PAN_START_THRESHOLD_PX = 3;
 
 function getTouchDistance(
@@ -345,7 +345,7 @@ export default function MapLayoutEditor({
       if (!touchRotateRef.current.isRotating) {
         if (
           Math.abs(deltaDeg) < TOUCH_ROTATION_ANGLE_THRESHOLD_DEG &&
-          Math.abs(distanceDelta) < TOUCH_ROTATION_DISTANCE_THRESHOLD_PX
+          Math.abs(distanceDelta) < TOUCH_PINCH_DISTANCE_THRESHOLD_PX
         ) {
           return;
         }

--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -5,7 +5,7 @@ import type { MouseEvent as ReactMouseEvent, MutableRefObject } from "react";
 import L from "leaflet";
 
 const TOUCH_ROTATION_ANGLE_THRESHOLD_DEG = 4;
-const TOUCH_ROTATION_DISTANCE_THRESHOLD_PX = 8;
+const TOUCH_PINCH_DISTANCE_THRESHOLD_PX = 8;
 const POINTER_PAN_START_THRESHOLD_PX = 3;
 const DEBUG_STORAGE_KEY = "nicchyo-map-gesture-debug";
 
@@ -241,7 +241,7 @@ export function useMapGestures({
 
     if (gesture.mode === "pending") {
       const angleExceeded = Math.abs(deltaDeg) >= TOUCH_ROTATION_ANGLE_THRESHOLD_DEG;
-      const distanceExceeded = Math.abs(distanceDelta) >= TOUCH_ROTATION_DISTANCE_THRESHOLD_PX;
+      const distanceExceeded = Math.abs(distanceDelta) >= TOUCH_PINCH_DISTANCE_THRESHOLD_PX;
       if (!angleExceeded && !distanceExceeded) {
         return;
       }
@@ -250,7 +250,7 @@ export function useMapGestures({
       // 各閾値に対する進捗度の大小で判定し、一方のモードにロックする。
       // 同時に発生したときの誤判定（例: ピンチ中にわずかに回ってしまう）を防ぐ。
       const angleProgress = Math.abs(deltaDeg) / TOUCH_ROTATION_ANGLE_THRESHOLD_DEG;
-      const distanceProgress = Math.abs(distanceDelta) / TOUCH_ROTATION_DISTANCE_THRESHOLD_PX;
+      const distanceProgress = Math.abs(distanceDelta) / TOUCH_PINCH_DISTANCE_THRESHOLD_PX;
       gesture.mode = distanceProgress > angleProgress ? "zoom" : "rotate";
 
       debugLog("touch:mode", {


### PR DESCRIPTION
## 概要

Issue #336 の対応。PR #333 のレビュー指摘（#pullrequestreview-4512564019）を受けて、変数名を実態に合わせてリネームする。

## 変更内容（2ファイル）

- `app/(public)/map/hooks/useMapGestures.ts`
- `app/(public)/map-edit/MapLayoutEditor.tsx`

`TOUCH_ROTATION_DISTANCE_THRESHOLD_PX` → `TOUCH_PINCH_DISTANCE_THRESHOLD_PX`

## 変更理由

この変数はズームと回転の両方のジェスチャー判定に使われる「2本指間の距離変化の閾値」だが、元の名前は「回転距離の閾値」しか示しておらず意図が伝わりにくかった。`PINCH` という語で2本指操作全般の距離閾値であることを明示する。

closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)