### PR TITLE
feat: AI相談に👍/👎フィードバック機能を追加する

### DIFF
--- a/app/(public)/admin/analytics/page.tsx
+++ b/app/(public)/admin/analytics/page.tsx
@@ -54,6 +54,7 @@ type ShopViewRow = { vendor_id: string; source: string | null; vendors: { shop_n
 type SearchLogRow = { keyword: string; searched_at: string };
 type ConsultLogRow = { intent_category: string | null; consulted_at: string };
 type VendorCatRow = { categories: { name: string } | null };
+type ConsultFeedbackRow = { question_text: string | null; comment: string | null; created_at: string; turn_text: string | null };
 
 export default async function AdminAnalyticsPage() {
   const cookieStore = await cookies();
@@ -77,6 +78,7 @@ export default async function AdminAnalyticsPage() {
     searchLogsResult,
     consultLogsResult,
     vendorCatsResult,
+    lowRatingResult,
   ] = await Promise.all([
     // web_page_analytics: 過去30日分
     dc.from("web_page_analytics")
@@ -98,6 +100,13 @@ export default async function AdminAnalyticsPage() {
     // vendors + categories
     dc.from("vendors")
       .select("categories(name)"),
+    // ai_consult_feedback: 最近の低評価（型未生成のためキャスト）
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dc as any).from("ai_consult_feedback")
+      .select("question_text, comment, created_at, turn_text")
+      .eq("rating", -1)
+      .order("created_at", { ascending: false })
+      .limit(20),
   ]);
 
   const pageRows = (pageAnalyticsResult.data ?? []) as PageAnalyticsRow[];
@@ -105,6 +114,7 @@ export default async function AdminAnalyticsPage() {
   const searchLogs = (searchLogsResult.data ?? []) as SearchLogRow[];
   const consultLogs = (consultLogsResult.data ?? []) as ConsultLogRow[];
   const vendorCats = (vendorCatsResult.data ?? []) as unknown as VendorCatRow[];
+  const lowRatingFeedback = (lowRatingResult.data ?? []) as ConsultFeedbackRow[];
 
   // 管理者アクセスを除外
   const userRows = pageRows.filter((r) => !isAdmin(r.user_role));
@@ -375,6 +385,32 @@ export default async function AdminAnalyticsPage() {
                   </div>
                 );
               })}
+            </div>
+          )}
+        </section>
+
+        {/* 最近の低評価フィードバック */}
+        <section className="mt-6 rounded-xl border border-rose-100 bg-white p-6 shadow-sm">
+          <h2 className="mb-1 text-lg font-bold text-slate-800">最近の低評価（👎）</h2>
+          <p className="mb-4 text-xs text-slate-400">AIばあちゃんへの低評価フィードバック（直近20件）</p>
+          {lowRatingFeedback.length === 0 ? (
+            <p className="py-8 text-center text-sm text-slate-400">低評価はありません</p>
+          ) : (
+            <div className="space-y-3">
+              {lowRatingFeedback.map((row, i) => (
+                <div key={i} className="rounded-lg border border-slate-100 bg-slate-50 p-3 text-sm">
+                  <p className="mb-1 text-xs text-slate-400">{new Date(row.created_at).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}</p>
+                  {row.question_text && (
+                    <p className="mb-1 text-slate-700"><span className="font-semibold text-slate-500">質問: </span>{row.question_text}</p>
+                  )}
+                  {row.comment && (
+                    <p className="text-rose-700"><span className="font-semibold">コメント: </span>{row.comment}</p>
+                  )}
+                  {!row.comment && (
+                    <p className="text-slate-400 italic">コメントなし</p>
+                  )}
+                </div>
+              ))}
             </div>
           )}
         </section>

--- a/app/(public)/consult/ConsultClient.tsx
+++ b/app/(public)/consult/ConsultClient.tsx
@@ -113,6 +113,7 @@ export default function ConsultClient({ embedded = false }: { embedded?: boolean
       helperQuestions?: string[];
       errorMessage?: string;
       retryable?: boolean;
+      consultId?: string;
     },
     ok: boolean
   ): ConsultAskResponse => {
@@ -143,6 +144,7 @@ export default function ConsultClient({ embedded = false }: { embedded?: boolean
       retryable: ok
         ? payload.retryable ?? false
         : payload.retryable ?? payload.errorCode === "system_error",
+      consultId: payload.consultId,
     };
   }, [mergeKnownShops]);
 

--- a/app/(public)/consult/types/consultConversation.ts
+++ b/app/(public)/consult/types/consultConversation.ts
@@ -32,6 +32,7 @@ export type ConsultAskResponse = {
   helperQuestions?: string[];
   errorMessage?: string;
   retryable?: boolean;
+  consultId?: string;
 };
 
 export type ConsultAskStreamEvent =

