### PR TITLE
feat: ズームモード遷移にフェードアニメーションを追加

### DIFF
--- a/app/(public)/map/components/ChomeAreaMarkers.tsx
+++ b/app/(public)/map/components/ChomeAreaMarkers.tsx
@@ -101,9 +101,10 @@ function createChomeBadgeIcon(chome: string, count: number): L.DivIcon {
 // ── コンポーネント ─────────────────────────────────────
 type Props = {
   shops: Shop[];
+  pane?: string;
 };
 
-export default function ChomeAreaMarkers({ shops }: Props) {
+export default function ChomeAreaMarkers({ shops, pane }: Props) {
   const map = useMap();
   const layerRef = useRef<L.LayerGroup | null>(null);
   const [toastLabel, setToastLabel] = useState<string | null>(null);
@@ -117,7 +118,7 @@ export default function ChomeAreaMarkers({ shops }: Props) {
 
     centroids.forEach(({ chome, lat, lng, count }) => {
       const icon = createChomeBadgeIcon(chome, count);
-      const marker = L.marker([lat, lng], { icon, interactive: true });
+      const marker = L.marker([lat, lng], { icon, interactive: true, pane });
 
       marker.on('click', () => {
         map.flyTo([lat, lng], map.getMaxZoom(), {

--- a/app/(public)/map/components/MapOverlays.tsx
+++ b/app/(public)/map/components/MapOverlays.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, memo, useCallback, useEffect, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
 import type { ComponentType } from "react";
 import type { OptimizedShopLayerWithClusteringProps } from "./OptimizedShopLayerWithClustering";
 import { CircleMarker, Marker, Pane, Popup, Rectangle, Tooltip, useMap } from "react-leaflet";
@@ -81,6 +81,70 @@ export const MapOverlays = memo(function MapOverlays({
   const handleRoadTap = useCallback((latlng: import("leaflet").LatLng) => {
     map.setView(latlng, 17);
   }, [map]);
+
+  // ── ズームモード遷移アニメーション ──────────────────────────────
+  const FADE_MS = 220;
+  const panesCreatedRef = useRef(false);
+
+  // 初回レンダー時に名前付きパネを同期的に作成（マーカー追加より前に確実に存在させるため）
+  if (!panesCreatedRef.current && map) {
+    if (!map.getPane('chome-overview-pane')) {
+      const p = map.createPane('chome-overview-pane');
+      // Leaflet の markerPane は z-index:600。同じレベルに合わせてタイル(200)の上に描画する
+      p.style.zIndex = '601';
+      p.style.transition = `opacity ${FADE_MS}ms ease`;
+    }
+    if (!map.getPane('shop-detail-pane')) {
+      const p = map.createPane('shop-detail-pane');
+      p.style.zIndex = '600';
+      p.style.transition = `opacity ${FADE_MS}ms ease`;
+    }
+    panesCreatedRef.current = true;
+  }
+
+  const shouldShowChome = !isMinimumZoomMode && isOverviewZoneMode;
+  const shouldShowShops = !isMinimumZoomMode && !isOverviewZoneMode && !isLowZoomTintMode;
+
+  const [chomeRendered, setChomeRendered] = useState(shouldShowChome);
+  const [chomeVisible, setChomeVisible] = useState(shouldShowChome);
+  const [shopsRendered, setShopsRendered] = useState(shouldShowShops);
+  const [shopsVisible, setShopsVisible] = useState(shouldShowShops);
+
+  useEffect(() => {
+    if (shouldShowChome) {
+      setChomeRendered(true);
+      const id = requestAnimationFrame(() => setChomeVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+    setChomeVisible(false);
+    const t = setTimeout(() => setChomeRendered(false), FADE_MS);
+    return () => clearTimeout(t);
+  }, [shouldShowChome]);
+
+  useEffect(() => {
+    if (shouldShowShops) {
+      setShopsRendered(true);
+      const id = requestAnimationFrame(() => setShopsVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+    setShopsVisible(false);
+    const t = setTimeout(() => setShopsRendered(false), FADE_MS);
+    return () => clearTimeout(t);
+  }, [shouldShowShops]);
+
+  useEffect(() => {
+    const pane = map.getPane('chome-overview-pane') as HTMLElement | undefined;
+    if (!pane) return;
+    pane.style.opacity = chomeVisible ? '1' : '0';
+    pane.style.pointerEvents = chomeVisible ? 'auto' : 'none';
+  }, [chomeVisible, map]);
+
+  useEffect(() => {
+    const pane = map.getPane('shop-detail-pane') as HTMLElement | undefined;
+    if (!pane) return;
+    pane.style.opacity = shopsVisible ? '1' : '0';
+    pane.style.pointerEvents = shopsVisible ? 'auto' : 'none';
+  }, [shopsVisible, map]);
 
   return (
     <>
@@ -170,13 +234,13 @@ export const MapOverlays = memo(function MapOverlays({
       </Pane>
       <Pane name="landmark-popup" style={{ zIndex: 10000 }} />
 
-      {/* 縮小時（zoom < 17）: 丁目エリアバッジ */}
-      {!isMinimumZoomMode && isOverviewZoneMode && (
-        <ChomeAreaMarkers shops={shops} />
+      {/* 縮小時（zoom 17-19）: 丁目エリアバッジ（フェード遷移） */}
+      {chomeRendered && (
+        <ChomeAreaMarkers shops={shops} pane="chome-overview-pane" />
       )}
 
-      {/* 通常時（zoom ≥ 19）: 個別店舗マーカー */}
-      {!isMinimumZoomMode && !isOverviewZoneMode && !isLowZoomTintMode && (
+      {/* 通常時（zoom ≥ 19）: 個別店舗マーカー（フェード遷移） */}
+      {shopsRendered && (
         <OptimizedShopLayerWithClustering
           shops={shops}
           onShopClick={onShopClick}
@@ -190,6 +254,7 @@ export const MapOverlays = memo(function MapOverlays({
           recipeIngredientIconsByShop={recipeIngredientIconsByShop}
           attendanceLabelsByShop={attendanceLabelsByShop}
           bagShopIds={bagShopIds}
+          pane="shop-detail-pane"
         />
       )}
 

--- a/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
+++ b/app/(public)/map/components/OptimizedShopLayerWithClustering.tsx
@@ -30,6 +30,7 @@ export interface OptimizedShopLayerWithClusteringProps {
   recipeIngredientIconsByShop?: Record<number, string[]>;
   attendanceLabelsByShop?: Record<number, string>;
   bagShopIds?: number[];
+  pane?: string;
 }
 
 const COMPACT_ICON_SIZE: [number, number] = [24, 36];
@@ -89,6 +90,7 @@ function OptimizedShopLayerWithClustering({
   recipeIngredientIconsByShop,
   attendanceLabelsByShop,
   bagShopIds,
+  pane,
 }: OptimizedShopLayerWithClusteringProps) {
   const map = useMap();
   const clusterGroupRef = useRef<L.MarkerClusterGroup | null>(null);
@@ -269,6 +271,7 @@ function OptimizedShopLayerWithClustering({
       chunkedLoading: true,
       chunkInterval: 200,
       chunkDelay: 50,
+      clusterPane: pane,
       iconCreateFunction: (_cluster) => {
         return L.divIcon({
           html: `<div class="cluster-icon cluster-small"></div>`,
@@ -376,6 +379,7 @@ function OptimizedShopLayerWithClustering({
 
       const marker = L.marker([shop.lat, shop.lng], {
         icon: initialIcon,
+        pane,
       });
 
       marker.on('click', () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -166,6 +166,12 @@ body.grandma-chat-open .leaflet-container {
   border: none !important;
 }
 
+@keyframes chome-badge-enter {
+  0%   { opacity: 0; transform: scale(0.7) translateY(8px); }
+  65%  { transform: scale(1.06) translateY(-2px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+
 .chome-area-badge {
   display: flex;
   flex-direction: column;
@@ -183,6 +189,7 @@ body.grandma-chat-open .leaflet-container {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   rotate: var(--map-rotation-inverse, 0deg);
   user-select: none;
+  animation: chome-badge-enter 0.28s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .chome-area-badge:hover {
@@ -270,10 +277,16 @@ body.grandma-chat-open .leaflet-container {
 
 /* ===== 店�Eマ�Eカー ===== */
 
+@keyframes shop-marker-enter {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 /* 店�Eマ�EカーのコンチE�� */
 .custom-shop-marker {
   background: transparent !important;
   border: none !important;
+  animation: shop-marker-enter 0.18s ease-out;
 }
 
 /* 選択された店�Eマ�Eカー */


### PR DESCRIPTION
## 概要

ズーム操作で OVERVIEW（丁目バッジ）⇔ DETAIL（店舗マーカー）が切り替わる際のモード遷移をアニメーション化した。

## 変更内容

### アニメーション方式

- Leaflet の **名前付き Pane** を2つ作成（`chome-overview-pane` / `shop-detail-pane`）
- React 側で表示/非表示を管理し、Pane DOM の `opacity` を CSS transition（220ms ease）で制御
- **遅延アンマウント**: フェードアウト完了後（220ms 後）に React コンポーネントを unmount することで exit animation を実現

### enter animation（CSS keyframes）

- `.chome-area-badge`: scale(0.7)+translateY(8px) → scale(1) の跳ね返り付きスケールアップ（0.28s）
- `.custom-shop-marker`: opacity 0 → 1 のフェードイン（0.18s）

### 技術的なポイント

- Pane の z-index は Leaflet の `markerPane`（600）に合わせて設定。200 にするとタイル層と同じ高さになりマーカーがタイルの下に隠れるため注意
- `L.marker()` に `pane` オプションを渡すことで、各マーカーを指定 Pane に配置
- `L.markerClusterGroup()` には `clusterPane` オプションでクラスターアイコンの Pane を指定

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/globals.css` | `@keyframes chome-badge-enter` / `shop-marker-enter` を追加 |
| `app/(public)/map/components/MapOverlays.tsx` | Pane 作成・遅延マウント状態管理・opacity 制御 |
| `app/(public)/map/components/ChomeAreaMarkers.tsx` | `pane?: string` prop を追加し `L.marker()` に渡す |
| `app/(public)/map/components/OptimizedShopLayerWithClustering.tsx` | `pane?: string` prop を追加し `L.markerClusterGroup()` / `L.marker()` に渡す |

## テスト

- [ ] ズームイン（zoom 17→19→21）でお店マーカーがフェードインして表示される
- [ ] ズームアウト（zoom 21→19→17）で丁目バッジがフェードインして表示される
- [ ] お店マーカーのクリック・選択が正常に動作する
- [ ] 丁目バッジのクリックで flyTo が動作する
- [ ] `npm run build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)