### PR TITLE
feat(map): ジェスチャーガイドトーストをナビバー直上へ移動・外観改善

### DIFF
--- a/app/(public)/map/components/ChomeAreaMarkers.tsx
+++ b/app/(public)/map/components/ChomeAreaMarkers.tsx
@@ -8,7 +8,7 @@
  * クリックすると該当丁目へ flyTo（DETAIL モード相当の zoom 20）。
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useMap } from 'react-leaflet';
 import L from 'leaflet';
 import type { Shop } from '../data/shops';
@@ -101,13 +101,15 @@ function createChomeBadgeIcon(chome: string, count: number): L.DivIcon {
 // ── コンポーネント ─────────────────────────────────────
 type Props = {
   shops: Shop[];
+  onChomeClick?: (chome: string) => void;
 };
 
-export default function ChomeAreaMarkers({ shops }: Props) {
+export default function ChomeAreaMarkers({ shops, onChomeClick }: Props) {
   const map = useMap();
   const layerRef = useRef<L.LayerGroup | null>(null);
-  const [toastLabel, setToastLabel] = useState<string | null>(null);
-  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onChomeClickRef = useRef(onChomeClick);
+
+  useEffect(() => { onChomeClickRef.current = onChomeClick; }, [onChomeClick]);
 
   const centroids = useMemo(() => computeChomeCentroids(shops), [shops]);
 
@@ -125,9 +127,7 @@ export default function ChomeAreaMarkers({ shops }: Props) {
           duration: 0.9,
           easeLinearity: 0.25,
         });
-        if (toastTimer.current) clearTimeout(toastTimer.current);
-        setToastLabel(chome);
-        toastTimer.current = setTimeout(() => setToastLabel(null), 2500);
+        onChomeClickRef.current?.(chome);
       });
 
       group.addLayer(marker);
@@ -141,14 +141,5 @@ export default function ChomeAreaMarkers({ shops }: Props) {
     };
   }, [map, centroids]);
 
-  if (!toastLabel) return null;
-
-  return (
-    <div className="fixed bottom-24 left-1/2 z-[2500] -translate-x-1/2 pointer-events-none animate-in fade-in slide-in-from-bottom-2 duration-200">
-      <div className="flex items-center gap-2 rounded-2xl bg-slate-900/88 px-4 py-2.5 shadow-xl backdrop-blur-sm">
-        <span className="text-base">🗺️</span>
-        <span className="text-sm font-semibold text-white">{toastLabel}のお店を表示します</span>
-      </div>
-    </div>
-  );
+  return null;
 }