--- a/app/(public)/map/components/GrandmaChatter.tsx
+++ b/app/(public)/map/components/GrandmaChatter.tsx
@@ -61,6 +61,8 @@ type ChatMessage = {
   speakerId?: ConsultCharacterId;
   speakerName?: string;
   followUpQuestion?: string;
+  consultId?: string;
+  turnIndex?: number;
 };
 
 type GrandmaChatterProps = {
@@ -265,6 +267,9 @@ const GrandmaChatter = memo(function GrandmaChatter({
   const chatStorageKeyRef = useRef<string | null>(null);
   const [isSpeechSupported, setIsSpeechSupported] = useState(false);
   const [isListening, setIsListening] = useState(false);
+  const [ratedMessageIds, setRatedMessageIds] = useState<Set<string>>(new Set());
+  const [thumbsDownOpenId, setThumbsDownOpenId] = useState<string | null>(null);
+  const [thumbsDownComments, setThumbsDownComments] = useState<Record<string, string>>({});
   const speechStartTextRef = useRef("");
   const speechRecognitionRef = useRef<{
     start: () => void;
@@ -699,6 +704,33 @@ const GrandmaChatter = memo(function GrandmaChatter({
     void handleAskSubmit(SHOP_CONSULT_PROMPT, nextContext, true);
   };
 
+  const submitFeedback = async (messageId: string, rating: 1 | -1, comment?: string) => {
+    const message = chatMessages.find((m) => m.id === messageId);
+    if (!message?.consultId || message.turnIndex === undefined) return;
+    setRatedMessageIds((prev) => new Set(prev).add(messageId));
+    setThumbsDownOpenId((prev) => (prev === messageId ? null : prev));
+    const questionText = chatMessages
+      .slice(0, chatMessages.findIndex((m) => m.id === messageId))
+      .reverse()
+      .find((m) => m.role === "user")?.text ?? "";
+    try {
+      await fetch("/api/grandma/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          consultId: message.consultId,
+          turnIndex: message.turnIndex,
+          rating,
+          comment: comment ?? null,
+          questionText,
+          turnText: message.text,
+        }),
+      });
+    } catch {
+      // fire and forget
+    }
+  };
+
   const handleAskSubmit = async (
     text?: string,
     context?: AskContext,
@@ -859,6 +891,8 @@ const GrandmaChatter = memo(function GrandmaChatter({
             speakerId: turn.speakerId,
             speakerName: turn.speakerName,
             followUpQuestion: includeResponseMeta ? response.followUpQuestion : undefined,
+            consultId: response.consultId,
+            turnIndex: index,
           },
         ]);
       };
@@ -878,6 +912,8 @@ const GrandmaChatter = memo(function GrandmaChatter({
                   speakerName: firstTurn.speakerName,
                   followUpQuestion:
                     remainingTurns.length === 0 ? response.followUpQuestion : undefined,
+                  consultId: response.consultId,
+                  turnIndex: 0,
                 }
               : message
           )
@@ -1267,7 +1303,61 @@ const GrandmaChatter = memo(function GrandmaChatter({
                       <div className="min-w-0 flex-1">
                         <div className="mb-1 flex items-center gap-2 pl-1">
                           <span className={`text-base font-semibold ${embedded ? "text-green-700 text-stroke-dark" : "text-slate-700"}`}>{speakerName}</span>
+                          {message.consultId !== undefined && message.turnIndex !== undefined && message.id !== activeStreamingMessageId && (
+                            <div className="ml-auto flex items-center gap-0.5">
+                              {ratedMessageIds.has(message.id) ? (
+                                <span className="text-[10px] text-slate-300 select-none">評価済み</span>
+                              ) : (
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={() => void submitFeedback(message.id, 1)}
+                                    className="rounded p-0.5 text-slate-300 transition hover:text-nicchyo-primary"
+                                    aria-label="役に立った"
+                                  >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5">
+                                      <path d="M1 8.25a1.25 1.25 0 1 1 2.5 0v7.5a1.25 1.25 0 0 1-2.5 0v-7.5ZM11 3V1.7c0-.268.14-.526.395-.607A2 2 0 0 1 14 3c0 .995-.182 1.948-.514 2.826-.204.54.166 1.174.744 1.174h2.52c1.243 0 2.261 1.01 2.146 2.247a23.9 23.9 0 0 1-1.341 5.974C17.153 16.323 16.072 17 14.9 17h-3.192a3 3 0 0 1-1.341-.317l-2.734-1.366A3 3 0 0 0 6.292 15H5V8h.963c.685 0 1.258-.483 1.612-1.068a4.011 4.011 0 0 0 .166-.281l.531-1.06a2 2 0 0 1 .911-.93l1.55-.775A1 1 0 0 1 11 5v.818L10.036 8H11c.552 0 1 .448 1 1v-5.182L11 3Z" />
+                                    </svg>
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => setThumbsDownOpenId((prev) => prev === message.id ? null : message.id)}
+                                    className={`rounded p-0.5 transition ${thumbsDownOpenId === message.id ? "text-rose-400" : "text-slate-300 hover:text-rose-400"}`}
+                                    aria-label="改善が必要"
+                                  >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5">
+                                      <path d="M18.905 12.75a1.25 1.25 0 0 1-2.5 0v-7.5a1.25 1.25 0 0 1 2.5 0v7.5ZM8.905 17v1.3c0 .268-.14.526-.395.607A2 2 0 0 1 5.905 17c0-.995.182-1.948.514-2.826.204-.54-.166-1.174-.744-1.174h-2.52c-1.243 0-2.261-1.01-2.146-2.247a23.9 23.9 0 0 1 1.341-5.974C2.752 3.677 3.833 3 5.005 3h3.192a3 3 0 0 1 1.341.317l2.734 1.366A3 3 0 0 0 13.613 5h1.292v7h-.963c-.685 0-1.258.483-1.612 1.068a4.01 4.01 0 0 0-.166.281l-.531 1.06a2 2 0 0 1-.911.93l-1.55.775A1 1 0 0 1 8.905 15v-.818l.964-2.182H8.905a1 1 0 0 1-1-1V17Z" />
+                                    </svg>
+                                  </button>
+                                </>
+                              )}
+                            </div>
+                          )}
                         </div>
+                        {thumbsDownOpenId === message.id && !ratedMessageIds.has(message.id) && (
+                          <div className="mb-2 flex items-center gap-1.5 pl-1">
+                            <input
+                              type="text"
+                              value={thumbsDownComments[message.id] ?? ""}
+                              onChange={(e) => setThumbsDownComments((prev) => ({ ...prev, [message.id]: e.target.value }))}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  void submitFeedback(message.id, -1, thumbsDownComments[message.id]);
+                                }
+                              }}
+                              placeholder="改善点を教えてください（任意）"
+                              maxLength={200}
+                              className="h-7 flex-1 rounded-lg border border-rose-200 bg-white px-2 text-[11px] text-slate-600 placeholder:text-slate-300 focus:border-rose-300 focus:outline-none"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => void submitFeedback(message.id, -1, thumbsDownComments[message.id])}
+                              className="rounded-lg border border-rose-200 bg-rose-50 px-2 py-0.5 text-[11px] font-medium text-rose-600 hover:bg-rose-100"
+                            >
+                              送信
+                            </button>
+                          </div>
+                        )}
                         <MessageBubble
                           role={message.role}
                           variant="consult"

--- a/app/(public)/map/components/MapCharacterConsult.tsx
+++ b/app/(public)/map/components/MapCharacterConsult.tsx
@@ -44,6 +44,7 @@ type AskPayload = {
   errorMessage?: string;
   turns?: ConsultAskResponse['turns'];
   shopIds?: number[];
+  consultId?: string;
 };
 
 function CharacterSprite({
@@ -169,6 +170,12 @@ export default function MapCharacterConsult({
   const [status, setStatus] = useState<Status>('idle');
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [history, setHistory] = useState<Array<{ role: 'user' | 'assistant'; text: string }>>([]);
+  const [lastConsultId, setLastConsultId] = useState<string | null>(null);
+  const [lastQuestionText, setLastQuestionText] = useState<string | null>(null);
+  const [lastTurnText, setLastTurnText] = useState<string | null>(null);
+  const [feedbackGiven, setFeedbackGiven] = useState(false);
+  const [thumbsDownOpen, setThumbsDownOpen] = useState(false);
+  const [thumbsDownComment, setThumbsDownComment] = useState('');
 
   const shopMap = useRef(new Map(shops.map((shop) => [shop.id, shop])));
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -317,6 +324,31 @@ export default function MapCharacterConsult({
     clearPlayback();
   }, [clearPlayback]);
 
+  const submitFeedback = useCallback(
+    async (rating: 1 | -1, comment?: string) => {
+      if (!lastConsultId) return;
+      setFeedbackGiven(true);
+      setThumbsDownOpen(false);
+      try {
+        await fetch('/api/grandma/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            consultId: lastConsultId,
+            turnIndex: 0,
+            rating,
+            comment: comment ?? null,
+            questionText: lastQuestionText ?? undefined,
+            turnText: lastTurnText ?? undefined,
+          }),
+        });
+      } catch {
+        // fire and forget
+      }
+    },
+    [lastConsultId, lastQuestionText, lastTurnText]
+  );
+
   const handleSend = useCallback(
     async (overrideText?: string) => {
       const text = (overrideText ?? inputText).trim();
@@ -325,6 +357,10 @@ export default function MapCharacterConsult({
       abortRef.current?.abort();
       if (tickerRef.current) clearInterval(tickerRef.current);
       clearPlayback();
+      setLastConsultId(null);
+      setFeedbackGiven(false);
+      setThumbsDownOpen(false);
+      setThumbsDownComment('');
 
       const controller = new AbortController();
       abortRef.current = controller;
@@ -394,6 +430,12 @@ export default function MapCharacterConsult({
 
         if (finalShopIds.length > 0) {
           onShopsRecommended(finalShopIds);
+        }
+
+        if (payload?.consultId) {
+          setLastConsultId(payload.consultId);
+          setLastQuestionText(text);
+          setLastTurnText(turns[0]?.text ?? null);
         }
 
         playbackStarted = playResponseSequence(turns, finalShopIds, false);
@@ -603,6 +645,54 @@ export default function MapCharacterConsult({
                   直前の相談を再試行
                 </button>
               </div>
+            )}
+
+            {status === 'idle' && lastConsultId && !feedbackGiven && !thumbsDownOpen && (
+              <div className="mt-2 flex items-center justify-end gap-1.5">
+                <span className="text-[11px] text-slate-400">参考になりましたか？</span>
+                <button
+                  type="button"
+                  onClick={() => submitFeedback(1)}
+                  className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[13px] shadow-sm transition hover:bg-slate-50 active:scale-95"
+                  aria-label="役に立った"
+                >
+                  👍
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setThumbsDownOpen(true)}
+                  className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[13px] shadow-sm transition hover:bg-slate-50 active:scale-95"
+                  aria-label="役に立たなかった"
+                >
+                  👎
+                </button>
+              </div>
+            )}
+
+            {thumbsDownOpen && (
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  type="text"
+                  value={thumbsDownComment}
+                  onChange={(e) => setThumbsDownComment(e.target.value)}
+                  placeholder="改善点を教えてください（任意）"
+                  className="flex-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[12px] text-slate-800 placeholder:text-slate-400 outline-none focus:border-amber-300"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') submitFeedback(-1, thumbsDownComment);
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => submitFeedback(-1, thumbsDownComment)}
+                  className="shrink-0 rounded-full bg-amber-500 px-3 py-1.5 text-[12px] font-bold text-white shadow-sm transition hover:bg-amber-600 active:scale-95"
+                >
+                  送信
+                </button>
+              </div>
+            )}
+
+            {status === 'idle' && feedbackGiven && (
+              <p className="mt-2 text-right text-[11px] text-slate-400">評価済み ✓</p>
             )}
           </div>}
         </div>

--- a/app/api/grandma/ask/route.ts
+++ b/app/api/grandma/ask/route.ts
@@ -179,6 +179,7 @@ async function parseRequest(request: Request): Promise<ParsedRequest> {
 async function finalizeConsultResponse(options: {
   request: Request;
   supabase: SupabaseClient<Database>;
+  consultId: string;
   text: string;
   keywords: string[];
   location: { lat: number; lng: number } | null;
@@ -197,6 +198,7 @@ async function finalizeConsultResponse(options: {
   const {
     request,
     supabase,
+    consultId,
     text,
     keywords,
     location,
@@ -295,6 +297,7 @@ async function finalizeConsultResponse(options: {
     followUpQuestion: safeFollowUpQuestion,
     memorySummary: summary.trim() || memorySummary,
     retryable: false,
+    consultId,
   };
 }
 
@@ -307,6 +310,7 @@ async function createStreamingConsultResponse(options: {
     | Array<{ type: "text"; text: string } | { type: "image_url"; image_url: { url: string } }>;
   request: Request;
   supabase: SupabaseClient<Database>;
+  consultId: string;
   text: string;
   keywords: string[];
   location: { lat: number; lng: number } | null;
@@ -324,6 +328,7 @@ async function createStreamingConsultResponse(options: {
     userContent,
     request,
     supabase,
+    consultId,
     text,
     keywords,
     location,
@@ -455,6 +460,7 @@ async function createStreamingConsultResponse(options: {
         const response = await finalizeConsultResponse({
           request,
           supabase,
+          consultId,
           text,
           keywords,
           location,
@@ -591,6 +597,8 @@ export async function POST(request: Request) {
         )
       );
     }
+
+    const consultId = crypto.randomUUID();
 
     const openaiKey = process.env.OPENAI_API_KEY;
     if (!supabaseUrl || !serviceRoleKey || !openaiKey) {
@@ -816,6 +824,7 @@ export async function POST(request: Request) {
         userContent,
         request,
         supabase,
+        consultId,
         text,
         keywords,
         location,
@@ -892,6 +901,7 @@ export async function POST(request: Request) {
     const response = await finalizeConsultResponse({
       request,
       supabase,
+      consultId,
       text,
       keywords,
       location,

--- a/app/api/grandma/feedback/route.ts
+++ b/app/api/grandma/feedback/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import type { Database } from "@/types/database.types";
+import { requireSameOrigin } from "@/lib/security/requestGuards";
+import { enforceRateLimit } from "@/lib/security/rateLimit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const FeedbackBodySchema = z.object({
+  consultId: z.string().uuid(),
+  turnIndex: z.number().int().min(0).max(10),
+  rating: z.union([z.literal(1), z.literal(-1)]),
+  comment: z.string().max(500).nullable().optional(),
+  questionText: z.string().max(2000).optional(),
+  turnText: z.string().max(2000).optional(),
+});
+
+export async function POST(request: Request) {
+  const originCheck = requireSameOrigin(request);
+  if (!originCheck.ok) return originCheck.response;
+
+  const rateLimited = await enforceRateLimit(request, {
+    bucket: "grandma-feedback",
+    limit: 60,
+    windowMs: 10 * 60 * 1000,
+  });
+  if (rateLimited) return rateLimited;
+
+  const parsed = FeedbackBodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ message: "Server configuration error" }, { status: 500 });
+  }
+
+  const supabase = createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const { data } = parsed;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any).from("ai_consult_feedback").insert({
+    consult_id: data.consultId,
+    turn_index: data.turnIndex,
+    rating: data.rating,
+    comment: data.comment ?? null,
+    question_text: data.questionText ?? null,
+    turn_text: data.turnText ?? null,
+  });
+
+  if (error) {
+    console.error("[ai_consult_feedback] insert failed:", error.message);
+    return NextResponse.json({ message: "Failed to save feedback" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/supabase/migrations/20260616000000_create_ai_consult_feedback.sql
+++ b/supabase/migrations/20260616000000_create_ai_consult_feedback.sql
@@ -1,0 +1,20 @@
+-- AIばあちゃんへの回答フィードバック（👍/👎）
+create table if not exists public.ai_consult_feedback (
+  id           uuid        primary key default gen_random_uuid(),
+  consult_id   uuid        not null,
+  turn_index   int         not null,
+  rating       smallint    not null,        -- 1 = 👍, -1 = 👎
+  comment      text,                        -- 👎 のときのみ任意入力
+  question_text text,
+  turn_text    text,
+  created_at   timestamptz not null default now()
+);
+
+alter table public.ai_consult_feedback enable row level security;
+
+-- 書き込みはサービスロール経由（APIから）のみ
+-- 読み取りはサービスロールのみ（管理者分析用）
+
+create index if not exists idx_ai_consult_feedback_created_at on public.ai_consult_feedback (created_at);
+create index if not exists idx_ai_consult_feedback_rating     on public.ai_consult_feedback (rating);
+create index if not exists idx_ai_consult_feedback_consult_id on public.ai_consult_feedback (consult_id);


### PR DESCRIPTION
## Summary
- MapCharacterConsult（/map のAI相談UI）に👍/👎フィードバックボタンを追加
- 回答再生が終わりアイドル状態になると表示。👎は任意コメント入力あり
- `/api/grandma/feedback` エンドポイントを新設（サービスロール経由でSupabaseに保存）
- `/api/grandma/ask` で `consultId`（UUID）を生成・返却しフィードバックと紐付け
- `ai_consult_feedback` テーブルのマイグレーションを追加
- 管理画面アナリティクスに最近の低評価（👎）リストを追加

## Migration
`supabase/migrations/20260616000000_create_ai_consult_feedback.sql` を
Supabase SQL Editor で実行すること（マージ前に適用済みであること）

## Test plan
- [ ] `/map` でAI相談を開き質問する
- [ ] 回答後に👍/👎が表示される
- [ ] 👍タップ → 「評価済み ✓」に変わる
- [ ] 👎タップ → コメント入力 → 送信 → 「評価済み ✓」
- [ ] Supabase の `ai_consult_feedback` テーブルに行が追加される
- [ ] `/admin/analytics` の最下部に低評価リストが表示される