### PR TITLE
fix: ジャンルフィルター展開時の現在地追従ボタン重なりを解消

### DIFF
--- a/app/(public)/map/MapPageClient.tsx
+++ b/app/(public)/map/MapPageClient.tsx
@@ -177,6 +177,8 @@ export default function MapPageClient({
     }, 2000);
   }, []);
   const [isShopBannerOpen, setIsShopBannerOpen] = useState(false);
+  const searchAreaRef = useRef<HTMLDivElement | null>(null);
+  const [trackingButtonTop, setTrackingButtonTop] = useState(112);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -191,6 +193,17 @@ export default function MapPageClient({
     });
     return () => observer.disconnect();
   }, []);
+  useEffect(() => {
+    const el = searchAreaRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      const rect = el.getBoundingClientRect();
+      setTrackingButtonTop(rect.bottom + 8);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   const dragControls = useDragControls();
   const [mapCharacterConsultActive, setMapCharacterConsultActive] = useState(false);
   const [mapInstance, setMapInstance] = useState<LeafletMap | null>(null);
@@ -721,6 +734,7 @@ export default function MapPageClient({
             {/* 全幅検索バー + ジャンルフィルター（AI相談モード時は非表示） */}
             {!mapCharacterConsultActive && (
               <div
+                ref={searchAreaRef}
                 className="absolute left-3 right-3 top-3 z-[1001] flex flex-col gap-2"
                 onMouseDown={(e) => e.stopPropagation()}
                 onClick={(e) => e.stopPropagation()}
@@ -806,6 +820,7 @@ export default function MapPageClient({
               attendanceEstimates={attendanceEstimates}
               suppressInitialLocationFocus={isAiFocusMode}
               hideMapUI={mapCharacterConsultActive}
+              trackingButtonTop={trackingButtonTop}
               overlaySlot={
                 mapCharacterConsultActive ? (
                   <MapCharacterConsult

--- a/app/(public)/map/components/MapView.tsx
+++ b/app/(public)/map/components/MapView.tsx
@@ -421,6 +421,7 @@ function MapControls({
   maxZoom,
   zoomSliderVisible,
   onZoomSliderInteract,
+  trackingButtonTop = 112,
 }: {
   map: L.Map | null;
   isTracking: boolean;
@@ -432,6 +433,8 @@ function MapControls({
   zoomSliderVisible: boolean;
   /** スライダー操作時に表示を延命させるためのコールバック */
   onZoomSliderInteract: () => void;
+  /** 現在地ボタンの top 位置（px）。検索エリアの高さに追従させるために外から渡す */
+  trackingButtonTop?: number;
 }) {
   return (
     <>
@@ -455,9 +458,10 @@ function MapControls({
         <span className="select-none text-[12px] font-black leading-none text-amber-700 drop-shadow-[0_1px_0_rgba(255,255,255,0.9)]">−</span>
       </div>
 
-      {/* 現在地追跡ボタン（画面上部右） */}
+      {/* 現在地追跡ボタン（検索エリアの高さに追従） */}
       <div
-        className="absolute right-4 top-28 z-[1000]"
+        className="absolute right-4 z-[1000] transition-[top] duration-200"
+        style={{ top: trackingButtonTop }}
         onMouseDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}
         onTouchStart={(e) => { e.stopPropagation(); }}
@@ -540,6 +544,8 @@ type MapViewProps = {
   overlaySlot?: React.ReactNode;
   /** trueのとき拡大縮小スライダーと検索バーを非表示にする */
   hideMapUI?: boolean;
+  /** 現在地ボタンの top 位置（px）。検索エリアの実際の高さに合わせて親から渡す */
+  trackingButtonTop?: number;
 };
 
 export type ShopBannerOrigin = { x: number; y: number; width: number; height: number };
@@ -666,6 +672,7 @@ const MapView = memo(function MapView({
   onClearSearch,
   overlaySlot,
   hideMapUI = false,
+  trackingButtonTop,
 }: MapViewProps = {}) {
   const [isMobile, setIsMobile] = useState(false);
   const [_isInMarket, setIsInMarket] = useState<boolean | null>(null);
@@ -1406,6 +1413,7 @@ const MapView = memo(function MapView({
             maxZoom={MAX_ZOOM}
             zoomSliderVisible={zoomSliderVisible}
             onZoomSliderInteract={keepZoomSliderAlive}
+            trackingButtonTop={trackingButtonTop}
           />
         </>
       )}


### PR DESCRIPTION
## 概要

ジャンルフィルターが展開されたとき、現在地追従ボタン（右上）がフィルターチップと重なる問題を修正。

## 変更内容

- `MapPageClient.tsx`: 検索エリア div に `ref` を付け、`ResizeObserver` で高さを常時計測。高さが変わるたびに `trackingButtonTop` state を更新（`rect.bottom + 8px`）し、`MapView` へ prop として渡す
- `MapView.tsx`: `MapViewProps` と `MapControls` に `trackingButtonTop?: number` を追加。`MapControls` 内の追従ボタンを `top-28` 固定から `style={{ top: trackingButtonTop }}` の動的位置に変更し、`transition-[top] duration-200` でスムーズなアニメーションを付与

## テスト方法

1. マップページを開く
2. ジャンルフィルターの「＋」ボタンをタップしてフィルターを展開
3. 現在地追従ボタンがフィルターチップの下に滑らかに移動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)