### PR TITLE
fix: マップデータ取得失敗時のエラーをログ出力するよう修正

### DIFF
--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -75,7 +75,8 @@ export default async function MapPage() {
       landmarks = fetchedLandmarks;
       mapRoute = fetchedMapRoute;
       attendanceEstimates = mapData.attendanceEstimates;
-    } catch {
+    } catch (error) {
+      console.error("[MapPage] マップデータの取得に失敗しました:", error);
       shops = [];
       landmarks = [];
       mapRoute = getFallbackMapRoute();


### PR DESCRIPTION
## 概要

`/map` ページでDB取得に失敗した際、エラーが握り潰されて原因調査ができない問題を修正します。

## 主な変更

- `app/(public)/map/page.tsx` の `catch {}` を `catch (error)` に変更し、`console.error` でログ出力するようにしました

## 変更ファイル

- `app/(public)/map/page.tsx`

## 確認してほしいこと

- [ ] Supabase接続不可など異常時に、サーバーログにエラーが出力されることを確認
- [ ] 正常時の挙動に変化がないことを確認

## 補足

ローカル開発でDocker未起動によりSupabaseに接続できず店舗が表示されなかった際、エラーが握り潰されていて原因特定に時間がかかったため、再発時に調査しやすくするための修正です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)