### PR TITLE
refactor: NavigationBarのメニュー状態をMenuContextに統合

### DIFF
--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState, useEffect, useCallback, Suspense } from "react";
+import { useEffect, useCallback, Suspense } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useBag } from "@/lib/storage/BagContext";
+import { useMenu } from "@/lib/ui/MenuContext";
 
 // ─── ナビゲーション項目 ────────────────────────────────────────────────────────
 type NavItem = {
@@ -64,7 +65,7 @@ function NavigationBarInner({
   const searchParams = useSearchParams();
   const { user, isLoggedIn, permissions, logout } = useAuth();
   const { items: bagItems } = useBag();
-  const [menuOpen, setMenuOpen] = useState(false);
+  const { isMenuOpen: menuOpen, toggleMenu, closeMenu } = useMenu();
 
   useEffect(() => {
     onMenuOpenChange?.(menuOpen);
@@ -84,7 +85,7 @@ function NavigationBarInner({
     : baseNavItems;
 
   const handleMenuItemClick = (href: string) => {
-    setMenuOpen(false);
+    closeMenu();
     router.push(href);
   };
 
@@ -94,7 +95,7 @@ function NavigationBarInner({
   }, [isPanelOpen, onCloseMode, router]);
 
   const handleLogout = async () => {
-    setMenuOpen(false);
+    closeMenu();
     await logout();
     router.push("/map");
   };
@@ -123,7 +124,7 @@ function NavigationBarInner({
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
               className="fixed inset-0 z-[9995] bg-black/40 backdrop-blur-sm"
-              onClick={() => setMenuOpen(false)}
+              onClick={closeMenu}
             />
 
             {/* シート本体 */}
@@ -358,7 +359,7 @@ function NavigationBarInner({
             <div className="flex flex-1 items-center justify-center">
               <button
                 type="button"
-                onClick={() => setMenuOpen((v) => !v)}
+                onClick={toggleMenu}
                 className="flex flex-col items-center gap-1 transition-all duration-200 active:scale-95"
               >
                 <motion.div


### PR DESCRIPTION
## 概要

`NavigationBar` が独自の `useState` でメニュー開閉を管理していたのを、`MenuContext` に統合します。

## 背景

`lib/ui/MenuContext.tsx` にメニュー開閉用のContextが実装済みで、`app/layout.tsx` で `MenuProvider` としてラップされていました。しかし `NavigationBar` はそれを使わず、ローカルな `useState` で同じ状態を独自管理していました。これにより MenuContext が死んだコードになっていました。

## 変更内容

- `NavigationBar` に `useMenu()` を接続
  - `const [menuOpen, setMenuOpen] = useState(false)` → `const { isMenuOpen: menuOpen, toggleMenu, closeMenu } = useMenu()`
- `setMenuOpen(false)` → `closeMenu()` に置換（メニュー項目クリック時・ログアウト時・バックドロップタップ時）
- `setMenuOpen((v) => !v)` → `toggleMenu()` に置換（メニューボタンクリック時）
- `useState` が不要になったためインポートから削除

## 効果

他のコンポーネントから `useMenu()` を通じてメニューの開閉状態を参照・操作できるようになります。

## テスト

- [ ] メニューボタンでシートが開閉すること
- [ ] メニュー項目タップでシートが閉じてページ遷移すること
- [ ] バックドロップタップでシートが閉じること
- [ ] ログアウトでシートが閉じること