### PR TITLE
fix: ローカル開発でのログイン不可とAuth初期化エラーログを修正

### DIFF
--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -100,7 +100,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         // getSession() はサーバー検証なし。getUser() でサーバーサイド検証を行う
         const { data, error } = await supabase.auth.getUser();
-        if (error) {
+        // 未ログイン状態では "Auth session missing!" が返るが、これは異常系ではない
+        if (error && error.name !== "AuthSessionMissingError") {
           console.error("[AuthContext] getUser failed:", error.message);
         }
         if (!active) return;

--- a/proxy.ts
+++ b/proxy.ts
@@ -47,7 +47,7 @@ export async function proxy(request: NextRequest) {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data: https://fonts.gstatic.com",
-    "connect-src 'self' https:",
+    `connect-src 'self' https:${process.env.NODE_ENV === "development" ? " http://127.0.0.1:* ws://127.0.0.1:*" : ""}`,
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",


### PR DESCRIPTION
## 概要

ローカル開発環境でログインができない問題と、未ログイン時に出る無害なエラーログを修正します。

## 主な変更

- `proxy.ts`: 開発時（`NODE_ENV === "development"`）のみ、CSPの`connect-src`に`http://127.0.0.1:*` `ws://127.0.0.1:*`を許可。これにより、ローカルSupabase（`http://127.0.0.1:54321`）へのfetchがCSPでブロックされ「Failed to fetch」でログインできなかった問題を解消（本番は`https://`のSupabase URLのため影響なし）
- `lib/auth/AuthContext.tsx`: 未ログイン時に`getUser()`が返す正常系の`AuthSessionMissingError`を`console.error`で出力していたのを抑制

## 変更ファイル

- `proxy.ts`
- `lib/auth/AuthContext.tsx`

## 確認してほしいこと

- [ ] ローカル開発環境（Supabase起動済み）でログインができることを確認
- [ ] 未ログイン状態でページを開いてもコンソールにAuthエラーが出ないことを確認
- [ ] 本番のCSPヘッダーに変化がないこと（`NODE_ENV !== "development"`で従来通り）を確認

## 補足

管理者ログインができない不具合の調査中に発見・修正しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)