--- a/app/(public)/map/components/MapOverlays.tsx
+++ b/app/(public)/map/components/MapOverlays.tsx
@@ -45,6 +45,7 @@ export const MapOverlays = memo(function MapOverlays({
   shopsWithIngredients,
   recipeIngredients,
   onRecipeShopClick,
+  onChomeClick,
   OptimizedShopLayerWithClustering,
 }: {
   isLowZoomTintMode: boolean;
@@ -75,6 +76,7 @@ export const MapOverlays = memo(function MapOverlays({
   shopsWithIngredients: Shop[];
   recipeIngredients: Array<{ name: string; icon: string }>;
   onRecipeShopClick: (shop: Shop) => void;
+  onChomeClick?: (chome: string) => void;
   OptimizedShopLayerWithClustering: ComponentType<OptimizedShopLayerWithClusteringProps>;
 }) {
   const map = useMap();
@@ -172,7 +174,7 @@ export const MapOverlays = memo(function MapOverlays({
 
       {/* 縮小時（zoom < 17）: 丁目エリアバッジ */}
       {!isMinimumZoomMode && isOverviewZoneMode && (
-        <ChomeAreaMarkers shops={shops} />
+        <ChomeAreaMarkers shops={shops} onChomeClick={onChomeClick} />
       )}
 
       {/* 通常時（zoom ≥ 19）: 個別店舗マーカー */}

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -487,13 +487,13 @@ function MapControls({
 function MapZoomGuideToast({ message }: { message: string | null }) {
   return (
     <div
-      className={`pointer-events-none absolute bottom-3 left-1/2 z-[1400] w-[min(calc(100vw-2rem),24rem)] -translate-x-1/2 transition-all duration-200 ${
+      className={`pointer-events-none absolute bottom-3 left-1/2 z-[1400] w-auto max-w-[min(calc(100vw-4rem),15rem)] -translate-x-1/2 transition-all duration-200 ${
         message ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"
       }`}
       aria-live="polite"
       aria-atomic="true"
     >
-      <div className="rounded-full bg-slate-900/88 px-4 py-2 text-center text-sm font-medium text-white shadow-lg backdrop-blur">
+      <div className="rounded-full bg-sky-100/95 px-3 py-1.5 text-center text-sm font-semibold text-sky-900 shadow-md backdrop-blur whitespace-nowrap">
         {message ?? ""}
       </div>
     </div>
@@ -1375,6 +1375,7 @@ const MapView = memo(function MapView({
             shopsWithIngredients={shopsWithIngredients}
             recipeIngredients={recipeIngredients}
             onRecipeShopClick={setSelectedShop}
+            onChomeClick={(chome) => showMapToast(`${chome}を拡大しました`, 2500)}
             OptimizedShopLayerWithClustering={OptimizedShopLayerWithClustering}
           />
 

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -487,13 +487,13 @@ function MapControls({
 function MapZoomGuideToast({ message }: { message: string | null }) {
   return (
     <div
-      className={`pointer-events-none absolute bottom-3 left-1/2 z-[1400] w-auto max-w-[min(calc(100vw-4rem),15rem)] -translate-x-1/2 transition-all duration-200 ${
+      className={`pointer-events-none absolute bottom-3 left-1/2 z-[1400] w-auto max-w-[min(calc(100vw-4rem),20rem)] -translate-x-1/2 transition-all duration-200 ${
         message ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"
       }`}
       aria-live="polite"
       aria-atomic="true"
     >
-      <div className="rounded-full bg-sky-100/95 px-3 py-1.5 text-center text-sm font-semibold text-sky-900 shadow-md backdrop-blur whitespace-nowrap">
+      <div className="rounded-2xl bg-sky-100/95 px-3 py-1.5 text-center text-sm font-semibold leading-snug text-sky-900 shadow-md backdrop-blur">
         {message ?? ""}
       </div>
     </div>
@@ -745,6 +745,7 @@ const MapView = memo(function MapView({
   const [mapUiZoom, setMapUiZoom] = useState(INITIAL_ZOOM);
   const [zoomGuideMessage, setZoomGuideMessage] = useState<string | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeGestureModeRef = useRef<"zoom" | "rotate" | null>(null);
   const showMapToast = useCallback((message: string, durationMs = 1500) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setZoomGuideMessage(message);
@@ -753,6 +754,17 @@ const MapView = memo(function MapView({
       toastTimerRef.current = null;
     }, durationMs);
   }, []);
+  const hideMapToast = useCallback(() => {
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+    setZoomGuideMessage(null);
+  }, []);
+  const handleChomeClick = useCallback(
+    (chome: string) => showMapToast(`${chome}を拡大しました`, 2500),
+    [showMapToast]
+  );
   const [mapShellSize, setMapShellSize] = useState(() => {
     if (typeof window === "undefined") return 1600;
     // visualViewport はブラウザUIを除いた実際の表示領域サイズ（iOS Safari 対応）
@@ -1213,8 +1225,16 @@ const MapView = memo(function MapView({
       markManualRotation();
       setAutoRotation(rotation);
     },
-    onGestureEnd: () => {},
+    onGestureEnd: () => {
+      // ズームはonPinchZoomEndが直後に「拡大/縮小しました」で上書きするため、
+      // 回転ジェスチャー終了時だけ明示的にトーストを消す
+      if (activeGestureModeRef.current === "rotate") {
+        hideMapToast();
+      }
+      activeGestureModeRef.current = null;
+    },
     onGestureMode: (mode) => {
+      activeGestureModeRef.current = mode;
       showMapToast(mode === "zoom" ? "ズーム中" : "回転中", 3000);
     },
     onFirstPan: () => {
@@ -1375,7 +1395,7 @@ const MapView = memo(function MapView({
             shopsWithIngredients={shopsWithIngredients}
             recipeIngredients={recipeIngredients}
             onRecipeShopClick={setSelectedShop}
-            onChomeClick={(chome) => showMapToast(`${chome}を拡大しました`, 2500)}
+            onChomeClick={handleChomeClick}
             OptimizedShopLayerWithClustering={OptimizedShopLayerWithClustering}
           />
 

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -746,6 +746,7 @@ const MapView = memo(function MapView({
   const [zoomGuideMessage, setZoomGuideMessage] = useState<string | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeGestureModeRef = useRef<"zoom" | "rotate" | null>(null);
+  const pinchZoomEndFiredRef = useRef(false);
   const showMapToast = useCallback((message: string, durationMs = 1500) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setZoomGuideMessage(message);
@@ -1226,21 +1227,25 @@ const MapView = memo(function MapView({
       setAutoRotation(rotation);
     },
     onGestureEnd: () => {
-      // ズームはonPinchZoomEndが直後に「拡大/縮小しました」で上書きするため、
-      // 回転ジェスチャー終了時だけ明示的にトーストを消す
-      if (activeGestureModeRef.current === "rotate") {
+      // ズームはonPinchZoomEndが直後に「拡大/縮小しました」で上書きするため基本は消さないが、
+      // しきい値未満でonPinchZoomEndが呼ばれなかった場合は「ズーム中」が残るので明示的に消す
+      const mode = activeGestureModeRef.current;
+      if (mode === "rotate" || (mode === "zoom" && !pinchZoomEndFiredRef.current)) {
         hideMapToast();
       }
       activeGestureModeRef.current = null;
+      pinchZoomEndFiredRef.current = false;
     },
     onGestureMode: (mode) => {
       activeGestureModeRef.current = mode;
+      pinchZoomEndFiredRef.current = false;
       showMapToast(mode === "zoom" ? "ズーム中" : "回転中", 3000);
     },
     onFirstPan: () => {
       showMapToast("地図を移動中", 1200);
     },
     onPinchZoomEnd: (direction) => {
+      pinchZoomEndFiredRef.current = true;
       showMapToast(direction === "in" ? "拡大しました" : "縮小しました", 1500);
     },
   });

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -487,8 +487,8 @@ function MapControls({
 function MapZoomGuideToast({ message }: { message: string | null }) {
   return (
     <div
-      className={`pointer-events-none absolute left-1/2 top-20 z-[1400] w-[min(calc(100vw-2rem),24rem)] -translate-x-1/2 transition-all duration-200 ${
-        message ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0"
+      className={`pointer-events-none absolute bottom-3 left-1/2 z-[1400] w-[min(calc(100vw-2rem),24rem)] -translate-x-1/2 transition-all duration-200 ${
+        message ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"
       }`}
       aria-live="polite"
       aria-atomic="true"
@@ -744,6 +744,15 @@ const MapView = memo(function MapView({
   const [autoRotation, setAutoRotation] = useState(initialMapRotation);
   const [mapUiZoom, setMapUiZoom] = useState(INITIAL_ZOOM);
   const [zoomGuideMessage, setZoomGuideMessage] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showMapToast = useCallback((message: string, durationMs = 1500) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setZoomGuideMessage(message);
+    toastTimerRef.current = setTimeout(() => {
+      setZoomGuideMessage(null);
+      toastTimerRef.current = null;
+    }, durationMs);
+  }, []);
   const [mapShellSize, setMapShellSize] = useState(() => {
     if (typeof window === "undefined") return 1600;
     // visualViewport はブラウザUIを除いた実際の表示領域サイズ（iOS Safari 対応）
@@ -758,7 +767,6 @@ const MapView = memo(function MapView({
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
   const mapRef = useRef<L.Map | null>(null);
   const isTouchGestureActiveRef = useRef(false);
-  const zoomGuideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // 【削除】visibleShops の計算を削除
@@ -798,8 +806,8 @@ const MapView = memo(function MapView({
 
   useEffect(() => {
     return () => {
-      if (zoomGuideTimerRef.current) {
-        clearTimeout(zoomGuideTimerRef.current);
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
       }
     };
   }, []);
@@ -1014,25 +1022,18 @@ const MapView = memo(function MapView({
       if (viewMode.mode === ViewMode.OVERVIEW) {
         // OVERVIEW → INTERMEDIATE（エリア探索）へ
         targetZoom = 18.0;
-        setZoomGuideMessage("このエリアを拡大しました");
+        showMapToast("このエリアを拡大しました", 1800);
       } else {
         // INTERMEDIATE → DETAIL（詳細閲覧）へ
         targetZoom = 18.5;
-        setZoomGuideMessage("もう一度タップするとお店の詳細を見られます");
+        showMapToast("もう一度タップするとお店の詳細を見られます", 1800);
       }
-
-      if (zoomGuideTimerRef.current) {
-        clearTimeout(zoomGuideTimerRef.current);
-      }
-      zoomGuideTimerRef.current = setTimeout(() => {
-        setZoomGuideMessage(null);
-      }, 1800);
 
       mapRef.current.flyTo([centerLat, centerLng], targetZoom, {
         duration: 0.75,
       });
     }
-  }, [onShopSelect, selectedShop, shopBannerMainSurface, shops]);
+  }, [onShopSelect, selectedShop, shopBannerMainSurface, shops, showMapToast]);
 
   const handleOpenShop = useCallback((shopId: number) => {
     const target = shops.find((s) => s.id === shopId);
@@ -1213,6 +1214,15 @@ const MapView = memo(function MapView({
       setAutoRotation(rotation);
     },
     onGestureEnd: () => {},
+    onGestureMode: (mode) => {
+      showMapToast(mode === "zoom" ? "ズーム中" : "回転中", 3000);
+    },
+    onFirstPan: () => {
+      showMapToast("地図を移動中", 1200);
+    },
+    onPinchZoomEnd: (direction) => {
+      showMapToast(direction === "in" ? "拡大しました" : "縮小しました", 1500);
+    },
   });
 
   useEffect(() => {

--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -351,7 +351,7 @@ export function useMapGestures({
       onGestureEndRef.current();
     }
     setIsTouchGestureActive(false);
-  }, [debugLog, flushPendingZoom]);
+  }, [debugLog, flushPendingZoom, mapRef]);
 
   const handleMouseDownCapture = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
     if (interactionDisabledRef.current || isTouchGestureActiveRef.current || e.button !== 0) return;

--- a/app/(public)/map/hooks/useMapGestures.ts
+++ b/app/(public)/map/hooks/useMapGestures.ts
@@ -70,6 +70,12 @@ type UseMapGesturesArgs = {
   onPanStart: () => void;
   onRotationChange: (rotation: number) => void;
   onGestureEnd: () => void;
+  /** ピンチのモード（ズーム/回転）が確定したタイミングで呼ばれる */
+  onGestureMode?: (mode: "zoom" | "rotate") => void;
+  /** 1本指/マウスで地図を初めて動かし始めたタイミングで呼ばれる */
+  onFirstPan?: () => void;
+  /** ピンチズームが終了したタイミングで方向を通知する */
+  onPinchZoomEnd?: (direction: "in" | "out") => void;
 };
 
 export function useMapGestures({
@@ -80,6 +86,9 @@ export function useMapGestures({
   onPanStart,
   onRotationChange,
   onGestureEnd,
+  onGestureMode,
+  onFirstPan,
+  onPinchZoomEnd,
 }: UseMapGesturesArgs) {
   const [isTouchGestureActive, setIsTouchGestureActive] = useState(false);
   const [gestureTarget, setGestureTarget] = useState<HTMLDivElement | null>(null);
@@ -93,6 +102,9 @@ export function useMapGestures({
   const onPanStartRef = useRef(onPanStart);
   const onRotationChangeRef = useRef(onRotationChange);
   const onGestureEndRef = useRef(onGestureEnd);
+  const onGestureModeRef = useRef(onGestureMode);
+  const onFirstPanRef = useRef(onFirstPan);
+  const onPinchZoomEndRef = useRef(onPinchZoomEnd);
   const touchPanRef = useRef<PointerPanState | null>(null);
   const mousePanRef = useRef<PointerPanState | null>(null);
   const touchGestureRef = useRef<TouchGestureState | null>(null);
@@ -127,6 +139,10 @@ export function useMapGestures({
   useEffect(() => {
     onGestureEndRef.current = onGestureEnd;
   }, [onGestureEnd]);
+
+  useEffect(() => { onGestureModeRef.current = onGestureMode; }, [onGestureMode]);
+  useEffect(() => { onFirstPanRef.current = onFirstPan; }, [onFirstPan]);
+  useEffect(() => { onPinchZoomEndRef.current = onPinchZoomEnd; }, [onPinchZoomEnd]);
 
   const debugLog = useCallback((event: string, data?: Record<string, unknown>) => {
     if (!debugEnabledRef.current) return;
@@ -214,9 +230,11 @@ export function useMapGestures({
       if (!touchPanRef.current.hasMoved && Math.hypot(dx, dy) < POINTER_PAN_START_THRESHOLD_PX) {
         return;
       }
+      const isFirstTouchPan = !touchPanRef.current.hasMoved;
       touchPanRef.current.hasMoved = true;
       touchPanRef.current.lastX = touch.clientX;
       touchPanRef.current.lastY = touch.clientY;
+      if (isFirstTouchPan) onFirstPanRef.current?.();
       onPanStartRef.current();
       if (e.cancelable) {
         e.preventDefault();
@@ -252,6 +270,7 @@ export function useMapGestures({
       const angleProgress = Math.abs(deltaDeg) / TOUCH_ROTATION_ANGLE_THRESHOLD_DEG;
       const distanceProgress = Math.abs(distanceDelta) / TOUCH_PINCH_DISTANCE_THRESHOLD_PX;
       gesture.mode = distanceProgress > angleProgress ? "zoom" : "rotate";
+      onGestureModeRef.current?.(gesture.mode);
 
       debugLog("touch:mode", {
         mode: gesture.mode,
@@ -323,6 +342,12 @@ export function useMapGestures({
     }
     if (isTouchGestureActiveRef.current) {
       debugLog("touch:end", { mode: activeGesture?.mode ?? "unknown" });
+      if (activeGesture?.mode === "zoom" && mapRef.current) {
+        const delta = mapRef.current.getZoom() - activeGesture.startZoom;
+        if (Math.abs(delta) > 0.15) {
+          onPinchZoomEndRef.current?.(delta > 0 ? "in" : "out");
+        }
+      }
       onGestureEndRef.current();
     }
     setIsTouchGestureActive(false);
@@ -375,9 +400,11 @@ export function useMapGestures({
         return;
       }
 
+      const isFirstMousePan = !mousePanRef.current.hasMoved;
       mousePanRef.current.hasMoved = true;
       mousePanRef.current.lastX = e.clientX;
       mousePanRef.current.lastY = e.clientY;
+      if (isFirstMousePan) onFirstPanRef.current?.();
       onPanStartRef.current();
       panMapByScreenDelta(dx, dy);
     };


### PR DESCRIPTION
## 概要

マップページのガイドトーストを改善します。

### 変更内容

**課題2: ジェスチャーモードが不透明 → トーストで明示**
- ピンチ操作でズーム/回転モードが確定した瞬間に「ズーム中」「回転中」を表示
- ピンチズーム終了後に「拡大しました」「縮小しました」を表示

**課題3: トースト位置が検索バーと被る → ナビバー直上に移動**
- `top-20`（画面上部）→ `bottom-3`（マップエリア最下部 = ナビバー直上）に変更
- アニメーションも下からスライドインに変更

**追加改善**
- 1本指ドラッグ開始時に「地図を移動中」を表示（専門用語「パン」を排除）
- 丁目バッジタップ時も統一トースト（「○丁目を拡大しました」）を表示
  - ChomeAreaMarkers 内の独自トーストを削除し showMapToast に統合
- トースト外観: 水色（bg-sky-100）・幅を絞る・whitespace-nowrap・text-sm

## 変更ファイル

- `app/(public)/map/hooks/useMapGestures.ts` — onGestureMode / onFirstPan / onPinchZoomEnd コールバック追加
- `app/(public)/map/components/MapView.tsx` — トースト位置・外観変更、showMapToast ヘルパー追加
- `app/(public)/map/components/ChomeAreaMarkers.tsx` — 内部トーストを onChomeClick に変換
- `app/(public)/map/components/MapOverlays.tsx` — onChomeClick prop 追加

## テスト計画

- [ ] ピンチ操作でズームすると「ズーム中」→「拡大しました」の順にナビバー直上に表示される
- [ ] 1本指ドラッグで「地図を移動中」が表示される
- [ ] 回転ジェスチャーで「回転中」が表示される
- [ ] 丁目バッジをタップすると「○丁目を拡大しました」が表示される
- [ ] 店舗タップ時の「このエリアを拡大しました」も同じ位置に出る
- [ ] 検索バー・ジャンルフィルターとトーストが被らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)